### PR TITLE
:bug: Fix: hard-coded image names in e2e-test when create klusterlet.

### DIFF
--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -32,7 +32,7 @@ test-e2e: deploy-hub deploy-spoke-operator run-e2e
 
 run-e2e: cluster-ip bootstrap-secret
 	go test -c ./test/e2e
-	./e2e.test -test.v -ginkgo.v -deploy-klusterlet=true -nil-executor-validating=true -image-tag=e2e
+	./e2e.test -test.v -ginkgo.v -deploy-klusterlet=true -nil-executor-validating=true -registration-image=$(REGISTRATION_IMAGE) -work-image=$(WORK_IMAGE)
 
 clean-hub: clean-hub-cr clean-hub-operator
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -64,13 +64,14 @@ type Tester struct {
 	clusterManagerNamespace string
 	operatorNamespace       string
 	klusterletOperator      string
-	imageTag                string
+	registrationImage       string
+	workImage               string
 }
 
 // kubeconfigPath is the path of kubeconfig file, will be get from env "KUBECONFIG" by default.
 // bootstrapHubSecret is the bootstrap hub kubeconfig secret, and the format is "namespace/secretName".
 // Default of bootstrapHubSecret is helpers.KlusterletDefaultNamespace/helpers.BootstrapHubKubeConfig.
-func NewTester(hubKubeConfigPath, spokeKubeConfigPath, imageTag string, timeout time.Duration) *Tester {
+func NewTester(hubKubeConfigPath, spokeKubeConfigPath, registrationImage, workImage string, timeout time.Duration) *Tester {
 	var tester = Tester{
 		hubKubeConfigPath:       hubKubeConfigPath,
 		spokeKubeConfigPath:     spokeKubeConfigPath,
@@ -80,7 +81,8 @@ func NewTester(hubKubeConfigPath, spokeKubeConfigPath, imageTag string, timeout 
 		clusterManagerNamespace: helpers.ClusterManagerDefaultNamespace,
 		operatorNamespace:       "open-cluster-management",
 		klusterletOperator:      "klusterlet",
-		imageTag:                imageTag,
+		registrationImage:       registrationImage,
+		workImage:               workImage,
 	}
 
 	return &tester
@@ -197,8 +199,8 @@ func (t *Tester) CreateKlusterlet(name, clusterName, klusterletNamespace string,
 			Name: name,
 		},
 		Spec: operatorapiv1.KlusterletSpec{
-			RegistrationImagePullSpec: "quay.io/open-cluster-management/registration:" + t.imageTag,
-			WorkImagePullSpec:         "quay.io/open-cluster-management/work:" + t.imageTag,
+			RegistrationImagePullSpec: t.registrationImage,
+			WorkImagePullSpec:         t.workImage,
 			ExternalServerURLs: []operatorapiv1.ServerURL{
 				{
 					URL: "https://localhost",

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -14,11 +14,12 @@ var t *Tester
 var (
 	clusterName           string
 	hubKubeconfig         string
-	imageTag              string
 	nilExecutorValidating bool
 	deployKlusterlet      bool
 	managedKubeconfig     string
 	eventuallyTimeout     time.Duration
+	registrationImage     string
+	workImage             string
 )
 
 func init() {
@@ -28,11 +29,12 @@ func init() {
 	flag.BoolVar(&deployKlusterlet, "deploy-klusterlet", false, "Whether deploy the klusterlet on the managed cluster or not (default false)")
 	flag.StringVar(&managedKubeconfig, "managed-kubeconfig", "", "The kubeconfig of the managed cluster")
 	flag.DurationVar(&eventuallyTimeout, "eventually-timeout", 60*time.Second, "The timeout of Gomega's Eventually (default 60 seconds)")
-	flag.StringVar(&imageTag, "image-tag", "latest", "Image tag to run the klusterlet, only used when enable deploy-klusterlet")
+	flag.StringVar(&registrationImage, "registration-image", "", "The image of the registration")
+	flag.StringVar(&workImage, "work-image", "", "The image of the work")
 }
 
 func TestE2E(tt *testing.T) {
-	t = NewTester(hubKubeconfig, managedKubeconfig, imageTag, eventuallyTimeout)
+	t = NewTester(hubKubeconfig, managedKubeconfig, registrationImage, workImage, eventuallyTimeout)
 
 	OutputFail := func(message string, callerSkip ...int) {
 		t.OutputDebugLogs()


### PR DESCRIPTION
In some situations, the images used in the e2e-test are not with the same "image-tag". 
We should pass the image names of registration and work in the function `NewTester ` instead of the "image-tag".