### PR TITLE
Fixed the install application-manager command

### DIFF
--- a/solutions/deploy-a-helm-chart/README.md
+++ b/solutions/deploy-a-helm-chart/README.md
@@ -10,7 +10,7 @@ Install application manager addon on the hub cluster
 
 ```
 kubectl config use kind-hub
-clusteradm install addon --names application-manager
+clusteradm install hub-addon --names application-manager
 ```
 
 Install application manager agent on all the managed clusters


### PR DESCRIPTION
The new version of clusteradm introduced a breaking change:
https://github.com/open-cluster-management-io/clusteradm/commit/263979dd9d0ec38f5ca30c6d87552b11a5e2326b

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
