### PR TITLE
🌱 increase the default work eviction grace period to 60 minutes

### DIFF
--- a/pkg/work/spoke/spokeagent.go
+++ b/pkg/work/spoke/spokeagent.go
@@ -53,7 +53,7 @@ func NewWorkloadAgentOptions() *WorkloadAgentOptions {
 	return &WorkloadAgentOptions{
 		AgentOptions:                           commonoptions.NewAgentOptions(),
 		StatusSyncInterval:                     10 * time.Second,
-		AppliedManifestWorkEvictionGracePeriod: 10 * time.Minute,
+		AppliedManifestWorkEvictionGracePeriod: 60 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Increase the default appliedmanifestwork eviction grace period from 10 minutes to 60 minutes
## Related issue(s)

Fixes #