### PR TITLE
:warning: enable addon management feature gate by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	k8s.io/kube-aggregator v0.27.2
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63
-	open-cluster-management.io/api v0.11.1-0.20230703133341-6d7212c2e941
+	open-cluster-management.io/api v0.11.1-0.20230714020829-ef97df044b15
 	sigs.k8s.io/controller-runtime v0.15.0
 	sigs.k8s.io/kube-storage-version-migrator v0.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1158,8 +1158,8 @@ k8s.io/utils v0.0.0-20230313181309-38a27ef9d749 h1:xMMXJlJbsU8w3V5N2FLDQ8YgU8s1E
 k8s.io/utils v0.0.0-20230313181309-38a27ef9d749/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63 h1:GCsAD1jb6wqhXTHdUM/HcWzv5b2NbZ6FxpLZcxa/jhI=
 open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63/go.mod h1:V+WUFC7GD89Lc68eXSN/FJebnCH4NjrfF44VsO0YAC8=
-open-cluster-management.io/api v0.11.1-0.20230703133341-6d7212c2e941 h1:k10Sx7Th1UDyJ+GYFqWddFq+m6U7x9MHk1g8KwrYy8Y=
-open-cluster-management.io/api v0.11.1-0.20230703133341-6d7212c2e941/go.mod h1:WgKUCJ7+Bf40DsOmH1Gdkpyj3joco+QLzrlM6Ak39zE=
+open-cluster-management.io/api v0.11.1-0.20230714020829-ef97df044b15 h1:S2a+NsIlaPNQAFruowBunN2wHnK2JfyrpnRU783WwMc=
+open-cluster-management.io/api v0.11.1-0.20230714020829-ef97df044b15/go.mod h1:WgKUCJ7+Bf40DsOmH1Gdkpyj3joco+QLzrlM6Ak39zE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/operator/helpers/helpers_test.go
+++ b/pkg/operator/helpers/helpers_test.go
@@ -1489,7 +1489,7 @@ func TestConvertToFeatureGateFlags(t *testing.T) {
 				{Feature: "ClusterClaim", Mode: operatorapiv1.FeatureGateModeTypeEnable},
 				{Feature: "AddonManagement", Mode: operatorapiv1.FeatureGateModeTypeEnable},
 			},
-			desiredFlags: []string{"--feature-gates=AddonManagement=true"},
+			desiredFlags: []string{},
 		},
 		{
 			name: "disable feature",
@@ -1497,7 +1497,7 @@ func TestConvertToFeatureGateFlags(t *testing.T) {
 				{Feature: "ClusterClaim", Mode: operatorapiv1.FeatureGateModeTypeDisable},
 				{Feature: "AddonManagement", Mode: operatorapiv1.FeatureGateModeTypeDisable},
 			},
-			desiredFlags: []string{"--feature-gates=ClusterClaim=false"},
+			desiredFlags: []string{"--feature-gates=ClusterClaim=false", "--feature-gates=AddonManagement=false"},
 		},
 		{
 			name: "invalid feature",
@@ -1514,10 +1514,10 @@ func TestConvertToFeatureGateFlags(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			flags, msg := ConvertToFeatureGateFlags("test", tc.features, ocmfeature.DefaultSpokeRegistrationFeatureGates)
 			if msg != tc.desiredMsg {
-				t.Errorf("unexpected message, got: %s, desired %s", msg, tc.desiredMsg)
+				t.Errorf("Name: %s, unexpected message, got: %s, desired %s", tc.name, msg, tc.desiredMsg)
 			}
 			if !equality.Semantic.DeepEqual(flags, tc.desiredFlags) {
-				t.Errorf("Unexpected flags, got %v, desired %v", flags, tc.desiredFlags)
+				t.Errorf("Name: %s, unexpected flags, got %v, desired %v", tc.name, flags, tc.desiredFlags)
 			}
 		})
 	}
