### PR TITLE
✨ run work and registration as a single binary

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,3 +75,32 @@ jobs:
           IMAGE_TAG=e2e KLUSTERLET_DEPLOY_MODE=Hosted make test-e2e
         env:
           KUBECONFIG: /home/runner/.kube/config
+  e2e-singleton:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Setup kind
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.17.0
+      - name: install imagebuilder
+        run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
+      - name: Build images
+        run: IMAGE_TAG=e2e make images
+      - name: Load images
+        run: |
+          kind load docker-image --name=kind quay.io/open-cluster-management/registration-operator:e2e
+          kind load docker-image --name=kind quay.io/open-cluster-management/registration:e2e
+          kind load docker-image --name=kind quay.io/open-cluster-management/work:e2e
+          kind load docker-image --name=kind quay.io/open-cluster-management/placement:e2e
+          kind load docker-image --name=kind quay.io/open-cluster-management/addon-manager:e2e
+      - name: Test E2E
+        run: |
+          IMAGE_TAG=e2e KLUSTERLET_DEPLOY_MODE=Singleton make test-e2e
+        env:
+          KUBECONFIG: /home/runner/.kube/config

--- a/cmd/registration-operator/main.go
+++ b/cmd/registration-operator/main.go
@@ -52,6 +52,7 @@ func newNucleusCommand() *cobra.Command {
 
 	cmd.AddCommand(hub.NewHubOperatorCmd())
 	cmd.AddCommand(spoke.NewKlusterletOperatorCmd())
+	cmd.AddCommand(spoke.NewKlusterletAgentCmd())
 
 	return cmd
 }

--- a/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
@@ -341,6 +341,15 @@ spec:
           verbs:
           - update
         - apiGroups:
+          - addon.open-cluster-management.io
+          resources:
+          - addondeploymentconfigs
+          - addontemplates
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -364,12 +373,11 @@ spec:
           - update
         - apiGroups:
           - certificates.k8s.io
-          resourceNames:
-          - kubernetes.io/kube-apiserver-client
           resources:
           - signers
           verbs:
           - approve
+          - sign
         - apiGroups:
           - cluster.open-cluster-management.io
           resources:

--- a/deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml
+++ b/deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml
@@ -7,6 +7,7 @@ spec:
     mode: Default
   registrationImagePullSpec: quay.io/open-cluster-management/registration
   workImagePullSpec: quay.io/open-cluster-management/work
+  imagePullSpec: quay.io/open-cluster-management/registration-operator
   clusterName: cluster1
   namespace: open-cluster-management-agent
   externalServerURLs:

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
@@ -20,6 +20,7 @@ metadata:
                 "url": "https://localhost"
               }
             ],
+            "imagePullSpec": "quay.io/open-cluster-management/registration-operator",
             "namespace": "open-cluster-management-agent",
             "registrationConfiguration": {
               "featureGates": [

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/operator.open-cluster-management.io_klusterlets.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/operator.open-cluster-management.io_klusterlets.yaml
@@ -37,7 +37,7 @@ spec:
                 description: DeployOption contains the options of deploying a klusterlet
                 properties:
                   mode:
-                    description: 'Mode can be Default or Hosted. It is Default mode if not specified In Default mode, all klusterlet related resources are deployed on the managed cluster. In Hosted mode, only crd and configurations are installed on the spoke/managed cluster. Controllers run in another cluster (defined as management-cluster) and connect to the mangaged cluster with the kubeconfig in secret of "external-managed-kubeconfig"(a kubeconfig of managed-cluster with cluster-admin permission). Note: Do not modify the Mode field once it''s applied.'
+                    description: 'Mode can be Default, Hosted or Singleton. It is Default mode if not specified In Default mode, all klusterlet related resources are deployed on the managed cluster. In Hosted mode, only crd and configurations are installed on the spoke/managed cluster. Controllers run in another cluster (defined as management-cluster) and connect to the mangaged cluster with the kubeconfig in secret of "external-managed-kubeconfig"(a kubeconfig of managed-cluster with cluster-admin permission). In Singleton mode, registration/work agent is started as a single deployment. Note: Do not modify the Mode field once it''s applied.'
                     type: string
                 type: object
               externalServerURLs:
@@ -69,6 +69,9 @@ spec:
                 - hostname
                 - ip
                 type: object
+              imagePullSpec:
+                description: ImagePullSpec represents the desired image configuration of agent, it takes effect only when singleton mode is set. quay.io/open-cluster-management.io/registration-operator:latest will be used if unspecified
+                type: string
               namespace:
                 description: Namespace is the namespace to deploy the agent on the managed cluster. The namespace must have a prefix of "open-cluster-management-", and if it is not set, the namespace of "open-cluster-management-agent" is used to deploy agent. In addition, the add-ons are deployed to the namespace of "{Namespace}-addon". In the Hosted mode, this namespace still exists on the managed cluster to contain necessary resources, like service accounts, roles and rolebindings, while the agent is deployed to the namespace with the same name as klusterlet on the management cluster.
                 maxLength: 63

--- a/manifests/klusterlet/managed/klusterlet-registration-clusterrolebinding-addon-management.yaml
+++ b/manifests/klusterlet/managed/klusterlet-registration-clusterrolebinding-addon-management.yaml
@@ -13,5 +13,5 @@ roleRef:
   name: open-cluster-management:{{ .KlusterletName }}-registration:addon-management
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-registration-sa
+    name: {{ .RegistrationServiceAccount }}
     namespace: {{ .KlusterletNamespace }}

--- a/manifests/klusterlet/managed/klusterlet-registration-clusterrolebinding.yaml
+++ b/manifests/klusterlet/managed/klusterlet-registration-clusterrolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: open-cluster-management:{{ .KlusterletName }}-registration:agent
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-registration-sa
+    name: {{ .RegistrationServiceAccount }}
     namespace: {{ .KlusterletNamespace }}

--- a/manifests/klusterlet/managed/klusterlet-registration-serviceaccount.yaml
+++ b/manifests/klusterlet/managed/klusterlet-registration-serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .KlusterletName }}-registration-sa
+  name: {{ .RegistrationServiceAccount }}
   namespace: {{ .KlusterletNamespace }}
 imagePullSecrets:
 - name: open-cluster-management-image-pull-credentials

--- a/manifests/klusterlet/managed/klusterlet-work-clusterrolebinding-execution-admin.yaml
+++ b/manifests/klusterlet/managed/klusterlet-work-clusterrolebinding-execution-admin.yaml
@@ -12,5 +12,5 @@ roleRef:
   name: admin
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-work-sa
+    name: {{ .WorkServiceAccount }}
     namespace: {{ .KlusterletNamespace }}

--- a/manifests/klusterlet/managed/klusterlet-work-clusterrolebinding-execution.yaml
+++ b/manifests/klusterlet/managed/klusterlet-work-clusterrolebinding-execution.yaml
@@ -10,5 +10,5 @@ roleRef:
   name: open-cluster-management:{{ .KlusterletName }}-work:execution
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-work-sa
+    name: {{ .WorkServiceAccount }}
     namespace: {{ .KlusterletNamespace }}

--- a/manifests/klusterlet/managed/klusterlet-work-clusterrolebinding.yaml
+++ b/manifests/klusterlet/managed/klusterlet-work-clusterrolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: open-cluster-management:{{ .KlusterletName }}-work:agent
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-work-sa
+    name: {{ .WorkServiceAccount }}
     namespace: {{ .KlusterletNamespace }}

--- a/manifests/klusterlet/managed/klusterlet-work-serviceaccount.yaml
+++ b/manifests/klusterlet/managed/klusterlet-work-serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .KlusterletName }}-work-sa
+  name: {{ .WorkServiceAccount }}
   namespace: {{ .KlusterletNamespace }}
 imagePullSecrets:
 - name: open-cluster-management-image-pull-credentials

--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -1,0 +1,119 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ .KlusterletName }}-agent
+  namespace: {{ .AgentNamespace }}
+  labels:
+    app: klusterlet-agent
+    createdBy: klusterlet
+spec:
+  replicas: {{ .Replica }}
+  selector:
+    matchLabels:
+      app: klusterlet-agent
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: klusterlet-agent
+    spec:
+      {{if .HubApiServerHostAlias }}
+      hostAliases:
+      - ip: {{ .HubApiServerHostAlias.IP }}
+        hostnames:
+        - {{ .HubApiServerHostAlias.Hostname }}
+      {{end}}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - klusterlet-registration-agent
+          - weight: 30
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - klusterlet-registration-agent
+      serviceAccountName: klusterlet-agent-sa
+      containers:
+      - name: registration-controller
+        image: {{ .SingletonImage }}
+        args:
+          - "/registration-operator"
+          - "agent"
+          - "--spoke-cluster-name={{ .ClusterName }}"
+          - "--bootstrap-kubeconfig=/spoke/bootstrap/kubeconfig"
+          - "--agent-id={{ .AgentID }}"
+          {{ if gt (len .WorkFeatureGates) 0 }}
+          {{range .WorkFeatureGates}}
+          - {{ . }}
+          {{end}}
+          {{ end }}
+          {{ if gt (len .RegistrationFeatureGates) 0 }}
+          {{range .RegistrationFeatureGates}}
+          - {{ . }}
+          {{end}}
+          {{ end }}
+          {{if .ExternalServerURL}}
+          - "--spoke-external-server-urls={{ .ExternalServerURL }}"
+          {{end}}
+          - "--terminate-on-files=/spoke/hub-kubeconfig/kubeconfig"
+          {{if eq .Replica 1}}
+          - "--disable-leader-election"
+          {{end}}
+          {{if gt .ClientCertExpirationSeconds 0}}
+          - "--client-cert-expiration-seconds={{ .ClientCertExpirationSeconds }}"
+          {{end}}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          runAsNonRoot: true
+        volumeMounts:
+        - name: bootstrap-secret
+          mountPath: "/spoke/bootstrap"
+          readOnly: true
+        - name: hub-kubeconfig
+          mountPath: "/spoke/hub-kubeconfig"
+        {{if eq .InstallMode "Hosted"}}
+        - name: spoke-kubeconfig-secret
+          mountPath: "/spoke/config"
+          readOnly: true
+        {{end}}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          initialDelaySeconds: 2
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          initialDelaySeconds: 2
+        resources:
+          requests:
+            cpu: 2m
+            memory: 16Mi
+      volumes:
+      - name: bootstrap-secret
+        secret:
+          secretName: {{ .BootStrapKubeConfigSecret }}
+      - name: hub-kubeconfig
+        emptyDir:
+          medium: Memory

--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -45,9 +45,9 @@ spec:
                   operator: In
                   values:
                   - klusterlet-registration-agent
-      serviceAccountName: klusterlet-agent-sa
+      serviceAccountName: {{ .KlusterletName }}-agent-sa
       containers:
-      - name: registration-controller
+      - name: klusterlet-agent
         image: {{ .SingletonImage }}
         args:
           - "/registration-operator"
@@ -88,11 +88,6 @@ spec:
           readOnly: true
         - name: hub-kubeconfig
           mountPath: "/spoke/hub-kubeconfig"
-        {{if eq .InstallMode "Hosted"}}
-        - name: spoke-kubeconfig-secret
-          mountPath: "/spoke/config"
-          readOnly: true
-        {{end}}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/klusterlet/management/klusterlet-registration-clusterrolebinding-addon-management.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-clusterrolebinding-addon-management.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: open-cluster-management:management:{{ .KlusterletName }}-registration:addon-management
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-registration-sa
+    name: {{ .RegistrationServiceAccount }}
     namespace: {{ .AgentNamespace }}

--- a/manifests/klusterlet/management/klusterlet-registration-rolebinding-extension-apiserver.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-rolebinding-extension-apiserver.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: open-cluster-management:management:{{ .KlusterletName }}:extension-apiserver
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-registration-sa
+    name: {{ .RegistrationServiceAccount }}
     namespace: {{ .AgentNamespace }}

--- a/manifests/klusterlet/management/klusterlet-registration-rolebinding.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-rolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
   name: open-cluster-management:management:{{ .KlusterletName }}-registration:agent
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-registration-sa
+    name: {{ .RegistrationServiceAccount }}
     namespace: {{ .AgentNamespace }}

--- a/manifests/klusterlet/management/klusterlet-registration-serviceaccount.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .KlusterletName }}-registration-sa
+  name: {{ .RegistrationServiceAccount }}
   namespace: {{ .AgentNamespace }}
 imagePullSecrets:
 - name: open-cluster-management-image-pull-credentials

--- a/manifests/klusterlet/management/klusterlet-work-rolebinding-extension-apiserver.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-rolebinding-extension-apiserver.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: open-cluster-management:management:{{ .KlusterletName }}:extension-apiserver
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-work-sa
+    name: {{ .WorkServiceAccount }}
     namespace: {{ .AgentNamespace }}

--- a/manifests/klusterlet/management/klusterlet-work-rolebinding.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-rolebinding.yaml
@@ -10,5 +10,5 @@ roleRef:
   name: open-cluster-management:management:{{ .KlusterletName }}-work:agent
 subjects:
   - kind: ServiceAccount
-    name: {{ .KlusterletName }}-work-sa
+    name: {{ .WorkServiceAccount }}
     namespace: {{ .AgentNamespace }}

--- a/manifests/klusterlet/management/klusterlet-work-serviceaccount.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .KlusterletName }}-work-sa
+  name: {{ .WorkServiceAccount }}
   namespace: {{ .AgentNamespace }}
 imagePullSecrets:
 - name: open-cluster-management-image-pull-credentials

--- a/pkg/cmd/spoke/operator.go
+++ b/pkg/cmd/spoke/operator.go
@@ -5,12 +5,22 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
+	ocmfeature "open-cluster-management.io/api/feature"
+
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/operator/operators/klusterlet"
+	registration "open-cluster-management.io/ocm/pkg/registration/spoke"
+	singletonspoke "open-cluster-management.io/ocm/pkg/singleton/spoke"
 	"open-cluster-management.io/ocm/pkg/version"
+	work "open-cluster-management.io/ocm/pkg/work/spoke"
 )
 
-// NewKlusterletOperatorCmd generatee a command to start klusterlet operator
+const agentCmdName = "agent"
+
+// NewKlusterletOperatorCmd generate a command to start klusterlet operator
 func NewKlusterletOperatorCmd() *cobra.Command {
 
 	options := klusterlet.Options{}
@@ -26,5 +36,33 @@ func NewKlusterletOperatorCmd() *cobra.Command {
 		"If set, will skip ensuring a placeholder hub secret which is originally intended for pulling "+
 			"work image before approved")
 
+	return cmd
+}
+
+// NewKlusterletAgentCmd is to start the singleton agent including registration/work
+func NewKlusterletAgentCmd() *cobra.Command {
+	commonOptions := commonoptions.NewAgentOptions()
+	workOptions := work.NewWorkloadAgentOptions()
+	registrationOption := registration.NewSpokeAgentOptions()
+
+	agentConfig := singletonspoke.NewAgentConfig(commonOptions, registrationOption, workOptions)
+	cmdConfig := controllercmd.
+		NewControllerCommandConfig("klusterlet", version.Get(), agentConfig.RunSpokeAgent)
+	cmd := cmdConfig.NewCommandWithContext(context.TODO())
+	cmd.Use = agentCmdName
+	cmd.Short = "Start the klusterlet agent"
+
+	flags := cmd.Flags()
+
+	commonOptions.AddFlags(flags)
+	workOptions.AddFlags(flags)
+	registrationOption.AddFlags(flags)
+
+	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates))
+	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
+	features.SpokeMutableFeatureGate.AddFlag(flags)
+
+	// add disable leader election flag
+	flags.BoolVar(&cmdConfig.DisableLeaderElection, "disable-leader-election", false, "Disable leader election for the agent.")
 	return cmd
 }

--- a/pkg/cmd/spoke/registration.go
+++ b/pkg/cmd/spoke/registration.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 
 	"open-cluster-management.io/ocm/pkg/registration/spoke"
 	"open-cluster-management.io/ocm/pkg/version"
@@ -12,14 +13,17 @@ import (
 
 func NewRegistrationAgent() *cobra.Command {
 	agentOptions := spoke.NewSpokeAgentOptions()
+	commonOptions := commonoptions.NewAgentOptions()
+	cfg := spoke.NewSpokeAgentConfig(commonOptions, agentOptions)
 	cmdConfig := controllercmd.
-		NewControllerCommandConfig("registration-agent", version.Get(), agentOptions.RunSpokeAgent)
+		NewControllerCommandConfig("registration-agent", version.Get(), cfg.RunSpokeAgent)
 
 	cmd := cmdConfig.NewCommandWithContext(context.TODO())
 	cmd.Use = "agent"
 	cmd.Short = "Start the Cluster Registration Agent"
 
 	flags := cmd.Flags()
+	commonOptions.AddFlags(flags)
 	agentOptions.AddFlags(flags)
 
 	flags.BoolVar(&cmdConfig.DisableLeaderElection, "disable-leader-election", false, "Disable leader election for the agent.")

--- a/pkg/cmd/spoke/registration.go
+++ b/pkg/cmd/spoke/registration.go
@@ -5,8 +5,12 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
-	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
+	ocmfeature "open-cluster-management.io/api/feature"
+
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/registration/spoke"
 	"open-cluster-management.io/ocm/pkg/version"
 )
@@ -19,12 +23,15 @@ func NewRegistrationAgent() *cobra.Command {
 		NewControllerCommandConfig("registration-agent", version.Get(), cfg.RunSpokeAgent)
 
 	cmd := cmdConfig.NewCommandWithContext(context.TODO())
-	cmd.Use = "agent"
+	cmd.Use = agentCmdName
 	cmd.Short = "Start the Cluster Registration Agent"
 
 	flags := cmd.Flags()
 	commonOptions.AddFlags(flags)
 	agentOptions.AddFlags(flags)
+
+	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates))
+	features.SpokeMutableFeatureGate.AddFlag(flags)
 
 	flags.BoolVar(&cmdConfig.DisableLeaderElection, "disable-leader-election", false, "Disable leader election for the agent.")
 	return cmd

--- a/pkg/cmd/spoke/work.go
+++ b/pkg/cmd/spoke/work.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 
 	"open-cluster-management.io/ocm/pkg/version"
 	"open-cluster-management.io/ocm/pkg/work/spoke"
