### PR TITLE
 🌱 Refactor cluster permission

### DIFF
--- a/pkg/common/apply/interface.go
+++ b/pkg/common/apply/interface.go
@@ -1,0 +1,84 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Getter is a wrapper interface of lister
+type Getter[T runtime.Object] interface {
+	Get(name string) (T, error)
+}
+
+// Client is a wrapper interface of client
+type Client[T runtime.Object] interface {
+	Create(ctx context.Context, obj T, opts metav1.CreateOptions) (T, error)
+
+	Update(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error)
+}
+
+// CompareFunc compares required and existing, returns the updated required
+// and whether updated is needed
+type CompareFunc[T runtime.Object] func(required, existing T) (T, bool)
+
+type Applier[T runtime.Object] interface {
+	Apply(ctx context.Context, required T, recorder events.Recorder) (runtime.Object, bool, error)
+}
+
+// applier implements Applier
+type applier[T runtime.Object] struct {
+	getter  Getter[T]
+	client  Client[T]
+	compare CompareFunc[T]
+}
+
+func NewApplier[T runtime.Object](getter Getter[T], client Client[T], compareFunc CompareFunc[T]) Applier[T] {
+	return &applier[T]{
+		getter:  getter,
+		client:  client,
+		compare: compareFunc,
+	}
+}
+
+func (a *applier[T]) Apply(ctx context.Context, required T, recorder events.Recorder) (runtime.Object, bool, error) {
+	requiredAccessor, err := meta.Accessor(required)
+	if err != nil {
+		return nil, false, err
+	}
+	gvk := resourcehelper.GuessObjectGroupVersionKind(required)
+	existing, err := a.getter.Get(requiredAccessor.GetName())
+	if errors.IsNotFound(err) {
+		actual, createErr := a.client.Create(ctx, required, metav1.CreateOptions{})
+		if errors.IsAlreadyExists(createErr) {
+			return required, false, nil
+		}
+		if createErr == nil {
+			recorder.Eventf(fmt.Sprintf("%sCreated", gvk.Kind), "Created %s because it was missing", resourcehelper.FormatResourceForCLIWithNamespace(actual))
+		} else {
+			recorder.Warningf(fmt.Sprintf("%sCreateFailed", gvk.Kind), "Failed to create %s: %v", resourcehelper.FormatResourceForCLIWithNamespace(required), createErr)
+		}
+
+		return actual, true, createErr
+	}
+
+	updated, modified := a.compare(required, existing)
+	if !modified {
+		return updated, modified, nil
+	}
+
+	updated, err = a.client.Update(ctx, updated, metav1.UpdateOptions{})
+	switch {
+	case err != nil:
+		recorder.Warningf(fmt.Sprintf("%sUpdateFailed", gvk.Kind), "Failed to update %s: %v", resourcehelper.FormatResourceForCLIWithNamespace(required), err)
+	default:
+		recorder.Eventf(fmt.Sprintf("%sUpdated", gvk.Kind), "Updated %s:\n%s", resourcehelper.FormatResourceForCLIWithNamespace(updated))
+	}
+
+	return updated, modified, err
+}

--- a/pkg/common/apply/rbac.go
+++ b/pkg/common/apply/rbac.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -37,7 +38,11 @@ func NewPermissionApplier(
 	}
 }
 
