### PR TITLE
:bug: Failed to sync sa work-controller-sa in cluster manger hosted mode

### DIFF
--- a/deploy/cluster-manager/config/rbac/cluster_role.yaml
+++ b/deploy/cluster-manager/config/rbac/cluster_role.yaml
@@ -19,6 +19,7 @@ rules:
     - "work-webhook-sa-kubeconfig"
     - "placement-controller-sa-kubeconfig"
     - "work-controller-sa-kubeconfig"
+    - "addon-manager-controller-sa-kubeconfig"
     - "external-hub-kubeconfig"
 - apiGroups: [""]
   resources: ["secrets"]

--- a/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
@@ -137,6 +137,7 @@ spec:
           - work-webhook-sa-kubeconfig
           - placement-controller-sa-kubeconfig
           - work-controller-sa-kubeconfig
+          - addon-manager-controller-sa-kubeconfig
           - external-hub-kubeconfig
           resources:
           - secrets

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
@@ -263,7 +263,10 @@ func setup(t *testing.T, tc *testController, cd []runtime.Object, crds ...runtim
 	tc.clusterManagerController.generateHubClusterClients = func(hubKubeConfig *rest.Config) (kubernetes.Interface, apiextensionsclient.Interface, migrationclient.StorageVersionMigrationsGetter, error) {
 		return fakeHubKubeClient, fakeAPIExtensionClient, fakeMigrationClient.MigrationV1alpha1(), nil
 	}
-	tc.clusterManagerController.ensureSAKubeconfigs = func(ctx context.Context, clusterManagerName, clusterManagerNamespace string, hubConfig *rest.Config, hubClient, managementClient kubernetes.Interface, recorder events.Recorder) error {
+	tc.clusterManagerController.ensureSAKubeconfigs = func(ctx context.Context,
+		clusterManagerName, clusterManagerNamespace string, hubConfig *rest.Config,
+		hubClient, managementClient kubernetes.Interface, recorder events.Recorder,
+		mwctrEnabled, addonManagerEnabled bool) error {
 		return nil
 	}
 }

--- a/test/integration/operator/integration_suite_test.go
+++ b/test/integration/operator/integration_suite_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
+	"open-cluster-management.io/api/feature"
 	operatorapiv1 "open-cluster-management.io/api/operator/v1"
 
 	"open-cluster-management.io/ocm/pkg/operator/operators/klusterlet/controllers/bootstrapcontroller"
@@ -142,12 +143,12 @@ var _ = ginkgo.BeforeSuite(func() {
 			WorkConfiguration: &operatorapiv1.WorkConfiguration{
 				FeatureGates: []operatorapiv1.FeatureGate{
 					{
-						Feature: "NilExecutorValidating",
-						Mode:    "Enable",
+						Feature: string(feature.NilExecutorValidating),
+						Mode:    operatorapiv1.FeatureGateModeTypeEnable,
 					},
 					{
-						Feature: "ManifestWorkReplicaSet",
-						Mode:    "Enable",
+						Feature: string(feature.ManifestWorkReplicaSet),
+						Mode:    operatorapiv1.FeatureGateModeTypeEnable,
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. Fix issue for cluster manger in hosted mode:
```
apiVersion: operator.open-cluster-management.io/v1
kind: ClusterManager
metadata:
  name: cluster-manager
spec:
  addOnManagerImagePullSpec: quay.io/open-cluster-management/addon-manager:latest
  deployOption:
    hosted:
      registrationWebhookConfiguration:
        address: management-control-plane
        port: 30443
      workWebhookConfiguration:
        address: management-control-plane
        port: 31443
    mode: Hosted
  placementImagePullSpec: quay.io/open-cluster-management/placement:latest
  registrationImagePullSpec: quay.io/open-cluster-management/registration:latest
  workImagePullSpec: quay.io/open-cluster-management/work:latest
status:
  conditions:
  - lastTransitionTime: "2023-07-14T07:51:04Z"
    message: 'Failed to sync service account: serviceaccounts "work-controller-sa"
      not found'
    reason: ServiceAccountSyncFailed
    status: "False"
    type: Applied
```

cluster-manager logs:
```
E0714 07:51:54.910585       1 base_controller.go:270] "ClusterManagerController" controller failed to sync "cluster-manager", err: serviceaccounts "work-controller-sa" not found
E0714 07:52:37.108738       1 base_controller.go:270] "ClusterManagerController" controller failed to sync "cluster-manager", err: serviceaccounts "work-controller-sa" not found
E0714 07:54:00.264383       1 base_controller.go:270] "ClusterManagerController" controller failed to sync "cluster-manager", err: serviceaccounts "work-controller-sa" not found
```

2. add permission for cluster manager to get secret `addon-manager-controller-sa-kubeconfig`

3. fix flaky integration test
## Related issue(s)

Fixes #