### PR TITLE
:sparkles: Add stale check for issues and PRs.

### DIFF
--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -1,0 +1,16 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *' # Runs at 1:30am every day
+
+# `stable` label will be added to issues and PRs that have been inactive for 60 days
+# Close stale issues and PRs after 7 days of inactivity
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'Message to comment on stale issues. If none provided, will not mark issues stale'
+          stale-pr-message: 'Message to comment on stale PRs. If none provided, will not mark PRs stale'


### PR DESCRIPTION
## Summary

This action can help us manage out-of-date issues. The official doc: https://github.com/actions/stale

`stable` label will be added to issues and PRs that have been inactive for **60** days

Close stale issues and PRs after **7** days of inactivity