-func (m *PermissionApplier) Apply(ctx context.Context, recorder events.Recorder, manifests resourceapply.AssetFunc, files ...string) []resourceapply.ApplyResult {
+func (m *PermissionApplier) Apply(
+	ctx context.Context,
+	recorder events.Recorder,
+	manifests resourceapply.AssetFunc,
+	files ...string) []resourceapply.ApplyResult {
 	ret := []resourceapply.ApplyResult{}
 	for _, file := range files {
 		result := resourceapply.ApplyResult{File: file}
@@ -56,17 +61,17 @@ func (m *PermissionApplier) Apply(ctx context.Context, recorder events.Recorder,
 		result.Type = fmt.Sprintf("%T", requiredObj)
 		switch t := requiredObj.(type) {
 		case *rbacv1.ClusterRole:
-			applier := NewApplier[*rbacv1.ClusterRole](m.clusterRoleLister, m.client.RbacV1().ClusterRoles(), compareClusterRole)
-			result.Result, result.Changed, result.Error = applier.Apply(ctx, t, recorder)
+			result.Result, result.Changed, result.Error = Apply[*rbacv1.ClusterRole](
+				ctx, m.clusterRoleLister, m.client.RbacV1().ClusterRoles(), compareClusterRole, t, recorder)
 		case *rbacv1.ClusterRoleBinding:
-			applier := NewApplier[*rbacv1.ClusterRoleBinding](m.clusterRoleBindingLister, m.client.RbacV1().ClusterRoleBindings(), compareClusterRoleBinding)
-			result.Result, result.Changed, result.Error = applier.Apply(ctx, t, recorder)
+			result.Result, result.Changed, result.Error = Apply[*rbacv1.ClusterRoleBinding](
+				ctx, m.clusterRoleBindingLister, m.client.RbacV1().ClusterRoleBindings(), compareClusterRoleBinding, t, recorder)
 		case *rbacv1.Role:
-			applier := NewApplier[*rbacv1.Role](m.roleLister.Roles(t.Namespace), m.client.RbacV1().Roles(t.Namespace), compareRole)
-			result.Result, result.Changed, result.Error = applier.Apply(ctx, t, recorder)
+			result.Result, result.Changed, result.Error = Apply[*rbacv1.Role](
+				ctx, m.roleLister.Roles(t.Namespace), m.client.RbacV1().Roles(t.Namespace), compareRole, t, recorder)
 		case *rbacv1.RoleBinding:
-			applier := NewApplier[*rbacv1.RoleBinding](m.roleBindingLister.RoleBindings(t.Namespace), m.client.RbacV1().RoleBindings(t.Namespace), compareRoleBinding)
-			result.Result, result.Changed, result.Error = applier.Apply(ctx, t, recorder)
+			result.Result, result.Changed, result.Error = Apply[*rbacv1.RoleBinding](
+				ctx, m.roleBindingLister.RoleBindings(t.Namespace), m.client.RbacV1().RoleBindings(t.Namespace), compareRoleBinding, t, recorder)
 		default:
 			result.Error = fmt.Errorf("object type is not correct.")
 		}

--- a/pkg/common/apply/rbac.go
+++ b/pkg/common/apply/rbac.go
@@ -1,0 +1,143 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/client-go/kubernetes"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
+)
+
+type PermissionApplier struct {
+	roleLister               rbacv1listers.RoleLister
+	roleBindingLister        rbacv1listers.RoleBindingLister
+	clusterRoleLister        rbacv1listers.ClusterRoleLister
+	clusterRoleBindingLister rbacv1listers.ClusterRoleBindingLister
+	client                   kubernetes.Interface
+}
+
+func NewPermissionApplier(
+	client kubernetes.Interface,
+	roleLister rbacv1listers.RoleLister,
+	roleBindingLister rbacv1listers.RoleBindingLister,
+	clusterRoleLister rbacv1listers.ClusterRoleLister,
+	clusterRoleBindingLister rbacv1listers.ClusterRoleBindingLister,
+) *PermissionApplier {
+	return &PermissionApplier{
+		client:                   client,
+		roleLister:               roleLister,
+		roleBindingLister:        roleBindingLister,
+		clusterRoleLister:        clusterRoleLister,
+		clusterRoleBindingLister: clusterRoleBindingLister,
+	}
+}
+
+func (m *PermissionApplier) Apply(ctx context.Context, recorder events.Recorder, manifests resourceapply.AssetFunc, files ...string) []resourceapply.ApplyResult {
+	ret := []resourceapply.ApplyResult{}
+	for _, file := range files {
+		result := resourceapply.ApplyResult{File: file}
+		objBytes, err := manifests(file)
+		if err != nil {
+			result.Error = fmt.Errorf("missing %q: %v", file, err)
+			ret = append(ret, result)
+			continue
+		}
+		requiredObj, err := resourceread.ReadGenericWithUnstructured(objBytes)
+		if err != nil {
+			result.Error = fmt.Errorf("cannot decode %q: %v", file, err)
+			ret = append(ret, result)
+			continue
+		}
+		result.Type = fmt.Sprintf("%T", requiredObj)
+		switch t := requiredObj.(type) {
+		case *rbacv1.ClusterRole:
+			applier := NewApplier[*rbacv1.ClusterRole](m.clusterRoleLister, m.client.RbacV1().ClusterRoles(), compareClusterRole)
+			result.Result, result.Changed, result.Error = applier.Apply(ctx, t, recorder)
+		case *rbacv1.ClusterRoleBinding:
+			applier := NewApplier[*rbacv1.ClusterRoleBinding](m.clusterRoleBindingLister, m.client.RbacV1().ClusterRoleBindings(), compareClusterRoleBinding)
+			result.Result, result.Changed, result.Error = applier.Apply(ctx, t, recorder)
+		case *rbacv1.Role:
+			applier := NewApplier[*rbacv1.Role](m.roleLister.Roles(t.Namespace), m.client.RbacV1().Roles(t.Namespace), compareRole)
+			result.Result, result.Changed, result.Error = applier.Apply(ctx, t, recorder)
+		case *rbacv1.RoleBinding:
+			applier := NewApplier[*rbacv1.RoleBinding](m.roleBindingLister.RoleBindings(t.Namespace), m.client.RbacV1().RoleBindings(t.Namespace), compareRoleBinding)
+			result.Result, result.Changed, result.Error = applier.Apply(ctx, t, recorder)
+		default:
+			result.Error = fmt.Errorf("object type is not correct.")
+		}
+	}
+	return ret
+}
+
+func compareRole(required, existing *rbacv1.Role) (*rbacv1.Role, bool) {
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	contentSame := equality.Semantic.DeepEqual(existingCopy.Rules, required.Rules)
+
+	if contentSame && !*modified {
+		return existingCopy, false
+	}
+
+	existingCopy.Rules = required.Rules
+	return existingCopy, true
+}
+
+func compareClusterRole(required, existing *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool) {
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	contentSame := equality.Semantic.DeepEqual(existingCopy.Rules, required.Rules)
+
+	if contentSame && !*modified {
+		return existingCopy, false
+	}
+
+	existingCopy.Rules = required.Rules
+	return existingCopy, true
+}
+
+func compareRoleBinding(required, existing *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool) {
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+
+	subjectsAreSame := equality.Semantic.DeepEqual(existingCopy.Subjects, required.Subjects)
+	roleRefIsSame := equality.Semantic.DeepEqual(existingCopy.RoleRef, required.RoleRef)
+
+	if subjectsAreSame && roleRefIsSame && !*modified {
+		return existingCopy, false
+	}
+
+	existingCopy.Subjects = required.Subjects
+	existingCopy.RoleRef = required.RoleRef
+
+	return existingCopy, true
+}
+
+func compareClusterRoleBinding(required, existing *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool) {
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+
+	subjectsAreSame := equality.Semantic.DeepEqual(existingCopy.Subjects, required.Subjects)
+	roleRefIsSame := equality.Semantic.DeepEqual(existingCopy.RoleRef, required.RoleRef)
+
+	if subjectsAreSame && roleRefIsSame && !*modified {
+		return existingCopy, false
+	}
+
+	existingCopy.Subjects = required.Subjects
+	existingCopy.RoleRef = required.RoleRef
+
+	return existingCopy, true
+}

--- a/pkg/common/apply/rbac_test.go
+++ b/pkg/common/apply/rbac_test.go
@@ -1,0 +1,387 @@
+package apply
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
+)
+
+func TestPermissionApply(t *testing.T) {
+	tc := []struct {
+		name             string
+		manifest         string
+		existingManifest string
+		validateAction   func(t *testing.T, actions []clienttesting.Action)
+	}{
+		{
+			name: "create clusterrole",
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch"] 
+`,
+			validateAction: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "create")
+			},
+		},
+		{
+			name: "upate clusterrole",
+			existingManifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch", "create"] 
+`,
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch"] 
+`,
+			validateAction: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "update")
+			},
+		},
+		{
+			name: "comapre and no update clusterrole",
+			existingManifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch"] 
+`,
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch"] 
+`,
+			validateAction: testingcommon.AssertNoActions,
+		},
+		{
+			name: "create clusterrolebinding",
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test
+`,
+			validateAction: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "create")
+			},
+		},
+		{
+			name: "update clusterrolebinding",
+			existingManifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test1
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test1
+`,
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test
+`,
+			validateAction: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "update")
+			},
+		},
+		{
+			name: "no update clusterrolebinding",
+			existingManifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test
+`,
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test
+`,
+			validateAction: testingcommon.AssertNoActions,
+		},
+		{
+			name: "create role",
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch"] 
+`,
+			validateAction: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "create")
+			},
+		},
+		{
+			name: "upate role",
+			existingManifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch", "create"] 
+`,
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch"] 
+`,
+			validateAction: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "update")
+			},
+		},
+		{
+			name: "comapre and no update clusterrole",
+			existingManifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch"] 
+`,
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "events"]
+  verbs: ["get", "list", "watch"] 
+`,
+			validateAction: testingcommon.AssertNoActions,
+		},
+		{
+			name: "create rolebinding",
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test
+`,
+			validateAction: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "create")
+			},
+		},
+		{
+			name: "update rolebinding",
+			existingManifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test1
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test1
+`,
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test
+`,
+			validateAction: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "update")
+			},
+		},
+		{
+			name: "no update clusterrolebinding",
+			existingManifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test
+`,
+			manifest: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test
+subjects:
+  - kind: ServiceAccount
+    name: test
+    namespace: test
+`,
+			validateAction: testingcommon.AssertNoActions,
+		},
+	}
+
+	for _, c := range tc {
+		t.Run(c.name, func(t *testing.T) {
+			var kubeClient *kubefake.Clientset
+			var informerFactory informers.SharedInformerFactory
+			if len(c.existingManifest) > 0 {
+				o, err := resourceread.ReadGenericWithUnstructured([]byte(c.existingManifest))
+				if err != nil {
+					t.Fatal(err)
+				}
+				kubeClient = kubefake.NewSimpleClientset(o)
+				informerFactory = informers.NewSharedInformerFactory(kubeClient, 3*time.Minute)
+				switch t := o.(type) {
+				case *rbacv1.ClusterRole:
+					informerFactory.Rbac().V1().ClusterRoles().Informer().GetStore().Add(t)
+				case *rbacv1.ClusterRoleBinding:
+					informerFactory.Rbac().V1().ClusterRoleBindings().Informer().GetStore().Add(t)
+				case *rbacv1.Role:
+					informerFactory.Rbac().V1().Roles().Informer().GetStore().Add(t)
+				case *rbacv1.RoleBinding:
+					informerFactory.Rbac().V1().RoleBindings().Informer().GetStore().Add(t)
+				}
+			} else {
+				kubeClient = kubefake.NewSimpleClientset()
+				informerFactory = informers.NewSharedInformerFactory(kubeClient, 3*time.Minute)
+			}
+
+			applier := NewPermissionApplier(
+				kubeClient,
+				informerFactory.Rbac().V1().Roles().Lister(),
+				informerFactory.Rbac().V1().RoleBindings().Lister(),
+				informerFactory.Rbac().V1().ClusterRoles().Lister(),
+				informerFactory.Rbac().V1().ClusterRoleBindings().Lister(),
+			)
+			results := applier.Apply(context.TODO(), eventstesting.NewTestingEventRecorder(t),
+				func(name string) ([]byte, error) {
+					return []byte(c.manifest), nil
+				}, "test")
+
+			for _, r := range results {
+				if r.Error != nil {
+					t.Error(r.Error)
+				}
+			}
+			c.validateAction(t, kubeClient.Actions())
+		})
+	}
+}