@@ -1559,7 +1559,7 @@ func TestFeatureGateEnabled(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			enabled := FeatureGateEnabled(tc.features, ocmfeature.DefaultSpokeRegistrationFeatureGates, tc.featureName)
 			if enabled != tc.desiredResult {
-				t.Errorf("Expect feature enabled is %v, but got %v", tc.desiredResult, enabled)
+				t.Errorf("Name: %s, expect feature enabled is %v, but got %v", tc.name, tc.desiredResult, enabled)
 			}
 		})
 	}

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -359,7 +359,6 @@ func assertRegistrationDeployment(t *testing.T, actions []clienttesting.Action, 
 		"agent",
 		fmt.Sprintf("--spoke-cluster-name=%s", clusterName),
 		"--bootstrap-kubeconfig=/spoke/bootstrap/kubeconfig",
-		"--feature-gates=AddonManagement=true",
 	}
 
 	if serverURL != "" {

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -18,7 +18,6 @@ import (
 
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1apha1 "open-cluster-management.io/api/cluster/v1alpha1"
-	operatorapiv1 "open-cluster-management.io/api/operator/v1"
 
 	"open-cluster-management.io/ocm/pkg/addon/templateagent"
 	"open-cluster-management.io/ocm/test/e2e/manifests"
@@ -61,39 +60,6 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		"addon/signca_secret_role.yaml",
 		"addon/signca_secret_rolebinding.yaml",
 	}
-
-	ginkgo.BeforeAll(func() {
-		// enable addon management feature gate
-		gomega.Eventually(func() error {
-			clusterManager, err := t.OperatorClient.OperatorV1().ClusterManagers().Get(context.TODO(), "cluster-manager", metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			clusterManager.Spec.AddOnManagerConfiguration = &operatorapiv1.AddOnManagerConfiguration{
-				FeatureGates: []operatorapiv1.FeatureGate{
-					{
-						Feature: "AddonManagement",
-						Mode:    operatorapiv1.FeatureGateModeTypeEnable,
-					},
-				},
-			}
-			_, err = t.OperatorClient.OperatorV1().ClusterManagers().Update(context.TODO(), clusterManager, metav1.UpdateOptions{})
-			return err
-		}, t.EventuallyTimeout*5, t.EventuallyInterval*5).Should(gomega.Succeed())
-	})
-
-	ginkgo.AfterAll(func() {
-		// disable addon management feature gate
-		gomega.Eventually(func() error {
-			clusterManager, err := t.OperatorClient.OperatorV1().ClusterManagers().Get(context.TODO(), "cluster-manager", metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			clusterManager.Spec.AddOnManagerConfiguration = &operatorapiv1.AddOnManagerConfiguration{}
-			_, err = t.OperatorClient.OperatorV1().ClusterManagers().Update(context.TODO(), clusterManager, metav1.UpdateOptions{})
-			return err
-		}, t.EventuallyTimeout*5, t.EventuallyInterval*5).Should(gomega.Succeed())
-	})
 
 	ginkgo.BeforeEach(func() {
 		addonInstallNamespace = fmt.Sprintf("%s-addon", agentNamespace)

--- a/test/e2e/work_webhook_test.go
+++ b/test/e2e/work_webhook_test.go
@@ -127,7 +127,10 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 				_, err = impersonatedHubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 					context.Background(), work, metav1.CreateOptions{})
 				gomega.Expect(err).To(gomega.HaveOccurred())
-				gomega.Expect(errors.IsBadRequest(err)).Should(gomega.BeTrue())
+				if !errors.IsBadRequest(err) {
+					// not bad request, assert true=false to show the error message
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				}
 			})
 		})
 	})

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -73,12 +73,6 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 				},
 				ClusterName: "testcluster",
 				Namespace:   klusterletNamespace,
-				RegistrationConfiguration: &operatorapiv1.RegistrationConfiguration{FeatureGates: []operatorapiv1.FeatureGate{
-					{
-						Feature: "AddonManagement",
-						Mode:    "Enable",
-					},
-				}},
 			},
 		}
 
@@ -506,7 +500,7 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 					return false
 				}
 				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(8))
+				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(7))
 				return actual.Spec.Template.Spec.Containers[0].Args[2] == "--spoke-cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
