### PR TITLE
:bug: upload coverge again when push commit.

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -17,6 +17,28 @@ env:
   GO_REQUIRED_MIN_VERSION: ''
 
 jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+      - name: install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: unit
+        run: make test
+      - name: report coverage
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
+          files: ./coverage.out
+          flags: unit
+          name: unit
+          verbose: true
+          fail_ci_if_error: true
+
   images:
     name: images
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Fixes

We should upload coverage again after PR merged at the time of pushing a commit.
Otherwise, the base branch will keep missing like this: https://github.com/open-cluster-management-io/ocm/pull/163#issuecomment-1580267727

Reference: https://github.com/codecov/example-go/blob/c76b419d5641077a561ebf807ca1f403af5c0bd3/.github/workflows/ci.yml#L3