--- a/pkg/registration/helpers/helpers.go
+++ b/pkg/registration/helpers/helpers.go
@@ -1,43 +1,20 @@
 package helpers
 
 import (
-	"context"
 	"embed"
-	"fmt"
 	"net/url"
 
-	"github.com/openshift/api"
 	"github.com/openshift/library-go/pkg/assets"
-	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
-	errorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
 
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
-
-var (
-	genericScheme = runtime.NewScheme()
-	genericCodecs = serializer.NewCodecFactory(genericScheme)
-	genericCodec  = genericCodecs.UniversalDeserializer()
-)
-
-func init() {
-	utilruntime.Must(api.InstallKube(genericScheme))
-}
 
 // Check whether a CSR is in terminal state
 func IsCSRInTerminalState(status *certificatesv1.CertificateSigningRequestStatus) bool {
@@ -81,52 +58,6 @@ func IsValidHTTPSURL(serverURL string) bool {
 	}
 
 	return true
-}
-
-// CleanUpManagedClusterManifests clean up managed cluster resources from its manifest files
-func CleanUpManagedClusterManifests(
-	ctx context.Context,
-	client kubernetes.Interface,
-	recorder events.Recorder,
-	assetFunc resourceapply.AssetFunc,
-	files ...string) error {
-	errs := []error{}
-	for _, file := range files {
-		objectRaw, err := assetFunc(file)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		object, _, err := genericCodec.Decode(objectRaw, nil, nil)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		switch t := object.(type) {
-		case *corev1.Namespace:
-			err = client.CoreV1().Namespaces().Delete(ctx, t.Name, metav1.DeleteOptions{})
-		case *rbacv1.Role:
-			err = client.RbacV1().Roles(t.Namespace).Delete(ctx, t.Name, metav1.DeleteOptions{})
-		case *rbacv1.RoleBinding:
-			err = client.RbacV1().RoleBindings(t.Namespace).Delete(ctx, t.Name, metav1.DeleteOptions{})
-		case *rbacv1.ClusterRole:
-			err = client.RbacV1().ClusterRoles().Delete(ctx, t.Name, metav1.DeleteOptions{})
-		case *rbacv1.ClusterRoleBinding:
-			err = client.RbacV1().ClusterRoleBindings().Delete(ctx, t.Name, metav1.DeleteOptions{})
-		default:
-			err = fmt.Errorf("unhandled type %T", object)
-		}
-		if errors.IsNotFound(err) {
-			continue
-		}
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		gvk := resourcehelper.GuessObjectGroupVersionKind(object)
-		recorder.Eventf(fmt.Sprintf("ManagedCluster%sDeleted", gvk.Kind), "Deleted %s", resourcehelper.FormatResourceForCLIWithNamespace(object))
-	}
-	return errorhelpers.NewMultiLineAggregate(errs)
 }
 
 func ManagedClusterAssetFn(fs embed.FS, managedClusterName string) resourceapply.AssetFunc {

--- a/pkg/registration/hub/addon/discovery_controller_test.go
+++ b/pkg/registration/hub/addon/discovery_controller_test.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
+	"open-cluster-management.io/ocm/pkg/common/patcher"
 	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
 )
 
@@ -78,158 +80,6 @@ func TestGetAddOnLabelValue(t *testing.T) {
 	}
 }
 