@@ -12,17 +13,19 @@ import (
 
 // NewWorkAgent generates a command to start work agent
 func NewWorkAgent() *cobra.Command {
-	o := spoke.NewWorkloadAgentOptions()
+	commonOptions := commonoptions.NewAgentOptions()
+	agentOption := spoke.NewWorkloadAgentOptions()
+	cfg := spoke.NewWorkAgentConfig(commonOptions, agentOption)
 	cmdConfig := controllercmd.
-		NewControllerCommandConfig("work-agent", version.Get(), o.RunWorkloadAgent)
+		NewControllerCommandConfig("work-agent", version.Get(), cfg.RunWorkloadAgent)
 	cmd := cmdConfig.NewCommandWithContext(context.TODO())
 	cmd.Use = "agent"
 	cmd.Short = "Start the Work Agent"
 
-	o.AddFlags(cmd)
-
 	// add disable leader election flag
 	flags := cmd.Flags()
+	commonOptions.AddFlags(flags)
+	agentOption.AddFlags(flags)
 	flags.BoolVar(&cmdConfig.DisableLeaderElection, "disable-leader-election", false, "Disable leader election for the agent.")
 
 	return cmd

--- a/pkg/cmd/spoke/work.go
+++ b/pkg/cmd/spoke/work.go
@@ -5,8 +5,12 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
-	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
+	ocmfeature "open-cluster-management.io/api/feature"
+
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/version"
 	"open-cluster-management.io/ocm/pkg/work/spoke"
 )
@@ -19,13 +23,16 @@ func NewWorkAgent() *cobra.Command {
 	cmdConfig := controllercmd.
 		NewControllerCommandConfig("work-agent", version.Get(), cfg.RunWorkloadAgent)
 	cmd := cmdConfig.NewCommandWithContext(context.TODO())
-	cmd.Use = "agent"
+	cmd.Use = agentCmdName
 	cmd.Short = "Start the Work Agent"
 
 	// add disable leader election flag
 	flags := cmd.Flags()
 	commonOptions.AddFlags(flags)
 	agentOption.AddFlags(flags)
+	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
+	features.SpokeMutableFeatureGate.AddFlag(flags)
+
 	flags.BoolVar(&cmdConfig.DisableLeaderElection, "disable-leader-election", false, "Disable leader election for the agent.")
 
 	return cmd

--- a/pkg/common/options/options.go
+++ b/pkg/common/options/options.go
@@ -2,19 +2,20 @@ package options
 
 import (
 	"fmt"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/klog/v2"
-	"open-cluster-management.io/ocm/pkg/registration/clientcert"
-	"open-cluster-management.io/ocm/pkg/registration/spoke/registration"
 	"os"
 	"path"
 	"strings"
 
 	"github.com/spf13/pflag"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	"open-cluster-management.io/ocm/pkg/registration/clientcert"
+	"open-cluster-management.io/ocm/pkg/registration/spoke/registration"
 )
 
 const (
@@ -166,7 +167,7 @@ func (o *AgentOptions) getOrGenerateClusterAgentID() (string, string) {
 			if agentNameInCert != agentID {
 				klog.Warningf(
 					"Use agent name %q in certification instead of %q in the mounted secret",
-					agentNameInCert, string(agentID))
+					agentNameInCert, agentID)
 			}
 		case err == nil:
 			// use agent name loaded from the mounted secret

--- a/pkg/common/options/options.go
+++ b/pkg/common/options/options.go
@@ -2,6 +2,13 @@ package options
 
 import (
 	"fmt"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/klog/v2"
+	"open-cluster-management.io/ocm/pkg/registration/clientcert"
+	"open-cluster-management.io/ocm/pkg/registration/spoke/registration"
+	"os"
+	"path"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -10,20 +17,39 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	// spokeAgentNameLength is the length of the spoke agent name which is generated automatically
+	spokeAgentNameLength = 5
+	// defaultSpokeComponentNamespace is the default namespace in which the spoke agent is deployed
+	defaultSpokeComponentNamespace = "open-cluster-management-agent"
+)
+
 // AgentOptions is the common agent options
 type AgentOptions struct {
+	ComponentNamespace  string
 	SpokeKubeconfigFile string
 	SpokeClusterName    string
+	HubKubeconfigDir    string
+	HubKubeconfigFile   string
+	AgentID             string
 	Burst               int
 	QPS                 float32
 }
 
 // NewWorkloadAgentOptions returns the flags with default value set
 func NewAgentOptions() *AgentOptions {
-	return &AgentOptions{
-		QPS:   50,
-		Burst: 100,
+	opts := &AgentOptions{
+		HubKubeconfigDir:   "/spoke/hub-kubeconfig",
+		ComponentNamespace: defaultSpokeComponentNamespace,
+		QPS:                50,
+		Burst:              100,
 	}
+	// get component namespace of spoke agent
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err == nil {
+		opts.ComponentNamespace = string(nsBytes)
+	}
+	return opts
 }
 
 func (o *AgentOptions) AddFlags(flags *pflag.FlagSet) {
@@ -33,6 +59,10 @@ func (o *AgentOptions) AddFlags(flags *pflag.FlagSet) {
 	_ = flags.MarkDeprecated("cluster-name", "use spoke-cluster-name flag")
 	flags.StringVar(&o.SpokeClusterName, "cluster-name", o.SpokeClusterName,
 		"Name of the spoke cluster.")
+	flags.StringVar(&o.HubKubeconfigDir, "hub-kubeconfig-dir", o.HubKubeconfigDir,
+		"The mount path of hub-kubeconfig-secret in the container.")
+	flags.StringVar(&o.HubKubeconfigFile, "hub-kubeconfig", o.HubKubeconfigFile, "Location of kubeconfig file to connect to hub cluster.")
+	flags.StringVar(&o.AgentID, "agent-id", o.AgentID, "ID of the agent")
 	flags.Float32Var(&o.QPS, "spoke-kube-api-qps", o.QPS, "QPS to use while talking with apiserver on spoke cluster.")
 	flags.IntVar(&o.Burst, "spoke-kube-api-burst", o.Burst, "Burst to use while talking with apiserver on spoke cluster.")
 }
@@ -61,4 +91,101 @@ func (o *AgentOptions) Validate() error {
 	}
 
 	return nil
+}
+
+// Complete fills in missing values.
+func (o *AgentOptions) Complete() error {
+	if len(o.HubKubeconfigFile) == 0 {
+		o.HubKubeconfigFile = path.Join(o.HubKubeconfigDir, clientcert.KubeconfigFile)
+	}
+
+	// load or generate cluster/agent names
+	o.SpokeClusterName, o.AgentID = o.getOrGenerateClusterAgentID()
+
+	return nil
+}
+
+// getOrGenerateClusterAgentID returns cluster name and agent id.
+// Rules for picking up cluster name:
+//   1. Use cluster name from input arguments if 'spoke-cluster-name' is specified;
+//   2. Parse cluster name from the common name of the certification subject if the certification exists;
+//   3. Fallback to cluster name in the mounted secret if it exists;
+//   4. TODO: Read cluster name from openshift struct if the agent is running in an openshift cluster;
+//   5. Generate a random cluster name then;
+
+// Rules for picking up agent id:
+//  1. Read from the flag "agent-id" at first.
+//  2. Parse agent name from the common name of the certification subject if the certification exists;
+//  3. Fallback to agent name in the mounted secret if it exists;
+//  4. Generate a random agent name then;
+func (o *AgentOptions) getOrGenerateClusterAgentID() (string, string) {
+	if len(o.SpokeClusterName) > 0 && len(o.AgentID) > 0 {
+		return o.SpokeClusterName, o.AgentID
+	}
+	// try to load cluster/agent name from tls certification
+	var clusterNameInCert, agentNameInCert string
+	certPath := path.Join(o.HubKubeconfigDir, clientcert.TLSCertFile)
+	certData, certErr := os.ReadFile(path.Clean(certPath))
+	if certErr == nil {
+		clusterNameInCert, agentNameInCert, _ = registration.GetClusterAgentNamesFromCertificate(certData)
+	}
+
+	clusterName := o.SpokeClusterName
+	// if cluster name is not specified with input argument, try to load it from file
+	if clusterName == "" {
+		// TODO, read cluster name from openshift struct if the spoke agent is running in an openshift cluster
+
+		// and then load the cluster name from the mounted secret
+		clusterNameFilePath := path.Join(o.HubKubeconfigDir, clientcert.ClusterNameFile)
+		clusterNameBytes, err := os.ReadFile(path.Clean(clusterNameFilePath))
+		switch {
+		case len(clusterNameInCert) > 0:
+			// use cluster name loaded from the tls certification
+			clusterName = clusterNameInCert
+			if clusterNameInCert != string(clusterNameBytes) {
+				klog.Warningf("Use cluster name %q in certification instead of %q in the mounted secret", clusterNameInCert, string(clusterNameBytes))
+			}
+		case err == nil:
+			// use cluster name load from the mounted secret
+			clusterName = string(clusterNameBytes)
+		default:
+			// generate random cluster name
+			clusterName = generateClusterName()
+		}
+	}
+
+	agentID := o.AgentID
+	// try to load agent name from the mounted secret
+	if len(agentID) == 0 {
+		agentIDFilePath := path.Join(o.HubKubeconfigDir, clientcert.AgentNameFile)
+		agentIDBytes, err := os.ReadFile(path.Clean(agentIDFilePath))
+		switch {
+		case len(agentNameInCert) > 0:
+			// use agent name loaded from the tls certification
+			agentID = agentNameInCert
+			if agentNameInCert != agentID {
+				klog.Warningf(
+					"Use agent name %q in certification instead of %q in the mounted secret",
+					agentNameInCert, string(agentID))
+			}
+		case err == nil:
+			// use agent name loaded from the mounted secret
+			agentID = string(agentIDBytes)
+		default:
+			// generate random agent name
+			agentID = generateAgentName()
+		}
+	}
+
+	return clusterName, agentID
+}
+
+// generateClusterName generates a name for spoke cluster
+func generateClusterName() string {
+	return string(uuid.NewUUID())
+}
+
+// generateAgentName generates a random name for spoke cluster agent
+func generateAgentName() string {
+	return utilrand.String(spokeAgentNameLength)
 }

--- a/pkg/common/options/options_test.go
+++ b/pkg/common/options/options_test.go
@@ -2,17 +2,19 @@ package options
 
 import (
 	"context"
-	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kubefake "k8s.io/client-go/kubernetes/fake"
-	"open-cluster-management.io/ocm/pkg/registration/clientcert"
-	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
-	"open-cluster-management.io/ocm/pkg/registration/spoke/registration"
 	"os"
 	"path"
 	"testing"
 	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"open-cluster-management.io/ocm/pkg/registration/clientcert"
+	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
+	"open-cluster-management.io/ocm/pkg/registration/spoke/registration"
 )
 
 func TestComplete(t *testing.T) {

--- a/pkg/common/options/options_test.go
+++ b/pkg/common/options/options_test.go
@@ -1,0 +1,182 @@
+package options
+
+import (
+	"context"
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"open-cluster-management.io/ocm/pkg/registration/clientcert"
+	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
+	"open-cluster-management.io/ocm/pkg/registration/spoke/registration"
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+func TestComplete(t *testing.T) {
+	// get component namespace
+	var componentNamespace string
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		componentNamespace = defaultSpokeComponentNamespace
+	} else {
+		componentNamespace = string(nsBytes)
+	}
+
+	cases := []struct {
+		name                string
+		clusterName         string
+		secret              *corev1.Secret
+		expectedClusterName string
+		expectedAgentName   string
+	}{
+		{
+			name: "generate random cluster/agent name",
+		},
+		{
+			name:                "specify cluster name",
+			clusterName:         "cluster1",
+			expectedClusterName: "cluster1",
+		},
+		{
+			name:        "override cluster name in secret with specified value",
+			clusterName: "cluster1",
+			secret: testinghelpers.NewHubKubeconfigSecret(componentNamespace, "hub-kubeconfig-secret", "", nil, map[string][]byte{
+				"cluster-name": []byte("cluster2"),
+				"agent-name":   []byte("agent2"),
+			}),
+			expectedClusterName: "cluster1",
+			expectedAgentName:   "agent2",
+		},
+		{
+			name:        "override cluster name in cert with specified value",
+			clusterName: "cluster1",
+			secret: testinghelpers.NewHubKubeconfigSecret(componentNamespace, "hub-kubeconfig-secret", "", testinghelpers.NewTestCert("system:open-cluster-management:cluster2:agent2", 60*time.Second), map[string][]byte{
+				"kubeconfig":   testinghelpers.NewKubeconfig(nil, nil),
+				"cluster-name": []byte("cluster3"),
+				"agent-name":   []byte("agent3"),
+			}),
+			expectedClusterName: "cluster1",
+			expectedAgentName:   "agent2",
+		},
+		{
+			name: "take cluster/agent name from secret",
+			secret: testinghelpers.NewHubKubeconfigSecret(componentNamespace, "hub-kubeconfig-secret", "", nil, map[string][]byte{
+				"cluster-name": []byte("cluster1"),
+				"agent-name":   []byte("agent1"),
+			}),
+			expectedClusterName: "cluster1",
+			expectedAgentName:   "agent1",
+		},
+		{
+			name:                "take cluster/agent name from cert",
+			secret:              testinghelpers.NewHubKubeconfigSecret(componentNamespace, "hub-kubeconfig-secret", "", testinghelpers.NewTestCert("system:open-cluster-management:cluster1:agent1", 60*time.Second), map[string][]byte{}),
+			expectedClusterName: "cluster1",
+			expectedAgentName:   "agent1",
+		},
+		{
+			name: "override cluster name in secret with value from cert",
+			secret: testinghelpers.NewHubKubeconfigSecret(componentNamespace, "hub-kubeconfig-secret", "", testinghelpers.NewTestCert("system:open-cluster-management:cluster1:agent1", 60*time.Second), map[string][]byte{
+				"cluster-name": []byte("cluster2"),
+				"agent-name":   []byte("agent2"),
+			}),
+			expectedClusterName: "cluster1",
+			expectedAgentName:   "agent1",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// setup kube client
+			objects := []runtime.Object{}
+			if c.secret != nil {
+				objects = append(objects, c.secret)
+			}
+			kubeClient := kubefake.NewSimpleClientset(objects...)
+
+			// create a tmp dir to dump hub kubeconfig
+			dir, err := os.MkdirTemp("", "hub-kubeconfig")
+			if err != nil {
+				t.Error("unable to create a tmp dir")
+			}
+			defer os.RemoveAll(dir)
+
+			options := NewAgentOptions()
+			options.SpokeClusterName = c.clusterName
+			options.HubKubeconfigDir = dir
+
+			err = registration.DumpSecret(
+				kubeClient.CoreV1(), componentNamespace, "hub-kubeconfig-secret",
+				options.HubKubeconfigDir, context.TODO(), eventstesting.NewTestingEventRecorder(t))
+
+			if err := options.Complete(); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if options.ComponentNamespace == "" {
+				t.Error("component namespace should not be empty")
+			}
+			if options.SpokeClusterName == "" {
+				t.Error("cluster name should not be empty")
+			}
+			if options.AgentID == "" {
+				t.Error("agent name should not be empty")
+			}
+			if len(c.expectedClusterName) > 0 && options.SpokeClusterName != c.expectedClusterName {
+				t.Errorf("expect cluster name %q but got %q", c.expectedClusterName, options.SpokeClusterName)
+			}
+			if len(c.expectedAgentName) > 0 && options.AgentID != c.expectedAgentName {
+				t.Errorf("expect agent name %q but got %q", c.expectedAgentName, options.AgentID)
+			}
+		})
+	}
+}
+
+func TestGetOrGenerateClusterAgentNames(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "testgetorgenerateclusteragentnames")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cases := []struct {
+		name                string
+		options             *AgentOptions
+		expectedClusterName string
+		expectedAgentName   string
+	}{
+		{
+			name:                "cluster name is specified",
+			options:             &AgentOptions{SpokeClusterName: "cluster0"},
+			expectedClusterName: "cluster0",
+		},
+		{
+			name:                "cluster name and agent name are in file",
+			options:             &AgentOptions{HubKubeconfigDir: tempDir},
+			expectedClusterName: "cluster1",
+			expectedAgentName:   "agent1",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.options.HubKubeconfigDir != "" {
+				testinghelpers.WriteFile(path.Join(tempDir, clientcert.ClusterNameFile), []byte(c.expectedClusterName))
+				testinghelpers.WriteFile(path.Join(tempDir, clientcert.AgentNameFile), []byte(c.expectedAgentName))
+			}
+			clusterName, agentName := c.options.getOrGenerateClusterAgentID()
+			if clusterName != c.expectedClusterName {
+				t.Errorf("expect cluster name %q but got %q", c.expectedClusterName, clusterName)
+			}
+
+			// agent name cannot be empty, it is either generated or from file
+			if agentName == "" {
+				t.Error("agent name should not be empty")
+			}
+
+			if c.expectedAgentName != "" && c.expectedAgentName != agentName {
+				t.Errorf("expect agent name %q but got %q", c.expectedAgentName, agentName)
+			}
+		})
+	}
+}

--- a/pkg/common/options/options_test.go
+++ b/pkg/common/options/options_test.go
@@ -135,6 +135,43 @@ func TestComplete(t *testing.T) {
 	}
 }
 
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name        string
+		clusterName string
+		expectedErr bool
+	}{
+		{
+			name:        "empty cluster name",
+			expectedErr: true,
+		},
+		{
+			name:        "invalid cluster name format",
+			clusterName: "test.cluster",
+			expectedErr: true,
+		},
+		{
+			name:        "valid passed",
+			clusterName: "cluster-1",
+			expectedErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			options := NewAgentOptions()
+			options.SpokeClusterName = c.clusterName
+			err := options.Validate()
+			if err == nil && c.expectedErr {
+				t.Errorf("expect to get err")
+			}
+			if err != nil && !c.expectedErr {
+				t.Errorf("expect not error but got %v", err)
+			}
+		})
+	}
+}
+
 func TestGetOrGenerateClusterAgentNames(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "testgetorgenerateclusteragentnames")
 	if err != nil {

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -14,19 +14,14 @@ var (
 	// DefaultHubWorkMutableFeatureGate is made up of multiple mutable feature-gates for work controller
 	DefaultHubWorkMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
 
-	// DefaultSpokeWorkMutableFeatureGate is made up of multiple mutable feature-gates for work agent.
-	DefaultSpokeWorkMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-
-	// DefaultSpokeRegistrationMutableFeatureGate is made up of multiple mutable feature-gates for registration agent.
-	DefaultSpokeRegistrationMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-
 	// DefaultHubRegistrationMutableFeatureGate made up of multiple mutable feature-gates for registration hub controller.
 	DefaultHubRegistrationMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// SpokeMutableFeatureGate of multiple mutable feature-gates for agent
+	SpokeMutableFeatureGate = featuregate.NewFeatureGate()
 )
 
 func init() {
 	runtime.Must(DefaultHubWorkMutableFeatureGate.Add(ocmfeature.DefaultHubWorkFeatureGates))
-	runtime.Must(DefaultSpokeWorkMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
-	runtime.Must(DefaultSpokeRegistrationMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates))
 	runtime.Must(DefaultHubRegistrationMutableFeatureGate.Add(ocmfeature.DefaultHubRegistrationFeatureGates))
 }

--- a/pkg/operator/helpers/queuekey.go
+++ b/pkg/operator/helpers/queuekey.go
@@ -137,10 +137,6 @@ func ClusterManagerQueueKeyFunc(clusterManagerLister operatorlister.ClusterManag
 	return clusterManagerByNamespaceQueueKeyFunc(clusterManagerLister)
 }
 
-func ClusterManagerConfigmapQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeysFunc {
-	return clusterManagerByNamespaceQueueKeyFunc(clusterManagerLister)
-}
-
 func clusterManagerByNamespaceQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeysFunc {
 	return func(obj runtime.Object) []string {
 		accessor, _ := meta.Accessor(obj)

--- a/pkg/operator/helpers/queuekey.go
+++ b/pkg/operator/helpers/queuekey.go
@@ -50,8 +50,8 @@ func ClusterManagerNamespace(clustermanagername string, mode operatorapiv1.Insta
 	return ClusterManagerDefaultNamespace
 }
 
-func KlusterletSecretQueueKeyFunc(klusterletLister operatorlister.KlusterletLister) factory.ObjectQueueKeyFunc {
-	return func(obj runtime.Object) string {
+func KlusterletSecretQueueKeyFunc(klusterletLister operatorlister.KlusterletLister) factory.ObjectQueueKeysFunc {
+	return func(obj runtime.Object) []string {
 		accessor, _ := meta.Accessor(obj)
 		namespace := accessor.GetNamespace()
 		name := accessor.GetName()
@@ -60,24 +60,24 @@ func KlusterletSecretQueueKeyFunc(klusterletLister operatorlister.KlusterletList
 			interestedObjectFound = true
 		}
 		if !interestedObjectFound {
-			return ""
+			return []string{}
 		}
 
 		klusterlets, err := klusterletLister.List(labels.Everything())
 		if err != nil {
-			return ""
+			return []string{}
 		}
 
 		if klusterlet := FindKlusterletByNamespace(klusterlets, namespace); klusterlet != nil {
-			return klusterlet.Name
+			return []string{klusterlet.Name}
 		}
 
-		return ""
+		return []string{}
 	}
 }
 
-func KlusterletDeploymentQueueKeyFunc(klusterletLister operatorlister.KlusterletLister) factory.ObjectQueueKeyFunc {
-	return func(obj runtime.Object) string {
+func KlusterletDeploymentQueueKeyFunc(klusterletLister operatorlister.KlusterletLister) factory.ObjectQueueKeysFunc {
+	return func(obj runtime.Object) []string {
 		accessor, _ := meta.Accessor(obj)
 		namespace := accessor.GetNamespace()
 		name := accessor.GetName()
@@ -86,24 +86,24 @@ func KlusterletDeploymentQueueKeyFunc(klusterletLister operatorlister.Klusterlet
 			interestedObjectFound = true
 		}
 		if !interestedObjectFound {
-			return ""
+			return []string{}
 		}
 
 		klusterlets, err := klusterletLister.List(labels.Everything())
 		if err != nil {
-			return ""
+			return []string{}
 		}
 
 		if klusterlet := FindKlusterletByNamespace(klusterlets, namespace); klusterlet != nil {
-			return klusterlet.Name
+			return []string{klusterlet.Name}
 		}
 
-		return ""
+		return []string{}
 	}
 }
 
-func ClusterManagerDeploymentQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeyFunc {
-	return func(obj runtime.Object) string {
+func ClusterManagerDeploymentQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeysFunc {
+	return func(obj runtime.Object) []string {
 		accessor, _ := meta.Accessor(obj)
 		name := accessor.GetName()
 		namespace := accessor.GetNamespace()
@@ -116,47 +116,47 @@ func ClusterManagerDeploymentQueueKeyFunc(clusterManagerLister operatorlister.Cl
 			interestedObjectFound = true
 		}
 		if !interestedObjectFound {
-			return ""
+			return []string{}
 		}
 
 		clustermanagers, err := clusterManagerLister.List(labels.Everything())
 		if err != nil {
-			return ""
+			return []string{}
 		}
 
 		clustermanager, err := FindClusterManagerByNamespace(namespace, clustermanagers)
 		if err != nil {
-			return ""
+			return []string{}
 		}
 
-		return clustermanager.Name
+		return []string{clustermanager.Name}
 	}
 }
 
-func ClusterManagerQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeyFunc {
+func ClusterManagerQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeysFunc {
 	return clusterManagerByNamespaceQueueKeyFunc(clusterManagerLister)
 }
 
-func ClusterManagerConfigmapQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeyFunc {
+func ClusterManagerConfigmapQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeysFunc {
 	return clusterManagerByNamespaceQueueKeyFunc(clusterManagerLister)
 }
 
-func clusterManagerByNamespaceQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeyFunc {
-	return func(obj runtime.Object) string {
+func clusterManagerByNamespaceQueueKeyFunc(clusterManagerLister operatorlister.ClusterManagerLister) factory.ObjectQueueKeysFunc {
+	return func(obj runtime.Object) []string {
 		accessor, _ := meta.Accessor(obj)
 		namespace := accessor.GetNamespace()
 
 		clustermanagers, err := clusterManagerLister.List(labels.Everything())
 		if err != nil {
-			return ""
+			return []string{}
 		}
 
 		clustermanager, err := FindClusterManagerByNamespace(namespace, clustermanagers)
 		if err != nil {
-			return ""
+			return []string{}
 		}
 
-		return clustermanager.Name
+		return []string{clustermanager.Name}
 	}
 }
 

--- a/pkg/operator/helpers/queuekey_test.go
+++ b/pkg/operator/helpers/queuekey_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -57,31 +58,31 @@ func TestKlusterletSecretQueueKeyFunc(t *testing.T) {
 		name        string
 		object      runtime.Object
 		klusterlet  *operatorapiv1.Klusterlet
-		expectedKey string
+		expectedKey []string
 	}{
 		{
 			name:        "key by hub config secret",
 			object:      newSecret(HubKubeConfig, "test"),
 			klusterlet:  newKlusterlet("testklusterlet", "test", ""),
-			expectedKey: "testklusterlet",
+			expectedKey: []string{"testklusterlet"},
 		},
 		{
 			name:        "key by bootstrap secret",
 			object:      newSecret(BootstrapHubKubeConfig, "test"),
 			klusterlet:  newKlusterlet("testklusterlet", "test", ""),
-			expectedKey: "testklusterlet",
+			expectedKey: []string{"testklusterlet"},
 		},
 		{
 			name:        "key by wrong secret",
 			object:      newSecret("dummy", "test"),
 			klusterlet:  newKlusterlet("testklusterlet", "test", ""),
-			expectedKey: "",
+			expectedKey: []string{},
 		},
 		{
 			name:        "key by klusterlet with empty namespace",
 			object:      newSecret(BootstrapHubKubeConfig, KlusterletDefaultNamespace),
 			klusterlet:  newKlusterlet("testklusterlet", "", ""),
-			expectedKey: "testklusterlet",
+			expectedKey: []string{"testklusterlet"},
 		},
 	}
 
@@ -95,8 +96,8 @@ func TestKlusterletSecretQueueKeyFunc(t *testing.T) {
 			}
 			keyFunc := KlusterletSecretQueueKeyFunc(operatorInformers.Operator().V1().Klusterlets().Lister())
 			actualKey := keyFunc(c.object)
-			if actualKey != c.expectedKey {
-				t.Errorf("Queued key is not correct: actual %s, expected %s", actualKey, c.expectedKey)
+			if reflect.DeepEqual(actualKey, c.expectedKey) {
+				t.Errorf("Queued key is not correct: actual %v, expected %v", actualKey, c.expectedKey)
 			}
 		})
 	}
@@ -107,31 +108,31 @@ func TestKlusterletDeploymentQueueKeyFunc(t *testing.T) {
 		name        string
 		object      runtime.Object
 		klusterlet  *operatorapiv1.Klusterlet
-		expectedKey string
+		expectedKey []string
 	}{
 		{
 			name:        "key by work agent",
 			object:      newDeployment("testklusterlet-work-agent", "test", 0),
 			klusterlet:  newKlusterlet("testklusterlet", "test", ""),
-			expectedKey: "testklusterlet",
+			expectedKey: []string{"testklusterlet"},
 		},
 		{
 			name:        "key by registrartion agent",
 			object:      newDeployment("testklusterlet-registration-agent", "test", 0),
 			klusterlet:  newKlusterlet("testklusterlet", "test", ""),
-			expectedKey: "testklusterlet",
+			expectedKey: []string{"testklusterlet"},
 		},
 		{
 			name:        "key by wrong deployment",
 			object:      newDeployment("dummy", "test", 0),
 			klusterlet:  newKlusterlet("testklusterlet", "test", ""),
-			expectedKey: "",
+			expectedKey: []string{},
 		},
 		{
 			name:        "key by klusterlet with empty namespace",
 			object:      newDeployment("testklusterlet-work-agent", KlusterletDefaultNamespace, 0),
 			klusterlet:  newKlusterlet("testklusterlet", "", ""),
-			expectedKey: "testklusterlet",
+			expectedKey: []string{"testklusterlet"},
 		},
 	}
 
@@ -145,8 +146,8 @@ func TestKlusterletDeploymentQueueKeyFunc(t *testing.T) {
 			}
 			keyFunc := KlusterletDeploymentQueueKeyFunc(operatorInformers.Operator().V1().Klusterlets().Lister())
 			actualKey := keyFunc(c.object)
-			if actualKey != c.expectedKey {
-				t.Errorf("Queued key is not correct: actual %s, expected %s", actualKey, c.expectedKey)
+			if reflect.DeepEqual(actualKey, c.expectedKey) {
+				t.Errorf("Queued key is not correct: actual %v, expected %v", actualKey, c.expectedKey)
 			}
 		})
 	}
@@ -157,49 +158,49 @@ func TestClusterManagerDeploymentQueueKeyFunc(t *testing.T) {
 		name           string
 		object         runtime.Object
 		clusterManager *operatorapiv1.ClusterManager
-		expectedKey    string
+		expectedKey    []string
 	}{
 		{
 			name:           "key by registrartion controller",
 			object:         newDeployment("testhub-registration-controller", ClusterManagerDefaultNamespace, 0),
 			clusterManager: newClusterManager("testhub", operatorapiv1.InstallModeDefault),
-			expectedKey:    "testhub",
+			expectedKey:    []string{"testhub"},
 		},
 		{
 			name:           "key by registrartion webhook",
 			object:         newDeployment("testhub-registration-webhook", ClusterManagerDefaultNamespace, 0),
 			clusterManager: newClusterManager("testhub", operatorapiv1.InstallModeDefault),
-			expectedKey:    "testhub",
+			expectedKey:    []string{"testhub"},
 		},
 		{
 			name:           "key by work webhook",
 			object:         newDeployment("testhub-work-webhook", ClusterManagerDefaultNamespace, 0),
 			clusterManager: newClusterManager("testhub", operatorapiv1.InstallModeDefault),
-			expectedKey:    "testhub",
+			expectedKey:    []string{"testhub"},
 		},
 		{
 			name:           "key by placement controller",
 			object:         newDeployment("testhub-placement-controller", ClusterManagerDefaultNamespace, 0),
 			clusterManager: newClusterManager("testhub", operatorapiv1.InstallModeDefault),
-			expectedKey:    "testhub",
+			expectedKey:    []string{"testhub"},
 		},
 		{
 			name:           "key by wrong deployment",
 			object:         newDeployment("dummy", "test", 0),
 			clusterManager: newClusterManager("testhub", operatorapiv1.InstallModeDefault),
-			expectedKey:    "",
+			expectedKey:    []string{},
 		},
 		{
 			name:           "key by registrartion controller in hosted mode, namespace not match",
 			object:         newDeployment("testhub-registration-controller", ClusterManagerDefaultNamespace, 0),
 			clusterManager: newClusterManager("testhub", operatorapiv1.InstallModeHosted),
-			expectedKey:    "",
+			expectedKey:    []string{},
 		},
 		{
 			name:           "key by registrartion controller in hosted mode, namespace match",
 			object:         newDeployment("testhub-registration-controller", "testhub", 0),
 			clusterManager: newClusterManager("testhub", operatorapiv1.InstallModeHosted),
-			expectedKey:    "testhub",
+			expectedKey:    []string{"testhub"},
 		},
 	}
 
@@ -213,8 +214,8 @@ func TestClusterManagerDeploymentQueueKeyFunc(t *testing.T) {
 			}
 			keyFunc := ClusterManagerDeploymentQueueKeyFunc(operatorInformers.Operator().V1().ClusterManagers().Lister())
 			actualKey := keyFunc(c.object)
-			if actualKey != c.expectedKey {
-				t.Errorf("Queued key is not correct: actual %s, expected %s; test name:%s", actualKey, c.expectedKey, c.name)
+			if reflect.DeepEqual(actualKey, c.expectedKey) {
+				t.Errorf("Queued key is not correct: actual %v, expected %v; test name:%s", actualKey, c.expectedKey, c.name)
 			}
 		})
 	}

--- a/pkg/operator/operators/clustermanager/controllers/certrotationcontroller/certrotation_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/certrotationcontroller/certrotation_controller.go
@@ -79,7 +79,7 @@ func NewCertRotationController(
 		ResyncEvery(ResyncInterval).
 		WithSync(c.sync).
 		WithInformersQueueKeysFunc(queue.QueueKeyByMetaName, clusterManagerInformer.Informer()).
-		WithInformersQueueKeyFunc(helpers.ClusterManagerQueueKeyFunc(c.clusterManagerLister),
+		WithInformersQueueKeysFunc(helpers.ClusterManagerQueueKeyFunc(c.clusterManagerLister),
 			configMapInformer.Informer(),
 			secretInformers[helpers.SignerSecret].Informer(),
 			secretInformers[helpers.RegistrationWebhookSecret].Informer(),

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -101,8 +101,8 @@ func NewClusterManagerController(
 
 	return factory.New().WithSync(controller.sync).
 		ResyncEvery(3*time.Minute).
-		WithInformersQueueKeyFunc(helpers.ClusterManagerDeploymentQueueKeyFunc(controller.clusterManagerLister), deploymentInformer.Informer()).
-		WithFilteredEventsInformersQueueKeyFunc(
+		WithInformersQueueKeysFunc(helpers.ClusterManagerDeploymentQueueKeyFunc(controller.clusterManagerLister), deploymentInformer.Informer()).
+		WithFilteredEventsInformersQueueKeysFunc(
 			helpers.ClusterManagerConfigmapQueueKeyFunc(controller.clusterManagerLister),
 			queue.FilterByNames(helpers.CaBundleConfigmap),
 			configMapInformer.Informer()).

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -103,7 +103,7 @@ func NewClusterManagerController(
 		ResyncEvery(3*time.Minute).
 		WithInformersQueueKeysFunc(helpers.ClusterManagerDeploymentQueueKeyFunc(controller.clusterManagerLister), deploymentInformer.Informer()).
 		WithFilteredEventsInformersQueueKeysFunc(
-			helpers.ClusterManagerConfigmapQueueKeyFunc(controller.clusterManagerLister),
+			helpers.ClusterManagerQueueKeyFunc(controller.clusterManagerLister),
 			queue.FilterByNames(helpers.CaBundleConfigmap),
 			configMapInformer.Informer()).
 		WithInformersQueueKeysFunc(queue.QueueKeyByMetaName, clusterManagerInformer.Informer()).

--- a/pkg/operator/operators/clustermanager/controllers/statuscontroller/clustermanager_status_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/statuscontroller/clustermanager_status_controller.go
@@ -50,7 +50,7 @@ func NewClusterManagerStatusController(
 	}
 
 	return factory.New().WithSync(controller.sync).
-		WithInformersQueueKeyFunc(
+		WithInformersQueueKeysFunc(
 			helpers.ClusterManagerDeploymentQueueKeyFunc(controller.clusterManagerLister), deploymentInformer.Informer()).
 		WithInformersQueueKeysFunc(queue.QueueKeyByMetaName, clusterManagerInformer.Informer()).
 		ToController("ClusterManagerStatusController", recorder)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
@@ -63,11 +63,11 @@ func NewKlusterletCleanupController(
 	}
 
 	return factory.New().WithSync(controller.sync).
-		WithInformersQueueKeyFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister),
+		WithInformersQueueKeysFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister),
 			secretInformers[helpers.HubKubeConfig].Informer(),
 			secretInformers[helpers.BootstrapHubKubeConfig].Informer(),
 			secretInformers[helpers.ExternalManagedKubeConfig].Informer()).
-		WithInformersQueueKeyFunc(helpers.KlusterletDeploymentQueueKeyFunc(controller.klusterletLister), deploymentInformer.Informer()).
+		WithInformersQueueKeysFunc(helpers.KlusterletDeploymentQueueKeyFunc(controller.klusterletLister), deploymentInformer.Informer()).
 		WithInformersQueueKeysFunc(queue.QueueKeyByMetaName, klusterletInformer.Informer()).
 		ToController("KlusterletCleanupController", recorder)
 }

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
@@ -111,6 +111,9 @@ func (n *klusterletCleanupController) sync(ctx context.Context, controllerContex
 		ExternalManagedKubeConfigWorkSecret:         helpers.ExternalManagedKubeConfigWork,
 		InstallMode:                                 klusterlet.Spec.DeployOption.Mode,
 		HubApiServerHostAlias:                       klusterlet.Spec.HubApiServerHostAlias,
+
+		RegistrationServiceAccount: serviceAccountName("registration-sa", klusterlet),
+		WorkServiceAccount:         serviceAccountName("work-sa", klusterlet),
 	}
 
 	reconcilers := []klusterletReconcile{

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -96,11 +96,11 @@ func NewKlusterletController(
 	}
 
 	return factory.New().WithSync(controller.sync).
-		WithInformersQueueKeyFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister),
+		WithInformersQueueKeysFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister),
 			secretInformers[helpers.HubKubeConfig].Informer(),
 			secretInformers[helpers.BootstrapHubKubeConfig].Informer(),
 			secretInformers[helpers.ExternalManagedKubeConfig].Informer()).
-		WithInformersQueueKeyFunc(helpers.KlusterletDeploymentQueueKeyFunc(controller.klusterletLister), deploymentInformer.Informer()).
+		WithInformersQueueKeysFunc(helpers.KlusterletDeploymentQueueKeyFunc(controller.klusterletLister), deploymentInformer.Informer()).
 		WithInformersQueueKeysFunc(queue.QueueKeyByMetaName, klusterletInformer.Informer()).
 		ToController("KlusterletController", recorder)
 }

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -167,6 +167,7 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 		RegistrationImage:         klusterlet.Spec.RegistrationImagePullSpec,
 		WorkImage:                 klusterlet.Spec.WorkImagePullSpec,
 		ClusterName:               klusterlet.Spec.ClusterName,
+		SingletonImage:            klusterlet.Spec.ImagePullSpec,
 		BootStrapKubeConfigSecret: helpers.BootstrapHubKubeConfig,
 		HubKubeConfigSecret:       helpers.HubKubeConfig,
 		ExternalServerURL:         getServersFromKlusterlet(klusterlet),
@@ -393,10 +394,10 @@ func ensureNamespace(ctx context.Context, kubeClient kubernetes.Interface, klust
 }
 
 func serviceAccountName(suffix string, klusterlet *operatorapiv1.Klusterlet) string {
-	// in single ton mode, we only need one sa, so the name of work and registration sa are
+	// in singleton mode, we only need one sa, so the name of work and registration sa are
 	// the same.
-	if klusterlet.Spec.DeployOption.Mode == "Singleton" {
-		return "klusterlet-agent-sa"
+	if klusterlet.Spec.DeployOption.Mode == operatorapiv1.InstallModeSingleton {
+		return fmt.Sprintf("%s-agent-sa", klusterlet.Name)
 	}
 	return fmt.Sprintf("%s-%s", klusterlet.Name, suffix)
 }

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -92,6 +92,7 @@ func newKlusterlet(name, namespace, clustername string) *operatorapiv1.Klusterle
 		Spec: operatorapiv1.KlusterletSpec{
 			RegistrationImagePullSpec: "testregistration",
 			WorkImagePullSpec:         "testwork",
+			ImagePullSpec:             "testagent",
 			ClusterName:               clustername,
 			Namespace:                 namespace,
 			ExternalServerURLs:        []operatorapiv1.ServerURL{},
@@ -447,8 +448,16 @@ func ensureObject(t *testing.T, object runtime.Object, klusterlet *operatorapiv1
 				t.Errorf("Image does not match to the expected.")
 				return
 			}
+		} else if strings.Contains(access.GetName(), "agent") {
+			testingcommon.AssertEqualNameNamespace(
+				t, access.GetName(), access.GetNamespace(),
+				fmt.Sprintf("%s-agent", klusterlet.Name), namespace)
+			if klusterlet.Spec.ImagePullSpec != o.Spec.Template.Spec.Containers[0].Image {
+				t.Errorf("Image does not match to the expected.")
+				return
+			}
 		} else {
-			t.Errorf("Unexpected deployment")
+			t.Errorf("unexpected deployment")
 			return
 		}
 	}
@@ -483,6 +492,67 @@ func TestSyncDeploy(t *testing.T) {
 	// 11 managed static manifests + 11 management static manifests - 2 duplicated service account manifests + 1 addon namespace + 2 deployments
 	if len(createObjects) != 23 {
 		t.Errorf("Expect 23 objects created in the sync loop, actual %d", len(createObjects))
+	}
+	for _, object := range createObjects {
+		ensureObject(t, object, klusterlet)
+	}
+
+	apiExtenstionAction := controller.apiExtensionClient.Actions()
+	createCRDObjects := []runtime.Object{}
+	for _, action := range apiExtenstionAction {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "customresourcedefinitions" {
+			object := action.(clienttesting.CreateActionImpl).Object
+			createCRDObjects = append(createCRDObjects, object)
+		}
+	}
+	if len(createCRDObjects) != 2 {
+		t.Errorf("Expect 2 objects created in the sync loop, actual %d", len(createCRDObjects))
+	}
+
+	operatorAction := controller.operatorClient.Actions()
+	testingcommon.AssertActions(t, operatorAction, "patch")
+	klusterlet = &operatorapiv1.Klusterlet{}
+	patchData := operatorAction[0].(clienttesting.PatchActionImpl).Patch
+	err = json.Unmarshal(patchData, klusterlet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testinghelper.AssertOnlyConditions(
+		t, klusterlet,
+		testinghelper.NamedCondition(klusterletApplied, "KlusterletApplied", metav1.ConditionTrue),
+		testinghelper.NamedCondition(helpers.FeatureGatesTypeValid, helpers.FeatureGatesReasonAllValid, metav1.ConditionTrue),
+	)
+}
+
+func TestSyncDeploySingleton(t *testing.T) {
+	klusterlet := newKlusterlet("klusterlet", "testns", "cluster1")
+	klusterlet.Spec.DeployOption.Mode = operatorapiv1.InstallModeSingleton
+	bootStrapSecret := newSecret(helpers.BootstrapHubKubeConfig, "testns")
+	hubKubeConfigSecret := newSecret(helpers.HubKubeConfig, "testns")
+	hubKubeConfigSecret.Data["kubeconfig"] = []byte("dummuykubeconnfig")
+	namespace := newNamespace("testns")
+	controller := newTestController(t, klusterlet, nil, bootStrapSecret, hubKubeConfigSecret, namespace)
+	syncContext := testingcommon.NewFakeSyncContext(t, "klusterlet")
+
+	err := controller.controller.sync(context.TODO(), syncContext)
+	if err != nil {
+		t.Errorf("Expected non error when sync, %v", err)
+	}
+
+	createObjects := []runtime.Object{}
+	kubeActions := controller.kubeClient.Actions()
+	for _, action := range kubeActions {
+		if action.GetVerb() == "create" {
+			object := action.(clienttesting.CreateActionImpl).Object
+			createObjects = append(createObjects, object)
+
+		}
+	}
+
+	// Check if resources are created as expected
+	// 10 managed static manifests + 10 management static manifests - 1 service account manifests + 1 addon namespace + 1 deployments
+	if len(createObjects) != 21 {
+		t.Errorf("Expect 21 objects created in the sync loop, actual %d", len(createObjects))
 	}
 	for _, object := range createObjects {
 		ensureObject(t, object, klusterlet)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -206,8 +206,8 @@ func newTestControllerHosted(t *testing.T, klusterlet *operatorapiv1.Klusterlet,
 	kubeVersion, _ := version.ParseGeneric("v1.18.0")
 
 	klusterletNamespace := helpers.KlusterletNamespace(klusterlet)
-	saRegistrationSecret := newServiceAccountSecret(fmt.Sprintf("%s-token", registrationServiceAccountName(klusterlet.Name)), klusterlet.Name)
-	saWorkSecret := newServiceAccountSecret(fmt.Sprintf("%s-token", workServiceAccountName(klusterlet.Name)), klusterlet.Name)
+	saRegistrationSecret := newServiceAccountSecret(fmt.Sprintf("%s-token", serviceAccountName("registration-sa", klusterlet)), klusterlet.Name)
+	saWorkSecret := newServiceAccountSecret(fmt.Sprintf("%s-token", serviceAccountName("work-sa", klusterlet)), klusterlet.Name)
 	fakeManagedKubeClient := fakekube.NewSimpleClientset()
 	getRegistrationServiceAccountCount := 0
 	getWorkServiceAccountCount := 0
@@ -218,7 +218,7 @@ func newTestControllerHosted(t *testing.T, klusterlet *operatorapiv1.Klusterlet,
 	fakeManagedKubeClient.PrependReactor("get", "serviceaccounts", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
 		name := action.(clienttesting.GetAction).GetName()
 		namespace := action.(clienttesting.GetAction).GetNamespace()
-		if namespace == klusterletNamespace && name == registrationServiceAccountName(klusterlet.Name) {
+		if namespace == klusterletNamespace && name == serviceAccountName("registration-sa", klusterlet) {
 			getRegistrationServiceAccountCount++
 			if getRegistrationServiceAccountCount > 1 {
 				sa := newServiceAccount(name, klusterletNamespace, saRegistrationSecret.Name)
@@ -227,7 +227,7 @@ func newTestControllerHosted(t *testing.T, klusterlet *operatorapiv1.Klusterlet,
 			}
 		}
 
-		if namespace == klusterletNamespace && name == workServiceAccountName(klusterlet.Name) {
+		if namespace == klusterletNamespace && name == serviceAccountName("work-sa", klusterlet) {
 			getWorkServiceAccountCount++
 			if getWorkServiceAccountCount > 1 {
 				sa := newServiceAccount(name, klusterletNamespace, saWorkSecret.Name)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_runtime_reconcile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_runtime_reconcile.go
@@ -33,7 +33,7 @@ type runtimeReconcile struct {
 
 func (r *runtimeReconcile) reconcile(ctx context.Context, klusterlet *operatorapiv1.Klusterlet,
 	config klusterletConfig) (*operatorapiv1.Klusterlet, reconcileState, error) {
-	if config.InstallMode == "Singleton" {
+	if config.InstallMode == operatorapiv1.InstallModeSingleton {
 		return r.installSingletonAgent(ctx, klusterlet, config)
 	}
 
@@ -132,7 +132,7 @@ func (r *runtimeReconcile) reconcile(ctx context.Context, klusterlet *operatorap
 
 func (r *runtimeReconcile) installSingletonAgent(ctx context.Context, klusterlet *operatorapiv1.Klusterlet,
 	config klusterletConfig) (*operatorapiv1.Klusterlet, reconcileState, error) {
-	// Deploy registration agent
+	// Deploy singleton agent
 	_, generationStatus, err := helpers.ApplyDeployment(
 		ctx,
 		r.kubeClient,
@@ -203,7 +203,7 @@ func (r *runtimeReconcile) clean(ctx context.Context, klusterlet *operatorapiv1.
 		fmt.Sprintf("%s-registration-agent", config.KlusterletName),
 		fmt.Sprintf("%s-work-agent", config.KlusterletName),
 	}
-	if klusterlet.Spec.DeployOption.Mode == "Singleton" {
+	if klusterlet.Spec.DeployOption.Mode == operatorapiv1.InstallModeSingleton {
 		deployments = []string{fmt.Sprintf("%s-agent", config.KlusterletName)}
 	}
 	for _, deployment := range deployments {

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_runtime_reconcile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_runtime_reconcile.go
@@ -33,15 +33,19 @@ type runtimeReconcile struct {
 
 func (r *runtimeReconcile) reconcile(ctx context.Context, klusterlet *operatorapiv1.Klusterlet,
 	config klusterletConfig) (*operatorapiv1.Klusterlet, reconcileState, error) {
+	if config.InstallMode == "Singleton" {
+		return r.installSingletonAgent(ctx, klusterlet, config)
+	}
+
 	if config.InstallMode == operatorapiv1.InstallModeHosted {
 		// Create managed config secret for registration and work.
 		if err := r.createManagedClusterKubeconfig(ctx, klusterlet, config.KlusterletNamespace, config.AgentNamespace,
-			registrationServiceAccountName(klusterlet.Name), config.ExternalManagedKubeConfigRegistrationSecret,
+			config.RegistrationServiceAccount, config.ExternalManagedKubeConfigRegistrationSecret,
 			r.recorder); err != nil {
 			return klusterlet, reconcileStop, err
 		}
 		if err := r.createManagedClusterKubeconfig(ctx, klusterlet, config.KlusterletNamespace, config.AgentNamespace,
-			workServiceAccountName(klusterlet.Name), config.ExternalManagedKubeConfigWorkSecret,
+			config.WorkServiceAccount, config.ExternalManagedKubeConfigWorkSecret,
 			r.recorder); err != nil {
 			return klusterlet, reconcileStop, err
 		}
@@ -126,6 +130,35 @@ func (r *runtimeReconcile) reconcile(ctx context.Context, klusterlet *operatorap
 	return klusterlet, reconcileContinue, nil
 }
 
+func (r *runtimeReconcile) installSingletonAgent(ctx context.Context, klusterlet *operatorapiv1.Klusterlet,
+	config klusterletConfig) (*operatorapiv1.Klusterlet, reconcileState, error) {
+	// Deploy registration agent
+	_, generationStatus, err := helpers.ApplyDeployment(
+		ctx,
+		r.kubeClient,
+		klusterlet.Status.Generations,
+		klusterlet.Spec.NodePlacement,
+		func(name string) ([]byte, error) {
+			template, err := manifests.KlusterletManifestFiles.ReadFile(name)
+			if err != nil {
+				return nil, err
+			}
+			objData := assets.MustCreateAssetFromTemplate(name, template, config).Data
+			helpers.SetRelatedResourcesStatusesWithObj(&klusterlet.Status.RelatedResources, objData)
+			return objData, nil
+		},
+		r.recorder,
+		"klusterlet/management/klusterlet-agent-deployment.yaml")
+
+	if err != nil {
+		// TODO update condition
+		return klusterlet, reconcileStop, err
+	}
+
+	helpers.SetGenerationStatuses(&klusterlet.Status.Generations, generationStatus)
+	return klusterlet, reconcileContinue, nil
+}
+
 func (r *runtimeReconcile) createManagedClusterKubeconfig(
 	ctx context.Context,
 	klusterlet *operatorapiv1.Klusterlet,
@@ -170,6 +203,9 @@ func (r *runtimeReconcile) clean(ctx context.Context, klusterlet *operatorapiv1.
 		fmt.Sprintf("%s-registration-agent", config.KlusterletName),
 		fmt.Sprintf("%s-work-agent", config.KlusterletName),
 	}
+	if klusterlet.Spec.DeployOption.Mode == "Singleton" {
+		deployments = []string{fmt.Sprintf("%s-agent", config.KlusterletName)}
+	}
 	for _, deployment := range deployments {
 		err := r.kubeClient.AppsV1().Deployments(config.AgentNamespace).Delete(ctx, deployment, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
@@ -179,14 +215,4 @@ func (r *runtimeReconcile) clean(ctx context.Context, klusterlet *operatorapiv1.
 	}
 
 	return klusterlet, reconcileContinue, nil
-}
-
-// registrationServiceAccountName splices the name of registration service account
-func registrationServiceAccountName(klusterletName string) string {
-	return fmt.Sprintf("%s-registration-sa", klusterletName)
-}
-
-// workServiceAccountName splices the name of work service account
-func workServiceAccountName(klusterletName string) string {
-	return fmt.Sprintf("%s-work-sa", klusterletName)
 }

--- a/pkg/operator/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller.go
@@ -66,7 +66,7 @@ func NewKlusterletSSARController(
 	}
 
 	return factory.New().WithSync(controller.sync).
-		WithInformersQueueKeyFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister),
+		WithInformersQueueKeysFunc(helpers.KlusterletSecretQueueKeyFunc(controller.klusterletLister),
 			secretInformers[helpers.HubKubeConfig].Informer(),
 			secretInformers[helpers.BootstrapHubKubeConfig].Informer(),
 			secretInformers[helpers.ExternalManagedKubeConfig].Informer()).

--- a/pkg/operator/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller.go
@@ -247,7 +247,7 @@ func checkBootstrapSecret(ctx context.Context, kubeClient kubernetes.Interface, 
 }
 
 func getBootstrapSSARs() []authorizationv1.SelfSubjectAccessReview {
-	reviews := []authorizationv1.SelfSubjectAccessReview{}
+	var reviews []authorizationv1.SelfSubjectAccessReview
 	clusterResource := authorizationv1.ResourceAttributes{
 		Group:    "cluster.open-cluster-management.io",
 		Resource: "managedclusters",
@@ -335,7 +335,7 @@ func checkHubConfigSecret(ctx context.Context, kubeClient kubernetes.Interface, 
 }
 
 func getHubConfigSSARs(clusterName string) []authorizationv1.SelfSubjectAccessReview {
-	reviews := []authorizationv1.SelfSubjectAccessReview{}
+	var reviews []authorizationv1.SelfSubjectAccessReview
 
 	// registration resources
 	certResource := authorizationv1.ResourceAttributes{
@@ -435,7 +435,7 @@ func buildKubeClientWithSecret(secret *corev1.Secret) (kubernetes.Interface, str
 }
 
 func generateSelfSubjectAccessReviews(resource authorizationv1.ResourceAttributes, verbs ...string) []authorizationv1.SelfSubjectAccessReview {
-	reviews := []authorizationv1.SelfSubjectAccessReview{}
+	var reviews []authorizationv1.SelfSubjectAccessReview
 	for _, verb := range verbs {
 		reviews = append(reviews, authorizationv1.SelfSubjectAccessReview{
 			Spec: authorizationv1.SelfSubjectAccessReviewSpec{

--- a/pkg/operator/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller.go
@@ -85,6 +85,11 @@ func (k *klusterletStatusController) sync(ctx context.Context, controllerContext
 	registrationDeploymentName := fmt.Sprintf("%s-registration-agent", klusterlet.Name)
 	workDeploymentName := fmt.Sprintf("%s-work-agent", klusterlet.Name)
 
+	if klusterlet.Spec.DeployOption.Mode == operatorapiv1.InstallModeSingleton {
+		registrationDeploymentName = fmt.Sprintf("%s-agent", klusterlet.Name)
+		workDeploymentName = registrationDeploymentName
+	}
+
 	availableCondition := checkAgentsDeploymentAvailable(
 		ctx, k.kubeClient,
 		[]klusterletAgent{

--- a/pkg/operator/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller.go
@@ -54,7 +54,7 @@ func NewKlusterletStatusController(
 		klusterletLister: klusterletInformer.Lister(),
 	}
 	return factory.New().WithSync(controller.sync).
-		WithInformersQueueKeyFunc(helpers.KlusterletDeploymentQueueKeyFunc(controller.klusterletLister), deploymentInformer.Informer()).
+		WithInformersQueueKeysFunc(helpers.KlusterletDeploymentQueueKeyFunc(controller.klusterletLister), deploymentInformer.Informer()).
 		WithInformersQueueKeysFunc(queue.QueueKeyByMetaName, klusterletInformer.Informer()).
 		ToController("KlusterletStatusController", recorder)
 }

--- a/pkg/operator/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/statuscontroller/klusterlet_status_controller_test.go
@@ -165,6 +165,22 @@ func TestSync(t *testing.T) {
 				testinghelper.NamedCondition(klusterletWorkDesiredDegraded, "DeploymentsFunctional", metav1.ConditionFalse),
 			},
 		},
+		{
+			name: "Available & Desired with singleton",
+			object: []runtime.Object{
+				newDeployment("testklusterlet-agent", "test", 3, 3),
+			},
+			klusterlet: func() *operatorapiv1.Klusterlet {
+				k := newKlusterlet("testklusterlet", "test", "cluster1")
+				k.Spec.DeployOption.Mode = operatorapiv1.InstallModeSingleton
+				return k
+			}(),
+			expectedConditions: []metav1.Condition{
+				testinghelper.NamedCondition(klusterletAvailable, "klusterletAvailable", metav1.ConditionTrue),
+				testinghelper.NamedCondition(klusterletRegistrationDesiredDegraded, "DeploymentsFunctional", metav1.ConditionFalse),
+				testinghelper.NamedCondition(klusterletWorkDesiredDegraded, "DeploymentsFunctional", metav1.ConditionFalse),
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/registration/clientcert/certificate.go
+++ b/pkg/registration/clientcert/certificate.go
@@ -259,7 +259,7 @@ func (v *v1CSRControl) get(name string) (metav1.Object, error) {
 }
 
 func NewCSRControl(hubCSRInformer certificatesinformers.Interface, hubKubeClient kubernetes.Interface) (CSRControl, error) {
-	if features.DefaultSpokeRegistrationMutableFeatureGate.Enabled(ocmfeature.V1beta1CSRAPICompatibility) {
+	if features.SpokeMutableFeatureGate.Enabled(ocmfeature.V1beta1CSRAPICompatibility) {
 		v1CSRSupported, v1beta1CSRSupported, err := helpers.IsCSRSupported(hubKubeClient)
 		if err != nil {
 			return nil, err

--- a/pkg/registration/spoke/managedcluster/claim_reconcile.go
+++ b/pkg/registration/spoke/managedcluster/claim_reconcile.go
@@ -28,7 +28,7 @@ type claimReconcile struct {
 }
 
 func (r *claimReconcile) reconcile(ctx context.Context, cluster *clusterv1.ManagedCluster) (*clusterv1.ManagedCluster, reconcileState, error) {
-	if !features.DefaultSpokeRegistrationMutableFeatureGate.Enabled(ocmfeature.ClusterClaim) {
+	if !features.SpokeMutableFeatureGate.Enabled(ocmfeature.ClusterClaim) {
 		return cluster, reconcileContinue, nil
 	}
 	// current managed cluster has not joined the hub yet, do nothing.

--- a/pkg/registration/spoke/managedcluster/claim_reconcile_test.go
+++ b/pkg/registration/spoke/managedcluster/claim_reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -18,12 +19,15 @@ import (
 	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	ocmfeature "open-cluster-management.io/api/feature"
 
 	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
+	"open-cluster-management.io/ocm/pkg/features"
 	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
 )
 
 func TestSync(t *testing.T) {
+	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates))
 	cases := []struct {
 		name            string
 		cluster         runtime.Object

--- a/pkg/registration/spoke/options.go
+++ b/pkg/registration/spoke/options.go
@@ -1,0 +1,72 @@
+package spoke
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"open-cluster-management.io/ocm/pkg/features"
+	"open-cluster-management.io/ocm/pkg/registration/helpers"
+	"time"
+)
+
+// SpokeAgentOptions holds configuration for spoke cluster agent
+type SpokeAgentOptions struct {
+	BootstrapKubeconfig         string
+	HubKubeconfigSecret         string
+	SpokeExternalServerURLs     []string
+	ClusterHealthCheckPeriod    time.Duration
+	MaxCustomClusterClaims      int
+	ClientCertExpirationSeconds int32
+}
+
+func NewSpokeAgentOptions() *SpokeAgentOptions {
+	return &SpokeAgentOptions{
+		HubKubeconfigSecret:      "hub-kubeconfig-secret",
+		ClusterHealthCheckPeriod: 1 * time.Minute,
+		MaxCustomClusterClaims:   20,
+	}
+}
+
+// AddFlags registers flags for Agent
+func (o *SpokeAgentOptions) AddFlags(fs *pflag.FlagSet) {
+	features.DefaultSpokeRegistrationMutableFeatureGate.AddFlag(fs)
+	fs.StringVar(&o.BootstrapKubeconfig, "bootstrap-kubeconfig", o.BootstrapKubeconfig,
+		"The path of the kubeconfig file for agent bootstrap.")
+	fs.StringVar(&o.HubKubeconfigSecret, "hub-kubeconfig-secret", o.HubKubeconfigSecret,
+		"The name of secret in component namespace storing kubeconfig for hub.")
+	fs.StringArrayVar(&o.SpokeExternalServerURLs, "spoke-external-server-urls", o.SpokeExternalServerURLs,
+		"A list of reachable spoke cluster api server URLs for hub cluster.")
+	fs.DurationVar(&o.ClusterHealthCheckPeriod, "cluster-healthcheck-period", o.ClusterHealthCheckPeriod,
+		"The period to check managed cluster kube-apiserver health")
+	fs.IntVar(&o.MaxCustomClusterClaims, "max-custom-cluster-claims", o.MaxCustomClusterClaims,
+		"The max number of custom cluster claims to expose.")
+	fs.Int32Var(&o.ClientCertExpirationSeconds, "client-cert-expiration-seconds", o.ClientCertExpirationSeconds,
+		"The requested duration in seconds of validity of the issued client certificate. If this is not set, "+
+			"the value of --cluster-signing-duration command-line flag of the kube-controller-manager will be used.")
+}
+
+// Validate verifies the inputs.
+func (o *SpokeAgentOptions) Validate() error {
+	if o.BootstrapKubeconfig == "" {
+		return errors.New("bootstrap-kubeconfig is required")
+	}
+
+	// if SpokeExternalServerURLs is specified we validate every URL in it, we expect the spoke external server URL is https
+	if len(o.SpokeExternalServerURLs) != 0 {
+		for _, serverURL := range o.SpokeExternalServerURLs {
+			if !helpers.IsValidHTTPSURL(serverURL) {
+				return fmt.Errorf("%q is invalid", serverURL)
+			}
+		}
+	}
+
+	if o.ClusterHealthCheckPeriod <= 0 {
+		return errors.New("cluster healthcheck period must greater than zero")
+	}
+
+	if o.ClientCertExpirationSeconds != 0 && o.ClientCertExpirationSeconds < 3600 {
+		return errors.New("client certificate expiration seconds must greater or qual to 3600")
+	}
+
+	return nil
+}

--- a/pkg/registration/spoke/options.go
+++ b/pkg/registration/spoke/options.go
@@ -2,11 +2,12 @@ package spoke
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-	"open-cluster-management.io/ocm/pkg/features"
+
 	"open-cluster-management.io/ocm/pkg/registration/helpers"
-	"time"
 )
 
 // SpokeAgentOptions holds configuration for spoke cluster agent
@@ -29,7 +30,6 @@ func NewSpokeAgentOptions() *SpokeAgentOptions {
 
 // AddFlags registers flags for Agent
 func (o *SpokeAgentOptions) AddFlags(fs *pflag.FlagSet) {
-	features.DefaultSpokeRegistrationMutableFeatureGate.AddFlag(fs)
 	fs.StringVar(&o.BootstrapKubeconfig, "bootstrap-kubeconfig", o.BootstrapKubeconfig,
 		"The path of the kubeconfig file for agent bootstrap.")
 	fs.StringVar(&o.HubKubeconfigSecret, "hub-kubeconfig-secret", o.HubKubeconfigSecret,

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -352,7 +352,7 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 
 	var addOnLeaseController factory.Controller
 	var addOnRegistrationController factory.Controller
-	if features.DefaultSpokeRegistrationMutableFeatureGate.Enabled(ocmfeature.AddonManagement) {
+	if features.SpokeMutableFeatureGate.Enabled(ocmfeature.AddonManagement) {
 		addOnLeaseController = addon.NewManagedClusterAddOnLeaseController(
 			o.agentOptions.SpokeClusterName,
 			addOnClient,
@@ -383,14 +383,14 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 	go addOnInformerFactory.Start(ctx.Done())
 
 	go spokeKubeInformerFactory.Start(ctx.Done())
-	if features.DefaultSpokeRegistrationMutableFeatureGate.Enabled(ocmfeature.ClusterClaim) {
+	if features.SpokeMutableFeatureGate.Enabled(ocmfeature.ClusterClaim) {
 		go spokeClusterInformerFactory.Start(ctx.Done())
 	}
 
 	go clientCertForHubController.Run(ctx, 1)
 	go managedClusterLeaseController.Run(ctx, 1)
 	go managedClusterHealthCheckController.Run(ctx, 1)
-	if features.DefaultSpokeRegistrationMutableFeatureGate.Enabled(ocmfeature.AddonManagement) {
+	if features.SpokeMutableFeatureGate.Enabled(ocmfeature.AddonManagement) {
 		go addOnLeaseController.Run(ctx, 1)
 		go addOnRegistrationController.Run(ctx, 1)
 	}

--- a/pkg/singleton/spoke/agent.go
+++ b/pkg/singleton/spoke/agent.go
@@ -1,0 +1,55 @@
+package spoke
+
+import (
+	"context"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	registration "open-cluster-management.io/ocm/pkg/registration/spoke"
+	work "open-cluster-management.io/ocm/pkg/work/spoke"
+	"time"
+)
+
+type AgentConfig struct {
+	agentOption        *commonoptions.AgentOptions
+	registrationOption *registration.SpokeAgentOptions
+	workOption         *work.WorkloadAgentOptions
+}
+
+func NewAgentConfig(
+	agentOption *commonoptions.AgentOptions,
+	registrationOption *registration.SpokeAgentOptions,
+	workOption *work.WorkloadAgentOptions) *AgentConfig {
+	return &AgentConfig{
+		agentOption:        agentOption,
+		registrationOption: registrationOption,
+		workOption:         workOption,
+	}
+}
+
+func (a *AgentConfig) RunSpokeAgent(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+	registrationCfg := registration.NewSpokeAgentConfig(a.agentOption, a.registrationOption)
+	// start registration agent at first
+	go func() {
+		if err := registrationCfg.RunSpokeAgent(ctx, controllerContext); err != nil {
+			klog.Fatal(err)
+		}
+	}()
+
+	// wait for the hub client config ready.
+	klog.Info("Waiting for hub client config and managed cluster to be ready")
+	if err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, registrationCfg.HasValidHubClientConfig); err != nil {
+		return err
+	}
+
+	workCfg := work.NewWorkAgentConfig(a.agentOption, a.workOption)
+	// start work agent at first
+	go func() {
+		if err := workCfg.RunWorkloadAgent(ctx, controllerContext); err != nil {
+			klog.Fatal(err)
+		}
+	}()
+
+	return nil
+}

--- a/pkg/singleton/spoke/agent.go
+++ b/pkg/singleton/spoke/agent.go
@@ -53,5 +53,6 @@ func (a *AgentConfig) RunSpokeAgent(ctx context.Context, controllerContext *cont
 		}
 	}()
 
+	<-ctx.Done()
 	return nil
 }

--- a/pkg/singleton/spoke/agent.go
+++ b/pkg/singleton/spoke/agent.go
@@ -2,13 +2,15 @@ package spoke
 
 import (
 	"context"
+	"time"
+
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+
 	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 	registration "open-cluster-management.io/ocm/pkg/registration/spoke"
 	work "open-cluster-management.io/ocm/pkg/work/spoke"
-	"time"
 )
 
 type AgentConfig struct {

--- a/pkg/singleton/spoke/agent.go
+++ b/pkg/singleton/spoke/agent.go
@@ -46,7 +46,7 @@ func (a *AgentConfig) RunSpokeAgent(ctx context.Context, controllerContext *cont
 	}
 
 	workCfg := work.NewWorkAgentConfig(a.agentOption, a.workOption)
-	// start work agent at first
+	// start work agent
 	go func() {
 		if err := workCfg.RunWorkloadAgent(ctx, controllerContext); err != nil {
 			klog.Fatal(err)

--- a/pkg/work/spoke/controllers/statuscontroller/availablestatus_controller_test.go
+++ b/pkg/work/spoke/controllers/statuscontroller/availablestatus_controller_test.go
@@ -9,15 +9,18 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/utils/pointer"
 
 	fakeworkclient "open-cluster-management.io/api/client/work/clientset/versioned/fake"
+	ocmfeature "open-cluster-management.io/api/feature"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 
 	"open-cluster-management.io/ocm/pkg/common/patcher"
 	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
+	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/work/spoke/controllers"
 	"open-cluster-management.io/ocm/pkg/work/spoke/spoketesting"
 	"open-cluster-management.io/ocm/pkg/work/spoke/statusfeedback"
@@ -218,6 +221,7 @@ func TestSyncManifestWork(t *testing.T) {
 }
 
 func TestStatusFeedback(t *testing.T) {
+	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
 	cases := []struct {
 		name              string
 		existingResources []runtime.Object

--- a/pkg/work/spoke/options.go
+++ b/pkg/work/spoke/options.go
@@ -1,15 +1,13 @@
 package spoke
 
 import (
-	"github.com/spf13/pflag"
-	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
-	"open-cluster-management.io/ocm/pkg/features"
 	"time"
+
+	"github.com/spf13/pflag"
 )
 
 // WorkloadAgentOptions defines the flags for workload agent
 type WorkloadAgentOptions struct {
-	AgentOptions                           *commonoptions.AgentOptions
 	StatusSyncInterval                     time.Duration
 	AppliedManifestWorkEvictionGracePeriod time.Duration
 }
@@ -24,7 +22,6 @@ func NewWorkloadAgentOptions() *WorkloadAgentOptions {
 
 // AddFlags register and binds the default flags
 func (o *WorkloadAgentOptions) AddFlags(fs *pflag.FlagSet) {
-	features.DefaultSpokeWorkMutableFeatureGate.AddFlag(fs)
 	fs.DurationVar(&o.StatusSyncInterval, "status-sync-interval", o.StatusSyncInterval, "Interval to sync resource status to hub.")
 	fs.DurationVar(&o.AppliedManifestWorkEvictionGracePeriod, "appliedmanifestwork-eviction-grace-period",
 		o.AppliedManifestWorkEvictionGracePeriod, "Grace period for appliedmanifestwork eviction")

--- a/pkg/work/spoke/options.go
+++ b/pkg/work/spoke/options.go
@@ -1,0 +1,31 @@
+package spoke
+
+import (
+	"github.com/spf13/pflag"
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	"open-cluster-management.io/ocm/pkg/features"
+	"time"
+)
+
+// WorkloadAgentOptions defines the flags for workload agent
+type WorkloadAgentOptions struct {
+	AgentOptions                           *commonoptions.AgentOptions
+	StatusSyncInterval                     time.Duration
+	AppliedManifestWorkEvictionGracePeriod time.Duration
+}
+
+// NewWorkloadAgentOptions returns the flags with default value set
+func NewWorkloadAgentOptions() *WorkloadAgentOptions {
+	return &WorkloadAgentOptions{
+		StatusSyncInterval:                     10 * time.Second,
+		AppliedManifestWorkEvictionGracePeriod: 60 * time.Minute,
+	}
+}
+
+// AddFlags register and binds the default flags
+func (o *WorkloadAgentOptions) AddFlags(fs *pflag.FlagSet) {
+	features.DefaultSpokeWorkMutableFeatureGate.AddFlag(fs)
+	fs.DurationVar(&o.StatusSyncInterval, "status-sync-interval", o.StatusSyncInterval, "Interval to sync resource status to hub.")
+	fs.DurationVar(&o.AppliedManifestWorkEvictionGracePeriod, "appliedmanifestwork-eviction-grace-period",
+		o.AppliedManifestWorkEvictionGracePeriod, "Grace period for appliedmanifestwork eviction")
+}

--- a/pkg/work/spoke/spokeagent.go
+++ b/pkg/work/spoke/spokeagent.go
@@ -2,7 +2,6 @@ package spoke
 
 import (
 	"context"
-	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -17,6 +16,7 @@ import (
 	workinformers "open-cluster-management.io/api/client/work/informers/externalversions"
 	ocmfeature "open-cluster-management.io/api/feature"
 
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/work/helper"
 	"open-cluster-management.io/ocm/pkg/work/spoke/auth"
@@ -114,7 +114,7 @@ func (o *WorkAgentConfig) RunWorkloadAgent(ctx context.Context, controllerContex
 		o.agentOptions.SpokeClusterName,
 		controllerContext.EventRecorder,
 		restMapper,
-	).NewExecutorValidator(ctx, features.DefaultSpokeWorkMutableFeatureGate.Enabled(ocmfeature.ExecutorValidatingCaches))
+	).NewExecutorValidator(ctx, features.SpokeMutableFeatureGate.Enabled(ocmfeature.ExecutorValidatingCaches))
 
 	manifestWorkController := manifestcontroller.NewManifestWorkController(
 		controllerContext.EventRecorder,

--- a/pkg/work/spoke/statusfeedback/reader.go
+++ b/pkg/work/spoke/statusfeedback/reader.go
@@ -142,7 +142,7 @@ func getValueByJsonPath(name, path string, obj *unstructured.Unstructured) (*wor
 			Value: fieldValue,
 		}, nil
 	default:
-		if features.DefaultSpokeWorkMutableFeatureGate.Enabled(ocmfeature.RawFeedbackJsonString) {
+		if features.SpokeMutableFeatureGate.Enabled(ocmfeature.RawFeedbackJsonString) {
 			jsonRaw, err := json.Marshal(&t)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse the resource to json string for name %s: %v", name, err)

--- a/pkg/work/spoke/statusfeedback/reader_test.go
+++ b/pkg/work/spoke/statusfeedback/reader_test.go
@@ -338,7 +338,7 @@ func TestStatusReader(t *testing.T) {
 	reader := NewStatusReader()
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := features.DefaultSpokeWorkMutableFeatureGate.Set(fmt.Sprintf("%s=%t", ocmfeature.RawFeedbackJsonString, c.enableRaw))
+			err := features.SpokeMutableFeatureGate.Set(fmt.Sprintf("%s=%t", ocmfeature.RawFeedbackJsonString, c.enableRaw))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/work/spoke/statusfeedback/reader_test.go
+++ b/pkg/work/spoke/statusfeedback/reader_test.go
@@ -6,6 +6,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/pointer"
 
 	ocmfeature "open-cluster-management.io/api/feature"
@@ -126,6 +127,7 @@ func unstrctureObject(data string) *unstructured.Unstructured {
 }
 
 func TestStatusReader(t *testing.T) {
+	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
 	cases := []struct {
 		name          string
 		object        *unstructured.Unstructured

--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -33,7 +33,7 @@ test-e2e: deploy-hub deploy-spoke-operator run-e2e
 
 run-e2e: cluster-ip bootstrap-secret
 	go test -c ./test/e2e
-	./e2e.test -test.v -ginkgo.v -deploy-klusterlet=true -nil-executor-validating=true -registration-image=$(REGISTRATION_IMAGE) -work-image=$(WORK_IMAGE) -klusterlet-deploy-mode=$(KLUSTERLET_DEPLOY_MODE)
+	./e2e.test -test.v -ginkgo.v -deploy-klusterlet=true -nil-executor-validating=true -registration-image=$(REGISTRATION_IMAGE) -work-image=$(WORK_IMAGE) -singleton-image=$(OPERATOR_IMAGE_NAME) -klusterlet-deploy-mode=$(KLUSTERLET_DEPLOY_MODE)
 
 clean-hub: clean-hub-cr clean-hub-operator
 
@@ -60,7 +60,7 @@ deploy-spoke-operator: ensure-kustomize
 
 apply-spoke-cr: bootstrap-secret
 	$(KUSTOMIZE) build deploy/klusterlet/config/samples \
-	| $(SED_CMD) -e "s,quay.io/open-cluster-management/registration,$(REGISTRATION_IMAGE)," -e "s,quay.io/open-cluster-management/work,$(WORK_IMAGE)," -e "s,cluster1,$(MANAGED_CLUSTER_NAME)," \
+	| $(SED_CMD) -e "s,quay.io/open-cluster-management/registration,$(REGISTRATION_IMAGE)," -e "s,quay.io/open-cluster-management/work,$(WORK_IMAGE)," -e "s,quay.io/open-cluster-management/registration-operator,$(OPERATOR_IMAGE_NAME)," -e "s,cluster1,$(MANAGED_CLUSTER_NAME)," \
 	| $(KUBECTL) apply -f -
 
 clean-hub-cr:

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -75,12 +75,13 @@ type Tester struct {
 	klusterletOperator      string
 	registrationImage       string
 	workImage               string
+	singletonImage          string
 }
 
 // kubeconfigPath is the path of kubeconfig file, will be get from env "KUBECONFIG" by default.
 // bootstrapHubSecret is the bootstrap hub kubeconfig secret, and the format is "namespace/secretName".
 // Default of bootstrapHubSecret is helpers.KlusterletDefaultNamespace/helpers.BootstrapHubKubeConfig.
-func NewTester(hubKubeConfigPath, spokeKubeConfigPath, registrationImage, workImage string, timeout time.Duration) *Tester {
+func NewTester(hubKubeConfigPath, spokeKubeConfigPath, registrationImage, workImage, singletonImage string, timeout time.Duration) *Tester {
 	var tester = Tester{
 		hubKubeConfigPath:       hubKubeConfigPath,
 		spokeKubeConfigPath:     spokeKubeConfigPath,
@@ -92,6 +93,7 @@ func NewTester(hubKubeConfigPath, spokeKubeConfigPath, registrationImage, workIm
 		klusterletOperator:      "klusterlet",
 		registrationImage:       registrationImage,
 		workImage:               workImage,
+		singletonImage:          singletonImage,
 	}
 
 	return &tester
@@ -224,6 +226,7 @@ func (t *Tester) CreateKlusterlet(name, clusterName, klusterletNamespace string,
 		Spec: operatorapiv1.KlusterletSpec{
 			RegistrationImagePullSpec: t.registrationImage,
 			WorkImagePullSpec:         t.workImage,
+			ImagePullSpec:             t.singletonImage,
 			ExternalServerURLs: []operatorapiv1.ServerURL{
 				{
 					URL: "https://localhost",

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -26,6 +26,7 @@ var (
 	eventuallyTimeout     time.Duration
 	registrationImage     string
 	workImage             string
+	singletonImage        string
 	klusterletDeployMode  string
 )
 
@@ -38,11 +39,12 @@ func init() {
 	flag.DurationVar(&eventuallyTimeout, "eventually-timeout", 60*time.Second, "The timeout of Gomega's Eventually (default 60 seconds)")
 	flag.StringVar(&registrationImage, "registration-image", "", "The image of the registration")
 	flag.StringVar(&workImage, "work-image", "", "The image of the work")
+	flag.StringVar(&singletonImage, "singleton-image", "", "The image of the klusterlet agent")
 	flag.StringVar(&klusterletDeployMode, "klusterlet-deploy-mode", string(operatorapiv1.InstallModeDefault), "The image of the work")
 }
 
 func TestE2E(tt *testing.T) {
-	t = NewTester(hubKubeconfig, managedKubeconfig, registrationImage, workImage, eventuallyTimeout)
+	t = NewTester(hubKubeconfig, managedKubeconfig, registrationImage, workImage, singletonImage, eventuallyTimeout)
 
 	OutputFail := func(message string, callerSkip ...int) {
 		t.OutputDebugLogs()

--- a/test/integration/operator/klusterlet_singleton_test.go
+++ b/test/integration/operator/klusterlet_singleton_test.go
@@ -1,0 +1,214 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	operatorapiv1 "open-cluster-management.io/api/operator/v1"
+
+	"open-cluster-management.io/ocm/pkg/operator/helpers"
+	"open-cluster-management.io/ocm/test/integration/util"
+)
+
+var _ = ginkgo.Describe("Klusterlet Singleton mode", func() {
+	var cancel context.CancelFunc
+	var klusterlet *operatorapiv1.Klusterlet
+	var klusterletNamespace string
+	var agentNamespace string
+	var registrationManagementRoleName string
+	var registrationManagedRoleName string
+	var deploymentName string
+	var saName string
+	var workManagementRoleName string
+	var workManagedRoleName string
+
+	ginkgo.BeforeEach(func() {
+		var ctx context.Context
+		klusterlet = &operatorapiv1.Klusterlet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("klusterlet-%s", rand.String(6)),
+			},
+			Spec: operatorapiv1.KlusterletSpec{
+				ImagePullSpec: "quay.io/open-cluster-management/registration-operator",
+				ExternalServerURLs: []operatorapiv1.ServerURL{
+					{
+						URL: "https://localhost",
+					},
+				},
+				ClusterName: "testcluster",
+				DeployOption: operatorapiv1.KlusterletDeployOption{
+					Mode: operatorapiv1.InstallModeSingleton,
+				},
+			},
+		}
+		klusterletNamespace = helpers.KlusterletNamespace(klusterlet)
+		agentNamespace = helpers.AgentNamespace(klusterlet)
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: agentNamespace,
+			},
+		}
+		_, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		ctx, cancel = context.WithCancel(context.Background())
+		go startKlusterletOperator(ctx)
+	})
+
+	ginkgo.AfterEach(func() {
+		err := kubeClient.CoreV1().Namespaces().Delete(context.Background(), agentNamespace, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if cancel != nil {
+			cancel()
+		}
+	})
+
+	ginkgo.Context("Deploy and clean klusterlet component", func() {
+		ginkgo.BeforeEach(func() {
+			deploymentName = fmt.Sprintf("%s-agent", klusterlet.Name)
+			registrationManagementRoleName = fmt.Sprintf("open-cluster-management:management:%s-registration:agent", klusterlet.Name)
+			workManagementRoleName = fmt.Sprintf("open-cluster-management:management:%s-work:agent", klusterlet.Name)
+			registrationManagedRoleName = fmt.Sprintf("open-cluster-management:%s-registration:agent", klusterlet.Name)
+			workManagedRoleName = fmt.Sprintf("open-cluster-management:%s-work:agent", klusterlet.Name)
+			saName = fmt.Sprintf("%s-agent-sa", klusterlet.Name)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(operatorClient.OperatorV1().Klusterlets().Delete(context.Background(), klusterlet.Name, metav1.DeleteOptions{})).To(gomega.BeNil())
+		})
+
+		ginkgo.It("should have expected resource created successfully", func() {
+			_, err := operatorClient.OperatorV1().Klusterlets().Create(context.Background(), klusterlet, metav1.CreateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Check if relatedResources are correct
+			gomega.Eventually(func() error {
+				actual, err := operatorClient.OperatorV1().Klusterlets().Get(context.Background(), klusterlet.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				fmt.Printf("related resources are %v\n", actual.Status.RelatedResources)
+
+				// 10 managed static manifests + 9 management static manifests + 2CRDs + 1 deployments
+				if len(actual.Status.RelatedResources) != 22 {
+					return fmt.Errorf("should get 22 relatedResources, actual got %v", len(actual.Status.RelatedResources))
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+			// Check CRDs
+			gomega.Eventually(func() bool {
+				if _, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "appliedmanifestworks.work.open-cluster-management.io", metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				if _, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "clusterclaims.cluster.open-cluster-management.io", metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+			// Check clusterrole/clusterrolebinding
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), registrationManagedRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().ClusterRoles().Get(context.Background(), workManagedRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), registrationManagedRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().ClusterRoleBindings().Get(context.Background(), workManagedRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+			// Check role/rolebinding
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().Roles(agentNamespace).Get(context.Background(), registrationManagementRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().Roles(agentNamespace).Get(context.Background(), workManagementRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().RoleBindings(agentNamespace).Get(context.Background(), registrationManagementRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().RoleBindings(agentNamespace).Get(context.Background(), workManagementRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			// Check extension apiserver rolebinding
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().RoleBindings("kube-system").Get(context.Background(), registrationManagementRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.RbacV1().RoleBindings("kube-system").Get(context.Background(), workManagementRoleName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+			// Check service account
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.CoreV1().ServiceAccounts(agentNamespace).Get(context.Background(), saName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+			// Check deployment
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.AppsV1().Deployments(agentNamespace).Get(context.Background(), deploymentName, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+			// Check addon namespace
+			addonNamespace := fmt.Sprintf("%s-addon", klusterletNamespace)
+			gomega.Eventually(func() bool {
+				if _, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), addonNamespace, metav1.GetOptions{}); err != nil {
+					return false
+				}
+				return true
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+			util.AssertKlusterletCondition(klusterlet.Name, operatorClient, "Applied", "KlusterletApplied", metav1.ConditionTrue)
+		})
+	})
+})

--- a/test/integration/registration/addon_lease_test.go
+++ b/test/integration/registration/addon_lease_test.go
@@ -165,20 +165,20 @@ var _ = ginkgo.Describe("Addon Lease Resync", func() {
 		hubKubeconfigDir = path.Join(util.TestDir, fmt.Sprintf("addontest-%s", suffix), "hub-kubeconfig")
 		addOnName = fmt.Sprintf("addon-%s", suffix)
 
-		err := features.DefaultSpokeRegistrationMutableFeatureGate.Set("AddonManagement=true")
+		err := features.SpokeMutableFeatureGate.Set("AddonManagement=true")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
 
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
 
-		cancel = runAgent("addontest", agentOptions, spokeCfg)
+		cancel = runAgent("addontest", agentOptions, commOptions, spokeCfg)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/test/integration/registration/addon_registration_test.go
+++ b/test/integration/registration/addon_registration_test.go
@@ -39,21 +39,21 @@ var _ = ginkgo.Describe("Addon Registration", func() {
 		hubKubeconfigDir = path.Join(util.TestDir, fmt.Sprintf("addontest-%s", suffix), "hub-kubeconfig")
 		addOnName = fmt.Sprintf("addon-%s", suffix)
 
-		err := features.DefaultSpokeRegistrationMutableFeatureGate.Set("AddonManagement=true")
+		err := features.SpokeMutableFeatureGate.Set("AddonManagement=true")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
 
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
 
 		// run registration agent
-		cancel = runAgent("addontest", agentOptions, spokeCfg)
+		cancel = runAgent("addontest", agentOptions, commOptions, spokeCfg)
 	})
 
 	ginkgo.AfterEach(

--- a/test/integration/registration/certificate_rotation_test.go
+++ b/test/integration/registration/certificate_rotation_test.go
@@ -20,18 +20,18 @@ var _ = ginkgo.Describe("Certificate Rotation", func() {
 		hubKubeconfigSecret := "rotationtest-hub-kubeconfig-secret"
 		hubKubeconfigDir := path.Join(util.TestDir, "rotationtest", "hub-kubeconfig")
 
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
 
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
 
 		// run registration agent
-		cancel := runAgent("rotationtest", agentOptions, spokeCfg)
+		cancel := runAgent("rotationtest", agentOptions, commOptions, spokeCfg)
 		defer cancel()
 
 		// after bootstrap the spokecluster and csr should be created

--- a/test/integration/registration/disaster_recovery_test.go
+++ b/test/integration/registration/disaster_recovery_test.go
@@ -89,18 +89,18 @@ var _ = ginkgo.Describe("Disaster Recovery", func() {
 	}
 
 	startRegistrationAgent := func(managedClusterName, bootstrapKubeConfigFile, hubKubeconfigSecret, hubKubeconfigDir string) context.CancelFunc {
-		err := features.DefaultSpokeRegistrationMutableFeatureGate.Set("AddonManagement=true")
+		err := features.SpokeMutableFeatureGate.Set("AddonManagement=true")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		return runAgent("addontest", agentOptions, spokeCfg)
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		return runAgent("addontest", agentOptions, commOptions, spokeCfg)
 	}
 
 	assertSuccessClusterBootstrap := func(testNamespace, managedClusterName, hubKubeconfigSecret string, hubKubeClient, spokeKubeClient kubernetes.Interface, hubClusterClient clusterclientset.Interface, auth *util.TestAuthn) {

--- a/test/integration/registration/managedcluster_lease_test.go
+++ b/test/integration/registration/managedcluster_lease_test.go
@@ -33,15 +33,15 @@ var _ = ginkgo.Describe("Cluster Lease Update", func() {
 
 	ginkgo.It("managed cluster lease should be updated constantly", func() {
 		// run registration agent
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		cancel := runAgent("cluster-leasetest", agentOptions, spokeCfg)
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		cancel := runAgent("cluster-leasetest", agentOptions, commOptions, spokeCfg)
 		defer cancel()
 
 		bootstrapManagedCluster(managedClusterName, hubKubeconfigSecret, util.TestLeaseDurationSeconds)
@@ -52,15 +52,15 @@ var _ = ginkgo.Describe("Cluster Lease Update", func() {
 
 	ginkgo.It("managed cluster available condition should be recovered after its lease update is recovered", func() {
 		// run registration agent
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		stop := runAgent("cluster-availabletest", agentOptions, spokeCfg)
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		stop := runAgent("cluster-availabletest", agentOptions, commOptions, spokeCfg)
 
 		bootstrapManagedCluster(managedClusterName, hubKubeconfigSecret, util.TestLeaseDurationSeconds)
 		assertAvailableCondition(managedClusterName, metav1.ConditionTrue, 0)
@@ -72,15 +72,15 @@ var _ = ginkgo.Describe("Cluster Lease Update", func() {
 		gracePeriod := 5 * util.TestLeaseDurationSeconds
 		assertAvailableCondition(managedClusterName, metav1.ConditionUnknown, gracePeriod)
 
-		agentOptions = spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions = &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		stop = runAgent("cluster-availabletest", agentOptions, spokeCfg)
+		commOptions = commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		stop = runAgent("cluster-availabletest", agentOptions, commOptions, spokeCfg)
 		defer stop()
 
 		// after one grace period, make sure the managed cluster available condition is recovered
@@ -90,15 +90,15 @@ var _ = ginkgo.Describe("Cluster Lease Update", func() {
 
 	ginkgo.It("managed cluster available condition should be recovered after the cluster is restored", func() {
 		// run registration agent
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		cancel := runAgent("cluster-leasetest", agentOptions, spokeCfg)
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		cancel := runAgent("cluster-leasetest", agentOptions, commOptions, spokeCfg)
 		defer cancel()
 
 		bootstrapManagedCluster(managedClusterName, hubKubeconfigSecret, util.TestLeaseDurationSeconds)
@@ -141,15 +141,15 @@ var _ = ginkgo.Describe("Cluster Lease Update", func() {
 
 	ginkgo.It("should use a short lease duration", func() {
 		// run registration agent
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		stop := runAgent("cluster-leasetest", agentOptions, spokeCfg)
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		stop := runAgent("cluster-leasetest", agentOptions, commOptions, spokeCfg)
 
 		bootstrapManagedCluster(managedClusterName, hubKubeconfigSecret, 60)
 		assertAvailableCondition(managedClusterName, metav1.ConditionTrue, 0)

--- a/test/integration/registration/spokeagent_recovery_test.go
+++ b/test/integration/registration/spokeagent_recovery_test.go
@@ -35,16 +35,16 @@ var _ = ginkgo.Describe("Agent Recovery", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// run registration agent with an invalid bootstrap kubeconfig
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
 
-		cancel := runAgent("bootstrap-recoverytest", agentOptions, spokeCfg)
+		cancel := runAgent("bootstrap-recoverytest", agentOptions, commOptions, spokeCfg)
 		defer cancel()
 
 		// the managedcluster should not be created
@@ -123,16 +123,16 @@ var _ = ginkgo.Describe("Agent Recovery", func() {
 		hubKubeconfigDir := path.Join(util.TestDir, "hubkubeconfig-recoverytest", "hub-kubeconfig")
 
 		// run registration agent
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = spokeClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = spokeClusterName
 
-		cancel := runAgent("hubkubeconfig-recoverytest", agentOptions, spokeCfg)
+		cancel := runAgent("hubkubeconfig-recoverytest", agentOptions, commOptions, spokeCfg)
 		defer cancel()
 
 		// after bootstrap the spokecluster and csr should be created

--- a/test/integration/registration/spokeagent_restart_test.go
+++ b/test/integration/registration/spokeagent_restart_test.go
@@ -34,16 +34,16 @@ var _ = ginkgo.Describe("Agent Restart", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("run registration agent")
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
 
-		stopAgent := runAgent("restart-test", agentOptions, spokeCfg)
+		stopAgent := runAgent("restart-test", agentOptions, commOptions, spokeCfg)
 
 		ginkgo.By("Check existence of csr and ManagedCluster")
 		// the csr should be created
@@ -111,15 +111,15 @@ var _ = ginkgo.Describe("Agent Restart", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("Restart registration agent")
-		agentOptions = spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions = &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		stopAgent = runAgent("restart-test", agentOptions, spokeCfg)
+		commOptions = commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		stopAgent = runAgent("restart-test", agentOptions, commOptions, spokeCfg)
 		defer stopAgent()
 
 		ginkgo.By("Check if ManagedCluster joins the hub")
@@ -164,15 +164,15 @@ var _ = ginkgo.Describe("Agent Restart", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("run registration agent")
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		stopAgent := runAgent("restart-test", agentOptions, spokeCfg)
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		stopAgent := runAgent("restart-test", agentOptions, commOptions, spokeCfg)
 
 		ginkgo.By("Check existence of csr and ManagedCluster")
 		// the csr should be created
@@ -226,15 +226,15 @@ var _ = ginkgo.Describe("Agent Restart", func() {
 
 		ginkgo.By("Restart registration agent with a new cluster name")
 		managedClusterName = "restart-test-cluster3"
-		agentOptions = spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions = &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		stopAgent = runAgent("restart-test", agentOptions, spokeCfg)
+		commOptions = commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		stopAgent = runAgent("restart-test", agentOptions, commOptions, spokeCfg)
 		defer stopAgent()
 
 		ginkgo.By("Check the existence of csr and the new ManagedCluster")

--- a/test/integration/registration/spokecluster_autoapproval_test.go
+++ b/test/integration/registration/spokecluster_autoapproval_test.go
@@ -29,17 +29,17 @@ var _ = ginkgo.Describe("Cluster Auto Approval", func() {
 		err = authn.CreateBootstrapKubeConfigWithUser(bootstrapFile, serverCertFile, securePort, util.AutoApprovalBootstrapUser)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
 
 		// run registration agent
-		cancel := runAgent("autoapprovaltest", agentOptions, spokeCfg)
+		cancel := runAgent("autoapprovaltest", agentOptions, commOptions, spokeCfg)
 		defer cancel()
 
 		// after bootstrap the spokecluster should be accepted and its csr should be auto approved

--- a/test/integration/registration/spokecluster_claim_test.go
+++ b/test/integration/registration/spokecluster_claim_test.go
@@ -49,16 +49,16 @@ var _ = ginkgo.Describe("Cluster Claim", func() {
 		}
 
 		// run registration agent
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 			MaxCustomClusterClaims:   maxCustomClusterClaims,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-		cancel = runAgent("claimtest", agentOptions, spokeCfg)
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+		cancel = runAgent("claimtest", agentOptions, commOptions, spokeCfg)
 	})
 
 	ginkgo.AfterEach(

--- a/test/integration/registration/spokecluster_joining_test.go
+++ b/test/integration/registration/spokecluster_joining_test.go
@@ -25,16 +25,16 @@ var _ = ginkgo.Describe("Joining Process", func() {
 		hubKubeconfigDir := path.Join(util.TestDir, "joiningtest", "hub-kubeconfig")
 
 		// run registration agent
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
 
-		cancel := runAgent("joiningtest", agentOptions, spokeCfg)
+		cancel := runAgent("joiningtest", agentOptions, commOptions, spokeCfg)
 		defer cancel()
 
 		// the spoke cluster and csr should be created after bootstrap

--- a/test/integration/registration/spokecluster_status_test.go
+++ b/test/integration/registration/spokecluster_status_test.go
@@ -31,16 +31,16 @@ var _ = ginkgo.Describe("Collecting Node Resource", func() {
 		hubKubeconfigDir := path.Join(util.TestDir, "resorucetest", "hub-kubeconfig")
 
 		// run registration agent
-		agentOptions := spoke.SpokeAgentOptions{
-			AgentOptions:             commonoptions.NewAgentOptions(),
+		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,
-			HubKubeconfigDir:         hubKubeconfigDir,
 			ClusterHealthCheckPeriod: 1 * time.Minute,
 		}
-		agentOptions.AgentOptions.SpokeClusterName = managedClusterName
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
 
-		cancel := runAgent("resorucetest", agentOptions, spokeCfg)
+		cancel := runAgent("resorucetest", agentOptions, commOptions, spokeCfg)
 		defer cancel()
 
 		// the spoke cluster and csr should be created after bootstrap

--- a/test/integration/registration/taint_add_test.go
+++ b/test/integration/registration/taint_add_test.go
@@ -37,15 +37,17 @@ var _ = ginkgo.Describe("ManagedCluster Taints Update", func() {
 		ctx, stop := context.WithCancel(context.Background())
 		// run registration agent
 		go func() {
-			agentOptions := spoke.SpokeAgentOptions{
-				AgentOptions:             commonoptions.NewAgentOptions(),
+			agentOptions := &spoke.SpokeAgentOptions{
 				BootstrapKubeconfig:      bootstrapKubeConfigFile,
 				HubKubeconfigSecret:      hubKubeconfigSecret,
-				HubKubeconfigDir:         hubKubeconfigDir,
 				ClusterHealthCheckPeriod: 1 * time.Minute,
 			}
-			agentOptions.AgentOptions.SpokeClusterName = managedClusterName
-			err := agentOptions.RunSpokeAgent(ctx, &controllercmd.ControllerContext{
+			commOptions := commonoptions.NewAgentOptions()
+			commOptions.HubKubeconfigDir = hubKubeconfigDir
+			commOptions.SpokeClusterName = managedClusterName
+
+			agentCfg := spoke.NewSpokeAgentConfig(commOptions, agentOptions)
+			err := agentCfg.RunSpokeAgent(ctx, &controllercmd.ControllerContext{
 				KubeConfig:    spokeCfg,
 				EventRecorder: util.NewIntegrationTestEventRecorder("cluster-tainttest"),
 			})

--- a/test/integration/work/deleteoption_test.go
+++ b/test/integration/work/deleteoption_test.go
@@ -21,6 +21,7 @@ import (
 
 var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 	var o *spoke.WorkloadAgentOptions
+	var commOptions *commonoptions.AgentOptions
 	var cancel context.CancelFunc
 
 	var work *workapiv1.ManifestWork
@@ -31,26 +32,27 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 	ginkgo.BeforeEach(func() {
 		o = spoke.NewWorkloadAgentOptions()
-		o.HubKubeconfigFile = hubKubeconfigFileName
-		o.AgentOptions = commonoptions.NewAgentOptions()
-		o.AgentOptions.SpokeClusterName = utilrand.String(5)
 		o.StatusSyncInterval = 3 * time.Second
 
+		commOptions = commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigFile = hubKubeconfigFileName
+		commOptions.SpokeClusterName = utilrand.String(5)
+
 		ns := &corev1.Namespace{}
-		ns.Name = o.AgentOptions.SpokeClusterName
+		ns.Name = commOptions.SpokeClusterName
 		_, err := spokeKubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		var ctx context.Context
 		ctx, cancel = context.WithCancel(context.Background())
-		go startWorkAgent(ctx, o)
+		go startWorkAgent(ctx, o, commOptions)
 
 		// reset manifests
 		manifests = nil
 	})
 
 	ginkgo.JustBeforeEach(func() {
-		work = util.NewManifestWork(o.AgentOptions.SpokeClusterName, "", manifests)
+		work = util.NewManifestWork(commOptions.SpokeClusterName, "", manifests)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
@@ -58,7 +60,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 		if cancel != nil {
 			cancel()
 		}
-		err := spokeKubeClient.CoreV1().Namespaces().Delete(context.Background(), o.AgentOptions.SpokeClusterName, metav1.DeleteOptions{})
+		err := spokeKubeClient.CoreV1().Namespaces().Delete(context.Background(), commOptions.SpokeClusterName, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
@@ -67,29 +69,29 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 		var anotherAppliedManifestWorkName string
 		ginkgo.BeforeEach(func() {
 			manifests = []workapiv1.Manifest{
-				util.ToManifest(util.NewConfigmap(o.AgentOptions.SpokeClusterName, "cm1", map[string]string{"a": "b"}, []string{})),
-				util.ToManifest(util.NewConfigmap(o.AgentOptions.SpokeClusterName, "cm2", map[string]string{"c": "d"}, []string{})),
+				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, "cm1", map[string]string{"a": "b"}, []string{})),
+				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, "cm2", map[string]string{"c": "d"}, []string{})),
 			}
 			// Create another manifestworks with one shared resource.
-			anotherWork = util.NewManifestWork(o.AgentOptions.SpokeClusterName, "sharing-resource-work", []workapiv1.Manifest{manifests[0]})
+			anotherWork = util.NewManifestWork(commOptions.SpokeClusterName, "sharing-resource-work", []workapiv1.Manifest{manifests[0]})
 		})
 
 		ginkgo.JustBeforeEach(func() {
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			appliedManifestWorkName = fmt.Sprintf("%s-%s", hubHash, work.Name)
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
-			anotherWork, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), anotherWork, metav1.CreateOptions{})
+			anotherWork, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), anotherWork, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			util.AssertWorkCondition(anotherWork.Namespace, anotherWork.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(anotherWork.Namespace, anotherWork.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(anotherWork.Namespace, anotherWork.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(anotherWork.Namespace, anotherWork.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			anotherAppliedManifestWorkName = fmt.Sprintf("%s-%s", hubHash, anotherWork.Name)
@@ -98,91 +100,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 		ginkgo.It("shared resource between the manifestwork should be kept when one manifestwork is deleted", func() {
 			// ensure configmap exists and get its uid
 			util.AssertExistenceOfConfigMaps(manifests, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
-			curentConfigMap, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			currentUID := curentConfigMap.UID
-
-			// Ensure that uid recorded in the appliedmanifestwork and anotherappliedmanifestwork is correct.
-			gomega.Eventually(func() error {
-				appliedManifestWork, err := spokeWorkClient.WorkV1().AppliedManifestWorks().Get(context.Background(), appliedManifestWorkName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-
-				for _, appliedResource := range appliedManifestWork.Status.AppliedResources {
-					if appliedResource.Name == "cm1" && appliedResource.UID == string(currentUID) {
-						return nil
-					}
-				}
-
-				return fmt.Errorf("Resource name or uid in appliedmanifestwork does not match")
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-
-			gomega.Eventually(func() error {
-				anotherAppliedManifestWork, err := spokeWorkClient.WorkV1().AppliedManifestWorks().Get(context.Background(), anotherAppliedManifestWorkName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-
-				for _, appliedResource := range anotherAppliedManifestWork.Status.AppliedResources {
-					if appliedResource.Name == "cm1" && appliedResource.UID == string(currentUID) {
-						return nil
-					}
-				}
-
-				return fmt.Errorf("Resource name or uid in appliedmanifestwork does not match")
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-
-			// Delete one manifestwork
-			err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-			// Ensure the appliedmanifestwork of deleted manifestwork is removed so it won't try to delete shared resource
-			gomega.Eventually(func() error {
-				appliedWork, err := spokeWorkClient.WorkV1().AppliedManifestWorks().Get(context.Background(), appliedManifestWorkName, metav1.GetOptions{})
-				if errors.IsNotFound(err) {
-					return nil
-				}
-				if err != nil {
-					return err
-				}
-				return fmt.Errorf("appliedmanifestwork should not exist: %v", appliedWork.DeletionTimestamp)
-			}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
-
-			// Ensure the configmap is kept and tracked by anotherappliedmanifestwork.
-			gomega.Eventually(func() error {
-				configMap, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-
-				if currentUID != configMap.UID {
-					return fmt.Errorf("UID should be equal")
-				}
-
-				anotherappliedmanifestwork, err := spokeWorkClient.WorkV1().AppliedManifestWorks().Get(context.Background(), anotherAppliedManifestWorkName, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-
-				for _, appliedResource := range anotherappliedmanifestwork.Status.AppliedResources {
-					if appliedResource.Name != "cm1" {
-						return fmt.Errorf("Resource Name should be cm1")
-					}
-
-					if appliedResource.UID != string(currentUID) {
-						return fmt.Errorf("UID should be equal")
-					}
-				}
-
-				return nil
-			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-		})
-
-		ginkgo.It("shared resource between the manifestwork should be kept when the shared resource is removed from one manifestwork", func() {
-			// ensure configmap exists and get its uid
-			util.AssertExistenceOfConfigMaps(manifests, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
-			curentConfigMap, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+			curentConfigMap, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			currentUID := curentConfigMap.UID
 
@@ -214,14 +132,98 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					}
 				}
 
-				return fmt.Errorf("Resource name or uid in appliedmanifestwork does not match")
+				return fmt.Errorf("resource name or uid in appliedmanifestwork does not match")
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+			// Delete one manifestwork
+			err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// Ensure the appliedmanifestwork of deleted manifestwork is removed so it won't try to delete shared resource
+			gomega.Eventually(func() error {
+				appliedWork, err := spokeWorkClient.WorkV1().AppliedManifestWorks().Get(context.Background(), appliedManifestWorkName, metav1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("appliedmanifestwork should not exist: %v", appliedWork.DeletionTimestamp)
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+
+			// Ensure the configmap is kept and tracked by anotherappliedmanifestwork.
+			gomega.Eventually(func() error {
+				configMap, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if currentUID != configMap.UID {
+					return fmt.Errorf("UID should be equal")
+				}
+
+				anotherappliedmanifestwork, err := spokeWorkClient.WorkV1().AppliedManifestWorks().Get(context.Background(), anotherAppliedManifestWorkName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				for _, appliedResource := range anotherappliedmanifestwork.Status.AppliedResources {
+					if appliedResource.Name != "cm1" {
+						return fmt.Errorf("resource Name should be cm1")
+					}
+
+					if appliedResource.UID != string(currentUID) {
+						return fmt.Errorf("UID should be equal")
+					}
+				}
+
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("shared resource between the manifestwork should be kept when the shared resource is removed from one manifestwork", func() {
+			// ensure configmap exists and get its uid
+			util.AssertExistenceOfConfigMaps(manifests, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
+			curentConfigMap, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			currentUID := curentConfigMap.UID
+
+			// Ensure that uid recorded in the appliedmanifestwork and anotherappliedmanifestwork is correct.
+			gomega.Eventually(func() error {
+				appliedManifestWork, err := spokeWorkClient.WorkV1().AppliedManifestWorks().Get(context.Background(), appliedManifestWorkName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				for _, appliedResource := range appliedManifestWork.Status.AppliedResources {
+					if appliedResource.Name == "cm1" && appliedResource.UID == string(currentUID) {
+						return nil
+					}
+				}
+
+				return fmt.Errorf("resource name or uid in appliedmanifestwork does not match")
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+			gomega.Eventually(func() error {
+				anotherAppliedManifestWork, err := spokeWorkClient.WorkV1().AppliedManifestWorks().Get(context.Background(), anotherAppliedManifestWorkName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				for _, appliedResource := range anotherAppliedManifestWork.Status.AppliedResources {
+					if appliedResource.Name == "cm1" && appliedResource.UID == string(currentUID) {
+						return nil
+					}
+				}
+
+				return fmt.Errorf("resource name or uid in appliedmanifestwork does not match")
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Update one manifestwork to remove the shared resource
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			work.Spec.Workload.Manifests = []workapiv1.Manifest{manifests[1]}
-			_, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
+			_, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// Ensure the resource is not tracked by the appliedmanifestwork.
@@ -242,7 +244,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Ensure the configmap is kept and tracked by anotherappliedmanifestwork
 			gomega.Eventually(func() error {
-				configMap, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+				configMap, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -258,7 +260,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 				for _, appliedResource := range anotherAppliedManifestWork.Status.AppliedResources {
 					if appliedResource.Name != "cm1" {
-						return fmt.Errorf("Resource Name should be cm1")
+						return fmt.Errorf("resource Name should be cm1")
 					}
 
 					if appliedResource.UID != string(currentUID) {
@@ -275,8 +277,8 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 	ginkgo.Context("Delete options", func() {
 		ginkgo.BeforeEach(func() {
 			manifests = []workapiv1.Manifest{
-				util.ToManifest(util.NewConfigmap(o.AgentOptions.SpokeClusterName, "cm1", map[string]string{"a": "b"}, []string{})),
-				util.ToManifest(util.NewConfigmap(o.AgentOptions.SpokeClusterName, "cm2", map[string]string{"c": "d"}, []string{})),
+				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, "cm1", map[string]string{"a": "b"}, []string{})),
+				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, "cm2", map[string]string{"c": "d"}, []string{})),
 			}
 		})
 
@@ -285,14 +287,14 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				PropagationPolicy: workapiv1.DeletePropagationPolicyTypeOrphan,
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			appliedManifestWorkName = fmt.Sprintf("%s-%s", hubHash, work.Name)
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			// Ensure configmap exists
@@ -300,38 +302,38 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Ensure ownership of configmap is updated
 			gomega.Eventually(func() error {
-				cm, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+				cm, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(cm.OwnerReferences) != 0 {
-					return fmt.Errorf("Owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
+					return fmt.Errorf("owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
 				}
 
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				cm, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm2", metav1.GetOptions{})
+				cm, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm2", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(cm.OwnerReferences) != 0 {
-					return fmt.Errorf("Owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
+					return fmt.Errorf("owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
 				}
 
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Delete the work
-			err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
+			err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// Wait for deletion of manifest work
 			gomega.Eventually(func() bool {
-				_, err := hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				_, err := hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				return errors.IsNotFound(err)
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
@@ -347,21 +349,21 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 						{
 							Group:     "",
 							Resource:  "configmaps",
-							Namespace: o.AgentOptions.SpokeClusterName,
+							Namespace: commOptions.SpokeClusterName,
 							Name:      "cm1",
 						},
 					},
 				},
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			appliedManifestWorkName = fmt.Sprintf("%s-%s", hubHash, work.Name)
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			// Ensure configmap exists
@@ -369,34 +371,34 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Ensure ownership of configmap is updated
 			gomega.Eventually(func() error {
-				cm, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+				cm, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(cm.OwnerReferences) != 0 {
-					return fmt.Errorf("Owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
+					return fmt.Errorf("owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
 				}
 
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Delete the work
-			err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
+			err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// Wait for deletion of manifest work
 			gomega.Eventually(func() bool {
-				_, err := hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				_, err := hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				return errors.IsNotFound(err)
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			// One of the resource should be deleted.
-			_, err = spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm2", metav1.GetOptions{})
+			_, err = spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm2", metav1.GetOptions{})
 			gomega.Expect(errors.IsNotFound(err)).To(gomega.BeTrue())
 
 			// One of the resource should be kept
-			_, err = spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+			_, err = spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
@@ -408,21 +410,21 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 						{
 							Group:     "",
 							Resource:  "configmaps",
-							Namespace: o.AgentOptions.SpokeClusterName,
+							Namespace: commOptions.SpokeClusterName,
 							Name:      "cm1",
 						},
 					},
 				},
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			appliedManifestWorkName = fmt.Sprintf("%s-%s", hubHash, work.Name)
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			// Ensure configmap exists
@@ -430,13 +432,13 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Ensure ownership of configmap is updated
 			gomega.Eventually(func() error {
-				cm, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+				cm, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(cm.OwnerReferences) != 0 {
-					return fmt.Errorf("Owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
+					return fmt.Errorf("owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
 				}
 
 				return nil
@@ -444,26 +446,26 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Remove the resource from the manifests
 			gomega.Eventually(func() error {
-				work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				work.Spec.Workload.Manifests = []workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(o.AgentOptions.SpokeClusterName, "cm2", map[string]string{"c": "d"}, []string{})),
+					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, "cm2", map[string]string{"c": "d"}, []string{})),
 				}
-				_, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
+				_, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			// Sleep 5 second and check the resource should be kept
 			time.Sleep(5 * time.Second)
-			_, err = spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+			_, err = spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
 
@@ -475,21 +477,21 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 						{
 							Group:     "",
 							Resource:  "configmaps",
-							Namespace: o.AgentOptions.SpokeClusterName,
+							Namespace: commOptions.SpokeClusterName,
 							Name:      "cm1",
 						},
 					},
 				},
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			appliedManifestWorkName = fmt.Sprintf("%s-%s", hubHash, work.Name)
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			// Ensure configmap exists
@@ -497,13 +499,13 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Ensure ownership of configmap is updated
 			gomega.Eventually(func() error {
-				cm, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+				cm, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(cm.OwnerReferences) != 0 {
-					return fmt.Errorf("Owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
+					return fmt.Errorf("owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
 				}
 
 				return nil
@@ -511,44 +513,44 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Remove the delete option
 			gomega.Eventually(func() error {
-				work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				work.Spec.DeleteOption = nil
-				_, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
+				_, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Ensure ownership of configmap is updated
 			gomega.Eventually(func() error {
-				cm, err := spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+				cm, err := spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(cm.OwnerReferences) != 1 {
-					return fmt.Errorf("Owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
+					return fmt.Errorf("owner reference are not correctly updated, current ownerrefs are %v", cm.OwnerReferences)
 				}
 
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Delete the work
-			err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
+			err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Delete(context.Background(), work.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// Wait for deletion of manifest work
 			gomega.Eventually(func() bool {
-				_, err := hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				_, err := hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				return errors.IsNotFound(err)
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			// All of the resource should be deleted.
-			_, err = spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm2", metav1.GetOptions{})
+			_, err = spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm2", metav1.GetOptions{})
 			gomega.Expect(errors.IsNotFound(err)).To(gomega.BeTrue())
-			_, err = spokeKubeClient.CoreV1().ConfigMaps(o.AgentOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
+			_, err = spokeKubeClient.CoreV1().ConfigMaps(commOptions.SpokeClusterName).Get(context.Background(), "cm1", metav1.GetOptions{})
 			gomega.Expect(errors.IsNotFound(err)).To(gomega.BeTrue())
 		})
 	})

--- a/test/integration/work/manifestworkreplicaset_test.go
+++ b/test/integration/work/manifestworkreplicaset_test.go
@@ -213,7 +213,7 @@ func assertWorksByReplicaSet(clusterNames sets.Set[string], mwrs *workapiv1alpha
 		}
 
 		if len(works.Items) != clusterNames.Len() {
-			return fmt.Errorf("The number of applied works should equal to %d, but got %d", clusterNames.Len(), len(works.Items))
+			return fmt.Errorf("the number of applied works should equal to %d, but got %d", clusterNames.Len(), len(works.Items))
 		}
 
 		for _, work := range works.Items {

--- a/test/integration/work/statusfeedback_test.go
+++ b/test/integration/work/statusfeedback_test.go
@@ -25,6 +25,7 @@ import (
 
 var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 	var o *spoke.WorkloadAgentOptions
+	var commOptions *commonoptions.AgentOptions
 	var cancel context.CancelFunc
 
 	var work *workapiv1.ManifestWork
@@ -34,13 +35,14 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 	ginkgo.BeforeEach(func() {
 		o = spoke.NewWorkloadAgentOptions()
-		o.HubKubeconfigFile = hubKubeconfigFileName
-		o.AgentOptions = commonoptions.NewAgentOptions()
-		o.AgentOptions.SpokeClusterName = utilrand.String(5)
 		o.StatusSyncInterval = 3 * time.Second
 
+		commOptions = commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigFile = hubKubeconfigFileName
+		commOptions.SpokeClusterName = utilrand.String(5)
+
 		ns := &corev1.Namespace{}
-		ns.Name = o.AgentOptions.SpokeClusterName
+		ns.Name = commOptions.SpokeClusterName
 		_, err = spokeKubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -49,24 +51,24 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 	})
 
 	ginkgo.JustBeforeEach(func() {
-		work = util.NewManifestWork(o.AgentOptions.SpokeClusterName, "", manifests)
+		work = util.NewManifestWork(commOptions.SpokeClusterName, "", manifests)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	ginkgo.AfterEach(func() {
-		err := spokeKubeClient.CoreV1().Namespaces().Delete(context.Background(), o.AgentOptions.SpokeClusterName, metav1.DeleteOptions{})
+		err := spokeKubeClient.CoreV1().Namespaces().Delete(context.Background(), commOptions.SpokeClusterName, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	ginkgo.Context("Deployment Status feedback", func() {
 		ginkgo.BeforeEach(func() {
-			u, _, err := util.NewDeployment(o.AgentOptions.SpokeClusterName, "deploy1", "sa")
+			u, _, err := util.NewDeployment(commOptions.SpokeClusterName, "deploy1", "sa")
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			manifests = append(manifests, util.ToManifest(u))
 
 			var ctx context.Context
 			ctx, cancel = context.WithCancel(context.Background())
-			go startWorkAgent(ctx, o)
+			go startWorkAgent(ctx, o, commOptions)
 		})
 
 		ginkgo.AfterEach(func() {
@@ -81,7 +83,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					ResourceIdentifier: workapiv1.ResourceIdentifier{
 						Group:     "apps",
 						Resource:  "deployments",
-						Namespace: o.AgentOptions.SpokeClusterName,
+						Namespace: commOptions.SpokeClusterName,
 						Name:      "deploy1",
 					},
 					FeedbackRules: []workapiv1.FeedbackRule{
@@ -92,7 +94,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				},
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
@@ -102,7 +104,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Update Deployment status on spoke
 			gomega.Eventually(func() error {
-				deploy, err := spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
+				deploy, err := spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -111,19 +113,19 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				deploy.Status.Replicas = 3
 				deploy.Status.ReadyReplicas = 2
 
-				_, err = spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Check if we get status of deployment on work api
 			gomega.Eventually(func() error {
-				work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(work.Status.ResourceStatus.Manifests) != 1 {
-					return fmt.Errorf("The size of resource status is not correct, expect to be 1 but got %d", len(work.Status.ResourceStatus.Manifests))
+					return fmt.Errorf("the size of resource status is not correct, expect to be 1 but got %d", len(work.Status.ResourceStatus.Manifests))
 				}
 
 				values := work.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values
@@ -152,11 +154,11 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					},
 				}
 				if !apiequality.Semantic.DeepEqual(values, expectedValues) {
-					return fmt.Errorf("Status feedback values are not correct, we got %v", values)
+					return fmt.Errorf("status feedback values are not correct, we got %v", values)
 				}
 
 				if !util.HaveManifestCondition(work.Status.ResourceStatus.Manifests, "StatusFeedbackSynced", []metav1.ConditionStatus{metav1.ConditionTrue}) {
-					return fmt.Errorf("Status sync condition should be True")
+					return fmt.Errorf("status sync condition should be True")
 				}
 
 				return err
@@ -164,7 +166,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 
 			// Update replica of deployment
 			gomega.Eventually(func() error {
-				deploy, err := spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
+				deploy, err := spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -173,19 +175,19 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				deploy.Status.Replicas = 3
 				deploy.Status.ReadyReplicas = 3
 
-				_, err = spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Check if the status of deployment is synced on work api
 			gomega.Eventually(func() error {
-				work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(work.Status.ResourceStatus.Manifests) != 1 {
-					return fmt.Errorf("The size of resource status is not correct, expect to be 1 but got %d", len(work.Status.ResourceStatus.Manifests))
+					return fmt.Errorf("the size of resource status is not correct, expect to be 1 but got %d", len(work.Status.ResourceStatus.Manifests))
 				}
 
 				values := work.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values
@@ -214,11 +216,11 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					},
 				}
 				if !apiequality.Semantic.DeepEqual(values, expectedValues) {
-					return fmt.Errorf("Status feedback values are not correct, we got %v", values)
+					return fmt.Errorf("status feedback values are not correct, we got %v", values)
 				}
 
 				if !util.HaveManifestCondition(work.Status.ResourceStatus.Manifests, "StatusFeedbackSynced", []metav1.ConditionStatus{metav1.ConditionTrue}) {
-					return fmt.Errorf("Status sync condition should be True")
+					return fmt.Errorf("status sync condition should be True")
 				}
 
 				return nil
@@ -231,7 +233,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					ResourceIdentifier: workapiv1.ResourceIdentifier{
 						Group:     "apps",
 						Resource:  "deployments",
-						Namespace: o.AgentOptions.SpokeClusterName,
+						Namespace: commOptions.SpokeClusterName,
 						Name:      "deploy1",
 					},
 					FeedbackRules: []workapiv1.FeedbackRule{
@@ -252,16 +254,16 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				},
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			gomega.Eventually(func() error {
-				deploy, err := spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
+				deploy, err := spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -273,19 +275,19 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					},
 				}
 
-				_, err = spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Check if we get status of deployment on work api
 			gomega.Eventually(func() error {
-				work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(work.Status.ResourceStatus.Manifests) != 1 {
-					return fmt.Errorf("The size of resource status is not correct, expect to be 1 but got %d", len(work.Status.ResourceStatus.Manifests))
+					return fmt.Errorf("the size of resource status is not correct, expect to be 1 but got %d", len(work.Status.ResourceStatus.Manifests))
 				}
 
 				values := work.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values
@@ -300,11 +302,11 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					},
 				}
 				if !apiequality.Semantic.DeepEqual(values, expectedValues) {
-					return fmt.Errorf("Status feedback values are not correct, we got %v", values)
+					return fmt.Errorf("status feedback values are not correct, we got %v", values)
 				}
 
 				if !util.HaveManifestCondition(work.Status.ResourceStatus.Manifests, "StatusFeedbackSynced", []metav1.ConditionStatus{metav1.ConditionFalse}) {
-					return fmt.Errorf("Status sync condition should be False")
+					return fmt.Errorf("status sync condition should be False")
 				}
 
 				return nil
@@ -312,7 +314,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 		})
 
 		ginkgo.It("should return none for resources with no wellKnowne status", func() {
-			sa, _ := util.NewServiceAccount(o.AgentOptions.SpokeClusterName, "sa")
+			sa, _ := util.NewServiceAccount(commOptions.SpokeClusterName, "sa")
 			work.Spec.Workload.Manifests = append(work.Spec.Workload.Manifests, util.ToManifest(sa))
 
 			work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
@@ -320,7 +322,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					ResourceIdentifier: workapiv1.ResourceIdentifier{
 						Group:     "apps",
 						Resource:  "deployments",
-						Namespace: o.AgentOptions.SpokeClusterName,
+						Namespace: commOptions.SpokeClusterName,
 						Name:      "deploy1",
 					},
 					FeedbackRules: []workapiv1.FeedbackRule{
@@ -333,7 +335,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					ResourceIdentifier: workapiv1.ResourceIdentifier{
 						Group:     "",
 						Resource:  "serviceaccounts",
-						Namespace: o.AgentOptions.SpokeClusterName,
+						Namespace: commOptions.SpokeClusterName,
 						Name:      "sa",
 					},
 					FeedbackRules: []workapiv1.FeedbackRule{
@@ -344,17 +346,17 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				},
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			// Update Deployment status on spoke
 			gomega.Eventually(func() error {
-				deploy, err := spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
+				deploy, err := spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -363,19 +365,19 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				deploy.Status.Replicas = 3
 				deploy.Status.ReadyReplicas = 2
 
-				_, err = spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Check if we get status of deployment on work api
 			gomega.Eventually(func() error {
-				work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(work.Status.ResourceStatus.Manifests) != 2 {
-					return fmt.Errorf("The size of resource status is not correct, expect to be 2 but got %d", len(work.Status.ResourceStatus.Manifests))
+					return fmt.Errorf("the size of resource status is not correct, expect to be 2 but got %d", len(work.Status.ResourceStatus.Manifests))
 				}
 
 				values := work.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values
@@ -404,15 +406,15 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					},
 				}
 				if !apiequality.Semantic.DeepEqual(values, expectedValues) {
-					return fmt.Errorf("Status feedback values are not correct, we got %v", values)
+					return fmt.Errorf("status feedback values are not correct, we got %v", values)
 				}
 
 				if len(work.Status.ResourceStatus.Manifests[1].StatusFeedbacks.Values) != 0 {
-					return fmt.Errorf("Status feedback values are not correct, we got %v", work.Status.ResourceStatus.Manifests[1].StatusFeedbacks.Values)
+					return fmt.Errorf("status feedback values are not correct, we got %v", work.Status.ResourceStatus.Manifests[1].StatusFeedbacks.Values)
 				}
 
 				if !util.HaveManifestCondition(work.Status.ResourceStatus.Manifests, "StatusFeedbackSynced", []metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionFalse}) {
-					return fmt.Errorf("Status sync condition should be True")
+					return fmt.Errorf("status sync condition should be True")
 				}
 
 				return nil
@@ -425,7 +427,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					ResourceIdentifier: workapiv1.ResourceIdentifier{
 						Group:     "apps",
 						Resource:  "deployments",
-						Namespace: o.AgentOptions.SpokeClusterName,
+						Namespace: commOptions.SpokeClusterName,
 						Name:      "deploy1",
 					},
 					FeedbackRules: []workapiv1.FeedbackRule{
@@ -442,27 +444,27 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				},
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 		})
 	})
 
 	ginkgo.Context("Deployment Status feedback with RawJsonString enabled", func() {
 		ginkgo.BeforeEach(func() {
-			u, _, err := util.NewDeployment(o.AgentOptions.SpokeClusterName, "deploy1", "sa")
+			u, _, err := util.NewDeployment(commOptions.SpokeClusterName, "deploy1", "sa")
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			manifests = append(manifests, util.ToManifest(u))
 
-			err = features.DefaultSpokeWorkMutableFeatureGate.Set(fmt.Sprintf("%s=true", ocmfeature.RawFeedbackJsonString))
+			err = features.SpokeMutableFeatureGate.Set(fmt.Sprintf("%s=true", ocmfeature.RawFeedbackJsonString))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			var ctx context.Context
 			ctx, cancel = context.WithCancel(context.Background())
-			go startWorkAgent(ctx, o)
+			go startWorkAgent(ctx, o, commOptions)
 		})
 
 		ginkgo.AfterEach(func() {
@@ -477,7 +479,7 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					ResourceIdentifier: workapiv1.ResourceIdentifier{
 						Group:     "apps",
 						Resource:  "deployments",
-						Namespace: o.AgentOptions.SpokeClusterName,
+						Namespace: commOptions.SpokeClusterName,
 						Name:      "deploy1",
 					},
 					FeedbackRules: []workapiv1.FeedbackRule{
@@ -494,16 +496,16 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				},
 			}
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkApplied), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
-			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, string(workapiv1.WorkAvailable), metav1.ConditionTrue,
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
 				[]metav1.ConditionStatus{metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
 
 			gomega.Eventually(func() error {
-				deploy, err := spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
+				deploy, err := spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -515,19 +517,19 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					},
 				}
 
-				_, err = spokeKubeClient.AppsV1().Deployments(o.AgentOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// Check if we get status of deployment on work api
 			gomega.Eventually(func() error {
-				work, err = hubWorkClient.WorkV1().ManifestWorks(o.AgentOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				if len(work.Status.ResourceStatus.Manifests) != 1 {
-					return fmt.Errorf("The size of resource status is not correct, expect to be 1 but got %d", len(work.Status.ResourceStatus.Manifests))
+					return fmt.Errorf("the size of resource status is not correct, expect to be 1 but got %d", len(work.Status.ResourceStatus.Manifests))
 				}
 
 				values := work.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values
@@ -543,13 +545,13 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				}
 				if !apiequality.Semantic.DeepEqual(values, expectedValues) {
 					if len(values) > 0 {
-						return fmt.Errorf("Status feedback values are not correct, we got %v", *values[0].Value.JsonRaw)
+						return fmt.Errorf("status feedback values are not correct, we got %v", *values[0].Value.JsonRaw)
 					}
-					return fmt.Errorf("Status feedback values are not correct, we got %v", values)
+					return fmt.Errorf("status feedback values are not correct, we got %v", values)
 				}
 
 				if !util.HaveManifestCondition(work.Status.ResourceStatus.Manifests, "StatusFeedbackSynced", []metav1.ConditionStatus{metav1.ConditionTrue}) {
-					return fmt.Errorf("Status sync condition should be True")
+					return fmt.Errorf("status sync condition should be True")
 				}
 
 				return nil

--- a/test/integration/work/suite_test.go
+++ b/test/integration/work/suite_test.go
@@ -18,8 +18,10 @@ import (
 
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
+	ocmfeature "open-cluster-management.io/api/feature"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 
+	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/work/helper"
 	"open-cluster-management.io/ocm/pkg/work/hub"
 	"open-cluster-management.io/ocm/test/integration/util"
@@ -79,8 +81,10 @@ var _ = ginkgo.BeforeSuite(func() {
 	err = util.CreateKubeconfigFile(cfg, hubKubeconfigFileName)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	err = workapiv1.AddToScheme(scheme.Scheme)
+	err = workapiv1.Install(scheme.Scheme)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates)
 
 	spokeRestConfig = cfg
 	hubHash = helper.HubHash(spokeRestConfig.Host)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This is start the registration/work together with `registration-operator agent` command

## Related issue(s)

Fixes #