### PR TITLE
:bug: filter secret informer to reduce cache size

### DIFF
--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .AgentNamespace }}
   labels:
     app: klusterlet-registration-agent
+    createdBy: klusterlet
 spec:
   replicas: {{ .Replica }}
   selector:

--- a/manifests/klusterlet/management/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .AgentNamespace }}
   labels:
     app: klusterlet-manifestwork-agent
+    createdBy: klusterlet
 spec:
   replicas: {{ .Replica }}
   selector:

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
@@ -46,7 +46,7 @@ func NewKlusterletCleanupController(
 	apiExtensionClient apiextensionsclient.Interface,
 	klusterletClient operatorv1client.KlusterletInterface,
 	klusterletInformer operatorinformer.KlusterletInformer,
-	secretInformer coreinformer.SecretInformer,
+	secretInformers map[string]coreinformer.SecretInformer,
 	deploymentInformer appsinformer.DeploymentInformer,
 	appliedManifestWorkClient workv1client.AppliedManifestWorkInterface,
 	kubeVersion *version.Version,
@@ -63,7 +63,10 @@ func NewKlusterletCleanupController(
 	}
 
 	return factory.New().WithSync(controller.sync).
-		WithInformersQueueKeyFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister), secretInformer.Informer()).
+		WithInformersQueueKeyFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister),
+			secretInformers[helpers.HubKubeConfig].Informer(),
+			secretInformers[helpers.BootstrapHubKubeConfig].Informer(),
+			secretInformers[helpers.ExternalManagedKubeConfig].Informer()).
 		WithInformersQueueKeyFunc(helpers.KlusterletDeploymentQueueKeyFunc(controller.klusterletLister), deploymentInformer.Informer()).
 		WithInformersQueueKeyFunc(func(obj runtime.Object) string {
 			accessor, _ := meta.Accessor(obj)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -76,7 +76,7 @@ func NewKlusterletController(
 	apiExtensionClient apiextensionsclient.Interface,
 	klusterletClient operatorv1client.KlusterletInterface,
 	klusterletInformer operatorinformer.KlusterletInformer,
-	secretInformer coreinformer.SecretInformer,
+	secretInformers map[string]coreinformer.SecretInformer,
 	deploymentInformer appsinformer.DeploymentInformer,
 	appliedManifestWorkClient workv1client.AppliedManifestWorkInterface,
 	kubeVersion *version.Version,
@@ -96,7 +96,10 @@ func NewKlusterletController(
 	}
 
 	return factory.New().WithSync(controller.sync).
-		WithInformersQueueKeyFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister), secretInformer.Informer()).
+		WithInformersQueueKeyFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister),
+			secretInformers[helpers.HubKubeConfig].Informer(),
+			secretInformers[helpers.BootstrapHubKubeConfig].Informer(),
+			secretInformers[helpers.ExternalManagedKubeConfig].Informer()).
 		WithInformersQueueKeyFunc(helpers.KlusterletDeploymentQueueKeyFunc(controller.klusterletLister), deploymentInformer.Informer()).
 		WithInformersQueueKeyFunc(func(obj runtime.Object) string {
 			accessor, _ := meta.Accessor(obj)

--- a/pkg/operator/operators/klusterlet/options.go
+++ b/pkg/operator/operators/klusterlet/options.go
@@ -7,14 +7,18 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/informers"
+	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	operatorinformer "open-cluster-management.io/api/client/operator/informers/externalversions"
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
 
+	"open-cluster-management.io/ocm/pkg/operator/helpers"
 	"open-cluster-management.io/ocm/pkg/operator/operators/klusterlet/controllers/addonsecretcontroller"
 	"open-cluster-management.io/ocm/pkg/operator/operators/klusterlet/controllers/bootstrapcontroller"
 	"open-cluster-management.io/ocm/pkg/operator/operators/klusterlet/controllers/klusterletcontroller"
@@ -52,6 +56,29 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 
 	kubeInformer := informers.NewSharedInformerFactory(kubeClient, 5*time.Minute)
 
+	// to reduce cache size if there are larges number of secrets
+	newOneTermInformer := func(name string) informers.SharedInformerFactory {
+		return informers.NewSharedInformerFactoryWithOptions(kubeClient, 5*time.Minute,
+			informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+				options.FieldSelector = fields.OneTermEqualSelector("metadata.name", name).String()
+			}))
+	}
+
+	hubConfigSecretInformer := newOneTermInformer(helpers.HubKubeConfig)
+	bootstrapConfigSecretInformer := newOneTermInformer(helpers.BootstrapHubKubeConfig)
+	externalConfigSecretInformer := newOneTermInformer(helpers.WorkWebhookSecret)
+
+	secretInformers := map[string]corev1informers.SecretInformer{
+		helpers.HubKubeConfig:             hubConfigSecretInformer.Core().V1().Secrets(),
+		helpers.BootstrapHubKubeConfig:    bootstrapConfigSecretInformer.Core().V1().Secrets(),
+		helpers.ExternalManagedKubeConfig: externalConfigSecretInformer.Core().V1().Secrets(),
+	}
+
+	deploymentInformer := informers.NewSharedInformerFactoryWithOptions(kubeClient, 5*time.Minute,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = "createdBy=klusterlet"
+		}))
+
 	// Build operator client and informer
 	operatorClient, err := operatorclient.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