-func TestDiscoveryController_SyncAddOn(t *testing.T) {
-	clusterName := "cluster1"
-	deleteTime := metav1.Now()
-
-	cases := []struct {
-		name            string
-		addOnName       string
-		cluster         *clusterv1.ManagedCluster
-		addOn           *addonv1alpha1.ManagedClusterAddOn
-		validateActions func(t *testing.T, actions []clienttesting.Action)
-	}{
-		{
-			name:      "addon is deleted",
-			addOnName: "addon1",
-			cluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-					Labels: map[string]string{
-						"feature.open-cluster-management.io/addon-addon1": addOnStatusAvailable,
-					},
-				},
-			},
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testingcommon.AssertActions(t, actions, "update")
-				actual := actions[0].(clienttesting.UpdateActionImpl).Object
-				assertNoAddonLabel(t, actual.(*clusterv1.ManagedCluster), "addon1")
-			},
-		},
-		{
-			name:      "addon is deleting",
-			addOnName: "addon1",
-			cluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-				},
-			},
-			addOn: &addonv1alpha1.ManagedClusterAddOn{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "addon1",
-					DeletionTimestamp: &deleteTime,
-				},
-			},
-			validateActions: testingcommon.AssertNoActions,
-		},
-		{
-			name:      "new addon is added",
-			addOnName: "addon1",
-			cluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-				},
-			},
-			addOn: &addonv1alpha1.ManagedClusterAddOn{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "addon1",
-					Namespace: clusterName,
-				},
-			},
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testingcommon.AssertActions(t, actions, "update")
-				actual := actions[0].(clienttesting.UpdateActionImpl).Object
-				assertAddonLabel(t, actual.(*clusterv1.ManagedCluster), "addon1", addOnStatusUnreachable)
-			},
-		},
-		{
-			name:      "addon status is updated",
-			addOnName: "addon1",
-			cluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-					Labels: map[string]string{
-						"feature.open-cluster-management.io/addon-addon1": addOnStatusAvailable,
-					},
-				},
-			},
-			addOn: &addonv1alpha1.ManagedClusterAddOn{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "addon1",
-					Namespace: clusterName,
-				},
-			},
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testingcommon.AssertActions(t, actions, "update")
-				actual := actions[0].(clienttesting.UpdateActionImpl).Object
-				assertAddonLabel(t, actual.(*clusterv1.ManagedCluster), "addon1", addOnStatusUnreachable)
-			},
-		},
-		{
-			name:      "cluster is deleting",
-			addOnName: "addon1",
-			cluster: &clusterv1.ManagedCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              clusterName,
-					DeletionTimestamp: &deleteTime,
-				},
-			},
-			addOn: &addonv1alpha1.ManagedClusterAddOn{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "addon1",
-					Namespace: clusterName,
-				},
-			},
-			validateActions: testingcommon.AssertNoActions,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			objs := []runtime.Object{}
-			if c.cluster != nil {
-				objs = append(objs, c.cluster)
-			}
-
-			clusterClient := clusterfake.NewSimpleClientset(objs...)
-
-			clusterInformerFactory := clusterinformers.NewSharedInformerFactory(clusterClient, time.Minute*10)
-			if c.cluster != nil {
-				clusterStore := clusterInformerFactory.Cluster().V1().ManagedClusters().Informer().GetStore()
-				if err := clusterStore.Add(c.cluster); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			objs = []runtime.Object{}
-			if c.addOn != nil {
-				objs = append(objs, c.addOn)
-			}
-			addOnClient := addonfake.NewSimpleClientset(objs...)
-			addOnInformerFactory := addoninformers.NewSharedInformerFactoryWithOptions(addOnClient, 10*time.Minute)
-			if c.addOn != nil {
-				addOnStore := addOnInformerFactory.Addon().V1alpha1().ManagedClusterAddOns().Informer().GetStore()
-				if err := addOnStore.Add(c.addOn); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			controller := addOnFeatureDiscoveryController{
-				clusterClient: clusterClient,
-				clusterLister: clusterInformerFactory.Cluster().V1().ManagedClusters().Lister(),
-				addOnLister:   addOnInformerFactory.Addon().V1alpha1().ManagedClusterAddOns().Lister(),
-			}
-
-			err := controller.syncAddOn(context.Background(), clusterName, c.addOnName)
-			if err != nil {
-				t.Errorf("unexpected err: %v", err)
-			}
-
-			c.validateActions(t, clusterClient.Actions())
-		})
-	}
-}
-
 func TestDiscoveryController_Sync(t *testing.T) {
 	clusterName := "cluster1"
 	deleteTime := metav1.Now()
@@ -243,10 +93,18 @@ func TestDiscoveryController_Sync(t *testing.T) {
 	}{
 		{
 			name:     "addon synced",
-			queueKey: "cluster1/addon1",
+			queueKey: clusterName,
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.ManagedClusterConditionAvailable,
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
 			addOns: []*addonv1alpha1.ManagedClusterAddOn{
@@ -258,9 +116,14 @@ func TestDiscoveryController_Sync(t *testing.T) {
 				},
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testingcommon.AssertActions(t, actions, "update")
-				actual := actions[0].(clienttesting.UpdateActionImpl).Object
-				assertAddonLabel(t, actual.(*clusterv1.ManagedCluster), "addon1", addOnStatusUnreachable)
+				testingcommon.AssertActions(t, actions, "patch")
+				patch := actions[0].(clienttesting.PatchAction).GetPatch()
+				actual := &clusterv1.ManagedCluster{}
+				err := json.Unmarshal(patch, actual)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertAddonLabel(t, actual, "addon1", addOnStatusUnreachable)
 			},
 		},
 		{
@@ -269,7 +132,7 @@ func TestDiscoveryController_Sync(t *testing.T) {
 			validateActions: testingcommon.AssertNoActions,
 		},
 		{
-			name:     "cluster is deleting",
+			name:     "cluster no available condition",
 			queueKey: clusterName,
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -280,11 +143,38 @@ func TestDiscoveryController_Sync(t *testing.T) {
 			validateActions: testingcommon.AssertNoActions,
 		},
 		{
+			name:     "cluster is deleting",
+			queueKey: clusterName,
+			cluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              clusterName,
+					DeletionTimestamp: &deleteTime,
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.ManagedClusterConditionAvailable,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			validateActions: testingcommon.AssertNoActions,
+		},
+		{
 			name:     "no change",
 			queueKey: clusterName,
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.ManagedClusterConditionAvailable,
+							Status: metav1.ConditionTrue,
+						},
+					},
 				},
 			},
 			validateActions: testingcommon.AssertNoActions,
@@ -297,6 +187,14 @@ func TestDiscoveryController_Sync(t *testing.T) {
 					Name: clusterName,
 					Labels: map[string]string{
 						"feature.open-cluster-management.io/addon-addon4": "available",
+					},
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   clusterv1.ManagedClusterConditionAvailable,
+							Status: metav1.ConditionTrue,
+						},
 					},
 				},
 			},