@@ -1003,7 +997,7 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 			registrationDeployment, err := kubeClient.AppsV1().Deployments(klusterletNamespace).Get(
 				context.Background(), registrationDeploymentName, metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			gomega.Expect(registrationDeployment.Spec.Template.Spec.Containers[0].Args).Should(
+			gomega.Expect(registrationDeployment.Spec.Template.Spec.Containers[0].Args).ShouldNot(
 				gomega.ContainElement("--feature-gates=AddonManagement=true"))
 
 			ginkgo.By("Check the work-agent has the expected feature gates")

--- a/test/integration/registration/addon_lease_test.go
+++ b/test/integration/registration/addon_lease_test.go
@@ -18,7 +18,6 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
-	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/registration/spoke"
 	"open-cluster-management.io/ocm/test/integration/util"
 )
@@ -164,9 +163,6 @@ var _ = ginkgo.Describe("Addon Lease Resync", func() {
 		hubKubeconfigSecret = fmt.Sprintf("hub-kubeconfig-secret-%s", suffix)
 		hubKubeconfigDir = path.Join(util.TestDir, fmt.Sprintf("addontest-%s", suffix), "hub-kubeconfig")
 		addOnName = fmt.Sprintf("addon-%s", suffix)
-
-		err := features.SpokeMutableFeatureGate.Set("AddonManagement=true")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,

--- a/test/integration/registration/addon_registration_test.go
+++ b/test/integration/registration/addon_registration_test.go
@@ -21,7 +21,6 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
-	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/registration/clientcert"
 	"open-cluster-management.io/ocm/pkg/registration/spoke"
 	"open-cluster-management.io/ocm/test/integration/util"
@@ -38,9 +37,6 @@ var _ = ginkgo.Describe("Addon Registration", func() {
 		hubKubeconfigSecret = fmt.Sprintf("hub-kubeconfig-secret-%s", suffix)
 		hubKubeconfigDir = path.Join(util.TestDir, fmt.Sprintf("addontest-%s", suffix), "hub-kubeconfig")
 		addOnName = fmt.Sprintf("addon-%s", suffix)
-
-		err := features.SpokeMutableFeatureGate.Set("AddonManagement=true")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,

--- a/test/integration/registration/disaster_recovery_test.go
+++ b/test/integration/registration/disaster_recovery_test.go
@@ -25,7 +25,6 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
-	"open-cluster-management.io/ocm/pkg/features"
 	"open-cluster-management.io/ocm/pkg/registration/clientcert"
 	"open-cluster-management.io/ocm/pkg/registration/hub"
 	"open-cluster-management.io/ocm/pkg/registration/spoke"
@@ -89,9 +88,6 @@ var _ = ginkgo.Describe("Disaster Recovery", func() {
 	}
 
 	startRegistrationAgent := func(managedClusterName, bootstrapKubeConfigFile, hubKubeconfigSecret, hubKubeconfigDir string) context.CancelFunc {
-		err := features.SpokeMutableFeatureGate.Set("AddonManagement=true")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
 		agentOptions := &spoke.SpokeAgentOptions{
 			BootstrapKubeconfig:      bootstrapKubeConfigFile,
 			HubKubeconfigSecret:      hubKubeconfigSecret,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1426,7 +1426,7 @@ open-cluster-management.io/addon-framework/pkg/index
 open-cluster-management.io/addon-framework/pkg/manager/controllers/addonconfiguration
 open-cluster-management.io/addon-framework/pkg/manager/controllers/addonowner
 open-cluster-management.io/addon-framework/pkg/utils
-# open-cluster-management.io/api v0.11.1-0.20230703133341-6d7212c2e941
+# open-cluster-management.io/api v0.11.1-0.20230714020829-ef97df044b15
 ## explicit; go 1.19
 open-cluster-management.io/api/addon/v1alpha1
 open-cluster-management.io/api/client/addon/clientset/versioned

--- a/vendor/open-cluster-management.io/api/feature/feature.go
+++ b/vendor/open-cluster-management.io/api/feature/feature.go
@@ -74,7 +74,7 @@ const (
 // add it here.
 var DefaultSpokeRegistrationFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ClusterClaim:               {Default: true, PreRelease: featuregate.Beta},
-	AddonManagement:            {Default: false, PreRelease: featuregate.Alpha},
+	AddonManagement:            {Default: true, PreRelease: featuregate.Alpha},
 	V1beta1CSRAPICompatibility: {Default: false, PreRelease: featuregate.Alpha},
 }
 
@@ -88,7 +88,7 @@ var DefaultHubRegistrationFeatureGates = map[featuregate.Feature]featuregate.Fea
 }
 
 var DefaultHubAddonManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AddonManagement: {Default: false, PreRelease: featuregate.Alpha},
+	AddonManagement: {Default: true, PreRelease: featuregate.Alpha},
 }
 
 // DefaultHubWorkFeatureGates consists of all known acm work wehbook feature keys.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Enable the addon management feature gate by default for:
- clusterManager, will install the addon-manager component, if you want disable:
```yaml
apiVersion: operator.open-cluster-management.io/v1
kind: ClusterManager
metadata:
  name: cluster-manager
spec:
...
  addOnManagerConfiguration:
    featureGates:
    - feature: AddonManagement
      mode: Disable
```
- klusterlet, will enable the addon management feature for the registration-agent, if you want to disable:
```yaml
apiVersion: operator.open-cluster-management.io/v1
kind: Klusterlet
metadata:
  name: klusterlet
spec:
...
  registrationConfiguration:
    featureGates:
    - feature: AddonManagement
      mode: Disable
```

## Related issue(s)

Fixes #