@@ -76,8 +103,8 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 		apiExtensionClient,
 		operatorClient.OperatorV1().Klusterlets(),
 		operatorInformer.Operator().V1().Klusterlets(),
-		kubeInformer.Core().V1().Secrets(),
-		kubeInformer.Apps().V1().Deployments(),
+		secretInformers,
+		deploymentInformer.Apps().V1().Deployments(),
 		workClient.WorkV1().AppliedManifestWorks(),
 		kubeVersion,
 		operatorNamespace,
@@ -89,8 +116,8 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 		apiExtensionClient,
 		operatorClient.OperatorV1().Klusterlets(),
 		operatorInformer.Operator().V1().Klusterlets(),
-		kubeInformer.Core().V1().Secrets(),
-		kubeInformer.Apps().V1().Deployments(),
+		secretInformers,
+		deploymentInformer.Apps().V1().Deployments(),
 		workClient.WorkV1().AppliedManifestWorks(),
 		kubeVersion,
 		operatorNamespace,
@@ -100,7 +127,7 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 		kubeClient,
 		operatorClient.OperatorV1().Klusterlets(),
 		operatorInformer.Operator().V1().Klusterlets(),
-		kubeInformer.Core().V1().Secrets(),
+		secretInformers,
 		controllerContext.EventRecorder,
 	)
 
@@ -108,14 +135,14 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 		kubeClient,
 		operatorClient.OperatorV1().Klusterlets(),
 		operatorInformer.Operator().V1().Klusterlets(),
-		kubeInformer.Apps().V1().Deployments(),
+		deploymentInformer.Apps().V1().Deployments(),
 		controllerContext.EventRecorder,
 	)
 
 	bootstrapController := bootstrapcontroller.NewBootstrapController(
 		kubeClient,
 		operatorInformer.Operator().V1().Klusterlets(),
-		kubeInformer.Core().V1().Secrets(),
+		secretInformers,
 		controllerContext.EventRecorder,
 	)
 
@@ -128,6 +155,10 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 
 	go operatorInformer.Start(ctx.Done())
 	go kubeInformer.Start(ctx.Done())
+	go hubConfigSecretInformer.Start(ctx.Done())
+	go bootstrapConfigSecretInformer.Start(ctx.Done())
+	go externalConfigSecretInformer.Start(ctx.Done())
+	go deploymentInformer.Start(ctx.Done())
 	go klusterletController.Run(ctx, 1)
 	go klusterletCleanupController.Run(ctx, 1)
 	go statusController.Run(ctx, 1)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the klusterlet watches the secrets and deployments. when there are large numbers of secrets  or deployments in the managed cluster, the pod of klusterlet will be OOM because the cache size of secret/deployment informer is increased beyond the limit. So this PR is to filter the secret and deployment informer to reduce the case size.

## Related issue(s)

Fixes #