@@ -330,11 +228,16 @@ func TestDiscoveryController_Sync(t *testing.T) {
 				},
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testingcommon.AssertActions(t, actions, "update")
-				actual := actions[0].(clienttesting.UpdateActionImpl).Object
-				assertAddonLabel(t, actual.(*clusterv1.ManagedCluster), "addon1", addOnStatusUnreachable)
-				assertAddonLabel(t, actual.(*clusterv1.ManagedCluster), "addon3", addOnStatusAvailable)
-				assertNoAddonLabel(t, actual.(*clusterv1.ManagedCluster), "addon4")
+				testingcommon.AssertActions(t, actions, "patch")
+				patch := actions[0].(clienttesting.PatchAction).GetPatch()
+				actual := &clusterv1.ManagedCluster{}
+				err := json.Unmarshal(patch, actual)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertAddonLabel(t, actual, "addon1", addOnStatusUnreachable)
+				assertAddonLabel(t, actual, "addon3", addOnStatusAvailable)
+				assertNoAddonLabel(t, actual, "addon4")
 			},
 		},
 	}
@@ -370,7 +273,9 @@ func TestDiscoveryController_Sync(t *testing.T) {
 			}
 
 			controller := addOnFeatureDiscoveryController{
-				clusterClient: clusterClient,
+				patcher: patcher.NewPatcher[
+					*clusterv1.ManagedCluster, clusterv1.ManagedClusterSpec, clusterv1.ManagedClusterStatus](
+					clusterClient.ClusterV1().ManagedClusters()),
 				clusterLister: clusterInformerFactory.Cluster().V1().ManagedClusters().Lister(),
 				addOnLister:   addOnInformerFactory.Addon().V1alpha1().ManagedClusterAddOns().Lister(),
 			}
