### PR TITLE
:bug: change build image to fix GLIBC not found issue

### DIFF
--- a/build/Dockerfile.placement
+++ b/build/Dockerfile.placement
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS builder
+FROM golang:1.20-bullseye AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm

--- a/build/Dockerfile.registration
+++ b/build/Dockerfile.registration
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS builder
+FROM golang:1.20-bullseye AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm

--- a/build/Dockerfile.registration-operator
+++ b/build/Dockerfile.registration-operator
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS builder
+FROM golang:1.20-bullseye AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm

--- a/build/Dockerfile.work
+++ b/build/Dockerfile.work
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS builder
+FROM golang:1.20-bullseye AS builder
 ARG OS=linux
 ARG ARCH=amd64
 WORKDIR /go/src/open-cluster-management.io/ocm


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)
the latest golang:1.20 image upgade ldd to 2.32, the built image cannot run with error
```
/placement: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /placement)
/placement: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /placement)
```
change the image to 1.20-bullseye which ldd version is 2.31. 
Fixes #