### PR TITLE
:seedling: expose the spoke informers

### DIFF
--- a/pkg/common/options/options.go
+++ b/pkg/common/options/options.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/pflag"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/client-go/rest"
@@ -39,9 +38,9 @@ func (o *AgentOptions) AddFlags(flags *pflag.FlagSet) {
 }
 
 // spokeKubeConfig builds kubeconfig for the spoke/managed cluster
-func (o *AgentOptions) SpokeKubeConfig(controllerContext *controllercmd.ControllerContext) (*rest.Config, error) {
+func (o *AgentOptions) SpokeKubeConfig(managedRestConfig *rest.Config) (*rest.Config, error) {
 	if o.SpokeKubeconfigFile == "" {
-		return controllerContext.KubeConfig, nil
+		return managedRestConfig, nil
 	}
 
 	spokeRestConfig, err := clientcmd.BuildConfigFromFlags("" /* leave masterurl as empty */, o.SpokeKubeconfigFile)

--- a/pkg/registration/spoke/spokeagent_test.go
+++ b/pkg/registration/spoke/spokeagent_test.go
@@ -308,7 +308,7 @@ func TestHasValidHubClientConfig(t *testing.T) {
 				AgentName:        c.agentName,
 				HubKubeconfigDir: tempDir,
 			}
-			valid, err := options.hasValidHubClientConfig()
+			valid, err := options.hasValidHubClientConfig(context.TODO())
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/work/spoke/spokeagent.go
+++ b/pkg/work/spoke/spokeagent.go
@@ -92,7 +92,7 @@ func (o *WorkloadAgentOptions) RunWorkloadAgent(ctx context.Context, controllerC
 
 	// load spoke client config and create spoke clients,
 	// the work agent may not running in the spoke/managed cluster.
-	spokeRestConfig, err := o.AgentOptions.SpokeKubeConfig(controllerContext)
+	spokeRestConfig, err := o.AgentOptions.SpokeKubeConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

exposing the spoke informers to share them with other components which are integrated with registration agent in code level.