@@ -399,7 +304,7 @@ func assertAddonLabel(t *testing.T, cluster *clusterv1.ManagedCluster, addOnName
 
 func assertNoAddonLabel(t *testing.T, cluster *clusterv1.ManagedCluster, addOnName string) {
 	key := fmt.Sprintf("%s%s", addOnFeaturePrefix, addOnName)
-	if _, ok := cluster.Labels[key]; ok {
-		t.Errorf("label %q found", key)
+	if value, ok := cluster.Labels[key]; ok && len(value) > 0 {
+		t.Errorf("label %q found with value %s", key, value)
 	}
 }

--- a/pkg/registration/hub/clusterrole/manifests/managedcluster-registration-clusterrole.yaml
+++ b/pkg/registration/hub/clusterrole/manifests/managedcluster-registration-clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:managedcluster:registration
+  labels:
+    open-cluster-management.io/cluster-name: ""
 rules:
 # Allow spoke registration agent to get/update coordination.k8s.io/lease
 - apiGroups: ["coordination.k8s.io"]

--- a/pkg/registration/hub/clusterrole/manifests/managedcluster-work-clusterrole.yaml
+++ b/pkg/registration/hub/clusterrole/manifests/managedcluster-work-clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:managedcluster:work
+  labels:
+    open-cluster-management.io/cluster-name: ""
 rules:
 # Allow work agent to send event to hub
 - apiGroups: ["", "events.k8s.io"]

--- a/pkg/registration/hub/managedcluster/controller_test.go
+++ b/pkg/registration/hub/managedcluster/controller_test.go
@@ -3,14 +3,13 @@ package managedcluster
 import (
 	"context"
 	"encoding/json"
-	kubeinformers "k8s.io/client-go/informers"
-	"open-cluster-management.io/ocm/pkg/common/apply"
 	"testing"
 	"time"
 
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 
@@ -18,6 +17,7 @@ import (
 	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	v1 "open-cluster-management.io/api/cluster/v1"
 
+	"open-cluster-management.io/ocm/pkg/common/apply"
 	"open-cluster-management.io/ocm/pkg/common/patcher"
 	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
 	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"

--- a/pkg/registration/hub/managedcluster/controller_test.go
+++ b/pkg/registration/hub/managedcluster/controller_test.go
@@ -3,11 +3,12 @@ package managedcluster
 import (
 	"context"
 	"encoding/json"
+	kubeinformers "k8s.io/client-go/informers"
+	"open-cluster-management.io/ocm/pkg/common/apply"
 	"testing"
 	"time"
 
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -117,6 +118,7 @@ func TestSyncManagedCluster(t *testing.T) {
 			clusterClient := clusterfake.NewSimpleClientset(c.startingObjects...)
 			kubeClient := kubefake.NewSimpleClientset()
 			clusterInformerFactory := clusterinformers.NewSharedInformerFactory(clusterClient, time.Minute*10)
+			kubeInformer := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, time.Minute*10)
 			clusterStore := clusterInformerFactory.Cluster().V1().ManagedClusters().Informer().GetStore()
 			for _, cluster := range c.startingObjects {
 				if err := clusterStore.Add(cluster); err != nil {
@@ -127,8 +129,14 @@ func TestSyncManagedCluster(t *testing.T) {
 			ctrl := managedClusterController{
 				kubeClient,
 				clusterInformerFactory.Cluster().V1().ManagedClusters().Lister(),
+				apply.NewPermissionApplier(
+					kubeClient,
+					kubeInformer.Rbac().V1().Roles().Lister(),
+					kubeInformer.Rbac().V1().RoleBindings().Lister(),
+					kubeInformer.Rbac().V1().ClusterRoles().Lister(),
+					kubeInformer.Rbac().V1().ClusterRoleBindings().Lister(),
+				),
 				patcher.NewPatcher[*v1.ManagedCluster, v1.ManagedClusterSpec, v1.ManagedClusterStatus](clusterClient.ClusterV1().ManagedClusters()),
-				resourceapply.NewResourceCache(),
 				eventstesting.NewTestingEventRecorder(t)}
 			syncErr := ctrl.sync(context.TODO(), testingcommon.NewFakeSyncContext(t, testinghelpers.TestManagedClusterName))
 			if syncErr != nil {

--- a/pkg/registration/hub/managedcluster/manifests/managedcluster-clusterrole.yaml
+++ b/pkg/registration/hub/managedcluster/manifests/managedcluster-clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
+  labels:
+    open-cluster-management.io/cluster-name: {{ .ManagedClusterName }}
 rules:
 # Allow agent to rotate its certificate
 - apiGroups: ["certificates.k8s.io"]

--- a/pkg/registration/hub/managedcluster/manifests/managedcluster-clusterrolebinding.yaml
+++ b/pkg/registration/hub/managedcluster/manifests/managedcluster-clusterrolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
+  labels:
+    open-cluster-management.io/cluster-name: {{ .ManagedClusterName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/pkg/registration/hub/managedcluster/manifests/managedcluster-namespace.yaml
+++ b/pkg/registration/hub/managedcluster/manifests/managedcluster-namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: "{{ .ManagedClusterName }}"

--- a/pkg/registration/hub/managedcluster/manifests/managedcluster-registration-rolebinding.yaml
+++ b/pkg/registration/hub/managedcluster/manifests/managedcluster-registration-rolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}:registration
   namespace: "{{ .ManagedClusterName }}"
+  labels:
+    open-cluster-management.io/cluster-name: {{ .ManagedClusterName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/pkg/registration/hub/managedcluster/manifests/managedcluster-work-rolebinding.yaml
+++ b/pkg/registration/hub/managedcluster/manifests/managedcluster-work-rolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}:work
   namespace: "{{ .ManagedClusterName }}"
+  labels:
+    open-cluster-management.io/cluster-name: {{ .ManagedClusterName }}
   finalizers:
   - cluster.open-cluster-management.io/manifest-work-cleanup
 roleRef:

--- a/pkg/registration/hub/manager.go
+++ b/pkg/registration/hub/manager.go
@@ -2,9 +2,6 @@ package hub
 
 import (
 	"context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -13,17 +10,20 @@ import (
 	"github.com/spf13/pflag"
 	certv1 "k8s.io/api/certificates/v1"
 	certv1beta1 "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
 	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
 	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	workv1client "open-cluster-management.io/api/client/work/clientset/versioned"
 	workv1informers "open-cluster-management.io/api/client/work/informers/externalversions"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ocmfeature "open-cluster-management.io/api/feature"
 
 	"open-cluster-management.io/ocm/pkg/features"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is to use lister for permission to avoid too frequent get calls. 
For all legacy k8s resource managed by registration, we add a cluster label and informer will use label selector to filter.

## Related issue(s)

Fixes #