### PR TITLE
:bug: refactor rbacfinalizercontroller to fix cluster ns is terminating after delete clustermanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ munge-csv
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 _output/
+.idea/
 
 .kubeconfig
 .hub-kubeconfig

--- a/pkg/registration/helpers/testing/testinghelpers.go
+++ b/pkg/registration/helpers/testing/testinghelpers.go
@@ -204,11 +204,12 @@ func NewManifestWork(namespace, name string, finalizers []string, deletionTimest
 	return work
 }
 
-func NewRole(namespace, name string, finalizers []string, terminated bool) *rbacv1.Role {
+func NewRole(namespace, name string, finalizers []string, labels map[string]string, terminated bool) *rbacv1.Role {
 	role := &rbacv1.Role{}
 	role.Namespace = namespace
 	role.Name = name
 	role.Finalizers = finalizers
+	role.Labels = labels
 	if terminated {
 		now := metav1.Now()
 		role.DeletionTimestamp = &now
@@ -216,11 +217,12 @@ func NewRole(namespace, name string, finalizers []string, terminated bool) *rbac
 	return role
 }
 
-func NewRoleBinding(namespace, name string, finalizers []string, terminated bool) *rbacv1.RoleBinding {
+func NewRoleBinding(namespace, name string, finalizers []string, labels map[string]string, terminated bool) *rbacv1.RoleBinding {
 	rolebinding := &rbacv1.RoleBinding{}
 	rolebinding.Namespace = namespace
 	rolebinding.Name = name
 	rolebinding.Finalizers = finalizers
+	rolebinding.Labels = labels
 	if terminated {
 		now := metav1.Now()
 		rolebinding.DeletionTimestamp = &now

--- a/pkg/registration/hub/manager.go
+++ b/pkg/registration/hub/manager.go
@@ -177,10 +177,9 @@ func (m *HubManagerOptions) RunControllerManager(ctx context.Context, controller
 	)
 
 	rbacFinalizerController := rbacfinalizerdeletion.NewFinalizeController(
-		kubeInfomers.Rbac().V1().Roles(),
-		kubeInfomers.Rbac().V1().RoleBindings(),
-		kubeInfomers.Core().V1().Namespaces().Lister(),
-		clusterInformers.Cluster().V1().ManagedClusters().Lister(),
+		kubeInfomers.Rbac().V1().RoleBindings().Lister(),
+		kubeInfomers.Core().V1().Namespaces(),
+		clusterInformers.Cluster().V1().ManagedClusters(),
 		workInformers.Work().V1().ManifestWorks().Lister(),
 		kubeClient.RbacV1(),
 		controllerContext.EventRecorder,


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)
when delete clustermanager cr, the registration-controller is deleted so fast to not remove the finalizer on work rolebinding in the cluster namespace. this PR is to refactor rbacfinalizercontroler to watch mcl and ns, remove the finalizer if there is no manifestworks when mcl or ns is deleting.
Fixes #