### PR TITLE
:sparkles: Add an annotation to identify managedclusters created by spoke. (WIP)

### DIFF
--- a/pkg/registration/spoke/registration/creating_controller.go
+++ b/pkg/registration/spoke/registration/creating_controller.go
@@ -65,6 +65,10 @@ func (c *managedClusterCreatingController) sync(ctx context.Context, syncCtx fac
 		managedCluster := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: c.clusterName,
+				Annotations: map[string]string{
+					// TODO: the const key and value should be defined in th api repo. Right now, it's just for testing and feedback collecting.
+					"cluster.open-cluster-management.io/created-by": "spoke-bootstrap",
+				},
 			},
 		}
 


### PR DESCRIPTION
## Summary

We want to identify whether a managed cluster is created by the `creating_controller` on the spoke.

## Related issue(s)
N/A

## Fixes
N/A