### PR TITLE
:sparkles: Support override addon images by the cluster's annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	k8s.io/klog/v2 v2.90.1
 	k8s.io/kube-aggregator v0.27.2
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
-	open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63
+	open-cluster-management.io/addon-framework v0.7.1-0.20230803002113-eea76f8f5ad7
 	open-cluster-management.io/api v0.11.1-0.20230727093131-915f5826cff9
 	sigs.k8s.io/controller-runtime v0.15.0
 	sigs.k8s.io/kube-storage-version-migrator v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	k8s.io/kube-aggregator v0.27.2
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63
-	open-cluster-management.io/api v0.11.1-0.20230725140722-c0c9fb59d249
+	open-cluster-management.io/api v0.11.1-0.20230727093131-915f5826cff9
 	sigs.k8s.io/controller-runtime v0.15.0
 	sigs.k8s.io/kube-storage-version-migrator v0.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1156,8 +1156,8 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20230313181309-38a27ef9d749 h1:xMMXJlJbsU8w3V5N2FLDQ8YgU8s1EoULdbQBcAeNJkY=
 k8s.io/utils v0.0.0-20230313181309-38a27ef9d749/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63 h1:GCsAD1jb6wqhXTHdUM/HcWzv5b2NbZ6FxpLZcxa/jhI=
-open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63/go.mod h1:V+WUFC7GD89Lc68eXSN/FJebnCH4NjrfF44VsO0YAC8=
+open-cluster-management.io/addon-framework v0.7.1-0.20230803002113-eea76f8f5ad7 h1:GozqvUtekO4Zg90wLih3CA/ZYKLJlGKX+vL990U8DoQ=
+open-cluster-management.io/addon-framework v0.7.1-0.20230803002113-eea76f8f5ad7/go.mod h1:gLGpXkdwAzzV+JB5eQPNHbZFJwp7HsKSSwgqOxGNVCw=
 open-cluster-management.io/api v0.11.1-0.20230727093131-915f5826cff9 h1:P5yjl8w09JYsTE1D6JV6y1vY9X2bBN8m494ZYg9HoyY=
 open-cluster-management.io/api v0.11.1-0.20230727093131-915f5826cff9/go.mod h1:WgKUCJ7+Bf40DsOmH1Gdkpyj3joco+QLzrlM6Ak39zE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/go.sum
+++ b/go.sum
@@ -1158,8 +1158,8 @@ k8s.io/utils v0.0.0-20230313181309-38a27ef9d749 h1:xMMXJlJbsU8w3V5N2FLDQ8YgU8s1E
 k8s.io/utils v0.0.0-20230313181309-38a27ef9d749/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63 h1:GCsAD1jb6wqhXTHdUM/HcWzv5b2NbZ6FxpLZcxa/jhI=
 open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63/go.mod h1:V+WUFC7GD89Lc68eXSN/FJebnCH4NjrfF44VsO0YAC8=
-open-cluster-management.io/api v0.11.1-0.20230725140722-c0c9fb59d249 h1:Q3UCh10q8w0k/sx0YDer6svU44/puTZMmxVVFndGdUs=
-open-cluster-management.io/api v0.11.1-0.20230725140722-c0c9fb59d249/go.mod h1:WgKUCJ7+Bf40DsOmH1Gdkpyj3joco+QLzrlM6Ak39zE=
+open-cluster-management.io/api v0.11.1-0.20230727093131-915f5826cff9 h1:P5yjl8w09JYsTE1D6JV6y1vY9X2bBN8m494ZYg9HoyY=
+open-cluster-management.io/api v0.11.1-0.20230727093131-915f5826cff9/go.mod h1:WgKUCJ7+Bf40DsOmH1Gdkpyj3joco+QLzrlM6Ak39zE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/addon/controllers/addontemplate/controller.go
+++ b/pkg/addon/controllers/addontemplate/controller.go
@@ -187,6 +187,8 @@ func (c *addonTemplateController) runController(
 		c.addonClient,
 		c.addonInformers,
 		kubeInformers.Rbac().V1().RoleBindings().Lister(),
+		// image overrides from cluster annotation has lower priority than from the addonDeploymentConfig
+		templateagent.GetAddOnRegistriesPrivateValuesFromClusterAnnotation,
 		addonfactory.GetAddOnDeploymentConfigValues(
 			addonfactory.NewAddOnDeploymentConfigGetter(c.addonClient),
 			addonfactory.ToAddOnCustomizedVariableValues,

--- a/pkg/addon/manager.go
+++ b/pkg/addon/manager.go
@@ -84,31 +84,21 @@ func RunManager(ctx context.Context, controllerContext *controllercmd.Controller
 		return err
 	}
 
-	// addonConfigController
 	err = addonInformerFactory.Addon().V1alpha1().ManagedClusterAddOns().Informer().AddIndexers(
-		cache.Indexers{index.AddonByConfig: index.IndexAddonByConfig},
+		cache.Indexers{
+			index.ManagedClusterAddonByNamespace: index.IndexManagedClusterAddonByNamespace, // addonDeployController
+			index.ManagedClusterAddonByName:      index.IndexManagedClusterAddonByName,      // addonConfigController
+			index.AddonByConfig:                  index.IndexAddonByConfig,                  // addonConfigController
+		},
 	)
 	if err != nil {
 		return err
 	}
-	// managementAddonConfigController
-	err = addonInformerFactory.Addon().V1alpha1().ClusterManagementAddOns().Informer().AddIndexers(
-		cache.Indexers{index.ClusterManagementAddonByConfig: index.IndexClusterManagementAddonByConfig})
-	if err != nil {
-		return err
-	}
 
 	err = addonInformerFactory.Addon().V1alpha1().ClusterManagementAddOns().Informer().AddIndexers(
 		cache.Indexers{
-			index.ClusterManagementAddonByPlacement: index.IndexClusterManagementAddonByPlacement,
-		})
-	if err != nil {
-		return err
-	}
-
-	err = addonInformerFactory.Addon().V1alpha1().ManagedClusterAddOns().Informer().AddIndexers(
-		cache.Indexers{
-			index.ManagedClusterAddonByName: index.IndexManagedClusterAddonByName,
+			index.ClusterManagementAddonByConfig:    index.IndexClusterManagementAddonByConfig,    // managementAddonConfigController
+			index.ClusterManagementAddonByPlacement: index.IndexClusterManagementAddonByPlacement, // addonConfigController
 		})
 	if err != nil {
 		return err

--- a/pkg/addon/templateagent/template_agent.go
+++ b/pkg/addon/templateagent/template_agent.go
@@ -116,6 +116,7 @@ func (a *CRDTemplateAgentAddon) GetAgentAddonOptions() agent.AgentAddonOptions {
 			CSRApproveCheck:   a.TemplateCSRApproveCheckFunc(),
 			CSRSign:           a.TemplateCSRSignFunc(),
 		},
+		AgentDeployTriggerClusterFilter: utils.ClusterImageRegistriesAnnotationChanged,
 	}
 }
 

--- a/pkg/addon/templateagent/values.go
+++ b/pkg/addon/templateagent/values.go
@@ -158,29 +158,13 @@ func hubKubeconfigPath() string {
 	return "/managed/hub-kubeconfig/kubeconfig"
 }
 
-const (
-	// ClusterImageRegistriesAnnotation represent the annotation key for image registries, the vale of the annotation
-	// should be a json string like this:
-	//
-	// {
-	//   "registries": [
-	//     {
-	//       "source": "quay.io/ocm",
-	//       "mirrors": "quay.io/open-cluster-management"
-	//     }
-	//   ]
-	// }
-	// TODO: move this to the api repo
-	ClusterImageRegistriesAnnotation = "open-cluster-management.io/image-registries"
-)
-
 func GetAddOnRegistriesPrivateValuesFromClusterAnnotation(
 	cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
 	values := map[string]interface{}{}
 	annotations := cluster.GetAnnotations()
-	klog.V(4).Infof("Try to get image registries from annotation %v", annotations[ClusterImageRegistriesAnnotation])
-	if len(annotations[ClusterImageRegistriesAnnotation]) == 0 {
+	klog.V(4).Infof("Try to get image registries from annotation %v", annotations[clusterv1.ClusterImageRegistriesAnnotationKey])
+	if len(annotations[clusterv1.ClusterImageRegistriesAnnotationKey]) == 0 {
 		return values, nil
 	}
 	type ImageRegistries struct {
@@ -188,9 +172,9 @@ func GetAddOnRegistriesPrivateValuesFromClusterAnnotation(
 	}
 
 	imageRegistries := ImageRegistries{}
-	err := json.Unmarshal([]byte(annotations[ClusterImageRegistriesAnnotation]), &imageRegistries)
+	err := json.Unmarshal([]byte(annotations[clusterv1.ClusterImageRegistriesAnnotationKey]), &imageRegistries)
 	if err != nil {
-		klog.Errorf("failed to unmarshal the annotation %v, err %v", annotations[ClusterImageRegistriesAnnotation], err)
+		klog.Errorf("failed to unmarshal the annotation %v, err %v", annotations[clusterv1.ClusterImageRegistriesAnnotationKey], err)
 		return values, err
 	}
 

--- a/pkg/addon/templateagent/values.go
+++ b/pkg/addon/templateagent/values.go
@@ -1,8 +1,11 @@
 package templateagent
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
+
+	"k8s.io/klog/v2"
 
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
@@ -52,7 +55,7 @@ func (a *CRDTemplateAgentAddon) getValues(
 
 	defaultSortedKeys, defaultValues, err := a.getDefaultValues(cluster, addon, template)
 	if err != nil {
-		return presetValues, overrideValues, privateValues, nil
+		return presetValues, overrideValues, privateValues, err
 	}
 	overrideValues = addonfactory.MergeValues(overrideValues, defaultValues)
 
@@ -153,4 +156,50 @@ func (a *CRDTemplateAgentAddon) sortValueKeys(value addonfactory.Values) []strin
 
 func hubKubeconfigPath() string {
 	return "/managed/hub-kubeconfig/kubeconfig"
+}
+
+const (
+	// ClusterImageRegistriesAnnotation represent the annotation key for image registries, the vale of the annotation
+	// should be a json string like this:
+	//
+	// {
+	//   "registries": [
+	//     {
+	//       "source": "quay.io/ocm",
+	//       "mirrors": "quay.io/open-cluster-management"
+	//     }
+	//   ]
+	// }
+	// TODO: move this to the api repo
+	ClusterImageRegistriesAnnotation = "open-cluster-management.io/image-registries"
+)
+
+func GetAddOnRegistriesPrivateValuesFromClusterAnnotation(
+	cluster *clusterv1.ManagedCluster,
+	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
+	values := map[string]interface{}{}
+	annotations := cluster.GetAnnotations()
+	klog.V(4).Infof("Try to get image registries from annotation %v", annotations[ClusterImageRegistriesAnnotation])
+	if len(annotations[ClusterImageRegistriesAnnotation]) == 0 {
+		return values, nil
+	}
+	type ImageRegistries struct {
+		Registries []addonapiv1alpha1.ImageMirror `json:"registries"`
+	}
+
+	imageRegistries := ImageRegistries{}
+	err := json.Unmarshal([]byte(annotations[ClusterImageRegistriesAnnotation]), &imageRegistries)
+	if err != nil {
+		klog.Errorf("failed to unmarshal the annotation %v, err %v", annotations[ClusterImageRegistriesAnnotation], err)
+		return values, err
+	}
+
+	if len(imageRegistries.Registries) == 0 {
+		return values, nil
+	}
+
+	klog.V(4).Infof("Image registries values %v", imageRegistries.Registries)
+	return addonfactory.Values{
+		RegistriesPrivateValueKey: imageRegistries.Registries,
+	}, nil
 }

--- a/pkg/addon/templateagent/values_test.go
+++ b/pkg/addon/templateagent/values_test.go
@@ -29,7 +29,7 @@ func TestGetAddOnRegistriesPrivateValuesFromClusterAnnotation(t *testing.T) {
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ClusterImageRegistriesAnnotation: `{"registries-test":[{"mirror-test":"quay.io/ocm","source-test":"quay-test.io/ocm"}]}`,
+						clusterv1.ClusterImageRegistriesAnnotationKey: `{"registries-test":[{"mirror-test":"quay.io/ocm","source-test":"quay-test.io/ocm"}]}`,
 					},
 				},
 			},
@@ -40,7 +40,7 @@ func TestGetAddOnRegistriesPrivateValuesFromClusterAnnotation(t *testing.T) {
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ClusterImageRegistriesAnnotation: `{"registries":`,
+						clusterv1.ClusterImageRegistriesAnnotationKey: `{"registries":`,
 					},
 				},
 			},
@@ -52,7 +52,7 @@ func TestGetAddOnRegistriesPrivateValuesFromClusterAnnotation(t *testing.T) {
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ClusterImageRegistriesAnnotation: `{"registries":[{"mirror":"quay.io/ocm","source":"quay-test.io/ocm"}]}`,
+						clusterv1.ClusterImageRegistriesAnnotationKey: `{"registries":[{"mirror":"quay.io/ocm","source":"quay-test.io/ocm"}]}`,
 					},
 				},
 			},
@@ -70,7 +70,7 @@ func TestGetAddOnRegistriesPrivateValuesFromClusterAnnotation(t *testing.T) {
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ClusterImageRegistriesAnnotation: `{"registries":[{"mirror":"quay.io/ocm/test","source":"quay.io/open-cluster-management/test"}]}`,
+						clusterv1.ClusterImageRegistriesAnnotationKey: `{"registries":[{"mirror":"quay.io/ocm/test","source":"quay.io/open-cluster-management/test"}]}`,
 					},
 				},
 			},

--- a/pkg/addon/templateagent/values_test.go
+++ b/pkg/addon/templateagent/values_test.go
@@ -1,0 +1,81 @@
+package templateagent
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+func TestGetAddOnRegistriesPrivateValuesFromClusterAnnotation(t *testing.T) {
+	cases := []struct {
+		name           string
+		cluster        *clusterv1.ManagedCluster
+		expectedValues addonfactory.Values
+		expectedError  string
+	}{
+		{
+			name:           "no values",
+			cluster:        &clusterv1.ManagedCluster{},
+			expectedValues: addonfactory.Values{},
+		},
+		{
+			name: "not expected annotation",
+			cluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ClusterImageRegistriesAnnotation: `{"registries-test":[{"mirror-test":"quay.io/open-cluster-management","source-test":"quay-test.io/open-cluster-management"}]}`,
+					},
+				},
+			},
+			expectedValues: addonfactory.Values{},
+		},
+		{
+			name: "annotation invalid",
+			cluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ClusterImageRegistriesAnnotation: `{"registries":`,
+					},
+				},
+			},
+			expectedValues: addonfactory.Values{},
+			expectedError:  "unexpected end of JSON input",
+		},
+		{
+			name: "override registries",
+			cluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ClusterImageRegistriesAnnotation: `{"registries":[{"mirror":"quay.io/open-cluster-management","source":"quay-test.io/open-cluster-management"}]}`,
+					},
+				},
+			},
+			expectedValues: addonfactory.Values{
+				RegistriesPrivateValueKey: []addonapiv1alpha1.ImageMirror{
+					{
+						Source: "quay-test.io/open-cluster-management",
+						Mirror: "quay.io/open-cluster-management",
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			values, err := GetAddOnRegistriesPrivateValuesFromClusterAnnotation(c.cluster, nil)
+			if err != nil || len(c.expectedError) > 0 {
+				assert.ErrorContains(t, err, c.expectedError, "expected error: %v, got: %v", c.expectedError, err)
+			}
+
+			if !reflect.DeepEqual(values, c.expectedValues) {
+				t.Errorf("expected values: %v, got: %v", c.expectedValues, values)
+			}
+		})
+	}
+}

--- a/pkg/addon/templateagent/values_test.go
+++ b/pkg/addon/templateagent/values_test.go
@@ -29,7 +29,7 @@ func TestGetAddOnRegistriesPrivateValuesFromClusterAnnotation(t *testing.T) {
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ClusterImageRegistriesAnnotation: `{"registries-test":[{"mirror-test":"quay.io/open-cluster-management","source-test":"quay-test.io/open-cluster-management"}]}`,
+						ClusterImageRegistriesAnnotation: `{"registries-test":[{"mirror-test":"quay.io/ocm","source-test":"quay-test.io/ocm"}]}`,
 					},
 				},
 			},
@@ -52,20 +52,39 @@ func TestGetAddOnRegistriesPrivateValuesFromClusterAnnotation(t *testing.T) {
 			cluster: &clusterv1.ManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						ClusterImageRegistriesAnnotation: `{"registries":[{"mirror":"quay.io/open-cluster-management","source":"quay-test.io/open-cluster-management"}]}`,
+						ClusterImageRegistriesAnnotation: `{"registries":[{"mirror":"quay.io/ocm","source":"quay-test.io/ocm"}]}`,
 					},
 				},
 			},
 			expectedValues: addonfactory.Values{
 				RegistriesPrivateValueKey: []addonapiv1alpha1.ImageMirror{
 					{
-						Source: "quay-test.io/open-cluster-management",
-						Mirror: "quay.io/open-cluster-management",
+						Source: "quay-test.io/ocm",
+						Mirror: "quay.io/ocm",
+					},
+				},
+			},
+		},
+		{
+			name: "override image",
+			cluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ClusterImageRegistriesAnnotation: `{"registries":[{"mirror":"quay.io/ocm/test","source":"quay.io/open-cluster-management/test"}]}`,
+					},
+				},
+			},
+			expectedValues: addonfactory.Values{
+				RegistriesPrivateValueKey: []addonapiv1alpha1.ImageMirror{
+					{
+						Source: "quay.io/open-cluster-management/test",
+						Mirror: "quay.io/ocm/test",
 					},
 				},
 			},
 		},
 	}
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			values, err := GetAddOnRegistriesPrivateValuesFromClusterAnnotation(c.cluster, nil)

--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -7,6 +7,8 @@ KUBECTL?=kubectl
 KUBECONFIG?=./.kubeconfig
 HUB_KUBECONFIG?=./.hub-kubeconfig
 KLUSTERLET_DEPLOY_MODE?=Default
+MANAGED_CLUSTER_NAME?=cluster1
+KLUSTERLET_NAME?=klusterlet
 
 SED_CMD:=sed
 ifeq ($(GOHOSTOS),darwin)

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/klog/v2"
 
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1apha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	"open-cluster-management.io/ocm/pkg/addon/templateagent"
 	"open-cluster-management.io/ocm/test/e2e/manifests"
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 
 	s := runtime.NewScheme()
 	_ = scheme.AddToScheme(s)
-	_ = clusterv1apha1.Install(s)
+	_ = clusterv1.Install(s)
 	_ = addonapiv1alpha1.Install(s)
 
 	templateResources := []string{

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -459,30 +459,6 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 			return err
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
-		// TODO: make the addon-framework deploy controller watch the ManagedCluster resurce, after that
-		// we can remove this
-		ginkgo.By("UPDATE ManagedClusterAddOn to trigger reconcile")
-		gomega.Eventually(func() error {
-			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(
-				context.Background(), addOnName, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			newAddon := addon.DeepCopy()
-			annotations := addon.Annotations
-			if annotations == nil {
-				annotations = make(map[string]string)
-			}
-			annotations["test"] = rand.String(6)
-			newAddon.Annotations = annotations
-			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Update(
-				context.Background(), newAddon, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
-			return nil
-		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-
 		ginkgo.By("Make sure addon is configured")
 		gomega.Eventually(func() error {
 			agentDeploy, err := t.SpokeKubeClient.AppsV1().Deployments(addonInstallNamespace).Get(
@@ -518,26 +494,6 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 			_, err = t.ClusterClient.ClusterV1().ManagedClusters().Update(
 				context.Background(), newCluster, metav1.UpdateOptions{})
 			return err
-		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-
-		// TODO: make the addon-framework deploy controller watch the ManagedCluster resurce, after that
-		// we can remove this
-		ginkgo.By("UPDATE ManagedClusterAddOn to trigger reconcile")
-		gomega.Eventually(func() error {
-			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(
-				context.Background(), addOnName, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			newAddon := addon.DeepCopy()
-
-			delete(newAddon.Annotations, "test")
-			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Update(
-				context.Background(), newAddon, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
-			return nil
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Make sure addon config is restored")

--- a/test/integration/registration/spokeagent_restart_test.go
+++ b/test/integration/registration/spokeagent_restart_test.go
@@ -176,20 +176,16 @@ var _ = ginkgo.Describe("Agent Restart", func() {
 
 		ginkgo.By("Check existence of csr and ManagedCluster")
 		// the csr should be created
-		gomega.Eventually(func() bool {
-			if _, err := util.FindUnapprovedSpokeCSR(kubeClient, managedClusterName); err != nil {
-				return false
-			}
-			return true
-		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() error {
+			_, err := util.FindUnapprovedSpokeCSR(kubeClient, managedClusterName)
+			return err
+		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 		// the spoke cluster should be created
-		gomega.Eventually(func() bool {
-			if _, err := util.GetManagedCluster(clusterClient, managedClusterName); err != nil {
-				return false
-			}
-			return true
-		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() error {
+			_, err := util.GetManagedCluster(clusterClient, managedClusterName)
+			return err
+		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Accept ManagedCluster and approve csr")
 		err = util.AcceptManagedCluster(clusterClient, managedClusterName)
@@ -200,12 +196,10 @@ var _ = ginkgo.Describe("Agent Restart", func() {
 
 		ginkgo.By("Check if hub kubeconfig secret is updated")
 		// the hub kubeconfig secret should be filled after the csr is approved
-		gomega.Eventually(func() bool {
-			if _, err := util.GetFilledHubKubeConfigSecret(kubeClient, testNamespace, hubKubeconfigSecret); err != nil {
-				return false
-			}
-			return true
-		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() error {
+			_, err := util.GetFilledHubKubeConfigSecret(kubeClient, testNamespace, hubKubeconfigSecret)
+			return err
+		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Check if ManagedCluster joins the hub")
 		// the spoke cluster should have joined condition finally
@@ -239,20 +233,16 @@ var _ = ginkgo.Describe("Agent Restart", func() {
 
 		ginkgo.By("Check the existence of csr and the new ManagedCluster")
 		// the csr should be created
-		gomega.Eventually(func() bool {
-			if _, err := util.FindUnapprovedSpokeCSR(kubeClient, managedClusterName); err != nil {
-				return false
-			}
-			return true
-		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() error {
+			_, err := util.FindUnapprovedSpokeCSR(kubeClient, managedClusterName)
+			return err
+		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 		// the spoke cluster should be created
-		gomega.Eventually(func() bool {
-			if _, err := util.GetManagedCluster(clusterClient, managedClusterName); err != nil {
-				return false
-			}
-			return true
-		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() error {
+			_, err := util.GetManagedCluster(clusterClient, managedClusterName)
+			return err
+		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Accept the new ManagedCluster and approve csr")
 		err = util.AcceptManagedCluster(clusterClient, managedClusterName)
@@ -263,12 +253,10 @@ var _ = ginkgo.Describe("Agent Restart", func() {
 
 		ginkgo.By("Check if hub kubeconfig secret is updated")
 		// the hub kubeconfig secret should be filled after the csr is approved
-		gomega.Eventually(func() bool {
-			if _, err := util.GetFilledHubKubeConfigSecret(kubeClient, testNamespace, hubKubeconfigSecret); err != nil {
-				return false
-			}
-			return true
-		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+		gomega.Eventually(func() error {
+			_, err := util.GetFilledHubKubeConfigSecret(kubeClient, testNamespace, hubKubeconfigSecret)
+			return err
+		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Check if the new ManagedCluster joins the hub")
 		// the spoke cluster should have joined condition finally

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1406,7 +1406,7 @@ k8s.io/utils/path
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
-# open-cluster-management.io/addon-framework v0.7.1-0.20230705031704-6a328fa5cd63
+# open-cluster-management.io/addon-framework v0.7.1-0.20230803002113-eea76f8f5ad7
 ## explicit; go 1.19
 open-cluster-management.io/addon-framework/pkg/addonfactory
 open-cluster-management.io/addon-framework/pkg/addonmanager

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1426,7 +1426,7 @@ open-cluster-management.io/addon-framework/pkg/index
 open-cluster-management.io/addon-framework/pkg/manager/controllers/addonconfiguration
 open-cluster-management.io/addon-framework/pkg/manager/controllers/addonowner
 open-cluster-management.io/addon-framework/pkg/utils
-# open-cluster-management.io/api v0.11.1-0.20230725140722-c0c9fb59d249
+# open-cluster-management.io/api v0.11.1-0.20230727093131-915f5826cff9
 ## explicit; go 1.19
 open-cluster-management.io/api/addon/v1alpha1
 open-cluster-management.io/api/client/addon/clientset/versioned

--- a/vendor/open-cluster-management.io/addon-framework/pkg/addonfactory/addondeploymentconfig.go
+++ b/vendor/open-cluster-management.io/addon-framework/pkg/addonfactory/addondeploymentconfig.go
@@ -2,17 +2,27 @@ package addonfactory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	"open-cluster-management.io/addon-framework/pkg/utils"
 )
+
+// Deprecated: use AddOnDeploymentConfigGVR in package "open-cluster-management.io/addon-framework/pkg/utils" instead.
+var AddOnDeploymentConfigGVR = schema.GroupVersionResource{
+	Group:    "addon.open-cluster-management.io",
+	Version:  "v1alpha1",
+	Resource: "addondeploymentconfigs",
+}
 
 // AddOnDeloymentConfigToValuesFunc transform the AddOnDeploymentConfig object into Values object
 // The transformation logic depends on the definition of the addon template
@@ -229,38 +239,149 @@ func ToAddOnDeploymentConfigValues(config addonapiv1alpha1.AddOnDeploymentConfig
 // the imageKey is "helloWorldImage", the image is "quay.io/open-cluster-management/addon-agent:v1"
 // after transformed, the Values object will be: {"helloWorldImage": "quay.io/ocm/addon-agent:v1"}
 //
-// Note: the imageKey can support the nested key, for example: "global.imageOverrides.helloWorldImage", the output
-// will be: {"global": {"imageOverrides": {"helloWorldImage": "quay.io/ocm/addon-agent:v1"}}}
+// Note:
+//   - the imageKey can support the nested key, for example: "global.imageOverrides.helloWorldImage", the output
+//     will be: {"global": {"imageOverrides": {"helloWorldImage": "quay.io/ocm/addon-agent:v1"}}}
+//   - If you want to override the image with the value from the AddOnDeploymentConfig.spec.Registries first, and
+//     if it is not changed, then override it with the value from the cluster annotation, you can use the function
+//     GetAgentImageValues instead.
 func ToImageOverrideValuesFunc(imageKey, image string) AddOnDeploymentConfigToValuesFunc {
 	return func(config addonapiv1alpha1.AddOnDeploymentConfig) (Values, error) {
-		if len(imageKey) == 0 {
-			return nil, fmt.Errorf("imageKey is empty")
-		}
-		if len(image) == 0 {
-			return nil, fmt.Errorf("image is empty")
-		}
-
-		nestedMap := make(map[string]interface{})
-
-		keys := strings.Split(imageKey, ".")
-		currentMap := nestedMap
-
-		for i := 0; i < len(keys)-1; i++ {
-			key := keys[i]
-			nextMap := make(map[string]interface{})
-			currentMap[key] = nextMap
-			currentMap = nextMap
-		}
-
-		lastKey := keys[len(keys)-1]
-		currentMap[lastKey] = image
-
-		if config.Spec.Registries != nil {
-			currentMap[lastKey] = OverrideImage(config.Spec.Registries, image)
-		}
-
-		return nestedMap, nil
+		values, _, err := overrideImageWithKeyValue(imageKey, image, getRegistriesFromAddonDeploymentConfig(config))
+		return values, err
 	}
+}
+
+func getRegistriesFromAddonDeploymentConfig(
+	config addonapiv1alpha1.AddOnDeploymentConfig) func() ([]addonapiv1alpha1.ImageMirror, error) {
+	return func() ([]addonapiv1alpha1.ImageMirror, error) {
+		return config.Spec.Registries, nil
+	}
+}
+
+func getRegistriesFromClusterAnnotation(
+	cluster *clusterv1.ManagedCluster) func() ([]addonapiv1alpha1.ImageMirror, error) {
+	return func() ([]addonapiv1alpha1.ImageMirror, error) {
+		if cluster == nil {
+			return nil, nil
+		}
+		annotations := cluster.GetAnnotations()
+		klog.V(4).Infof("Try to get image registries from annotation %v", annotations[clusterv1.ClusterImageRegistriesAnnotationKey])
+		if len(annotations[clusterv1.ClusterImageRegistriesAnnotationKey]) == 0 {
+			return nil, nil
+		}
+		type ImageRegistries struct {
+			Registries []addonapiv1alpha1.ImageMirror `json:"registries"`
+		}
+
+		imageRegistries := ImageRegistries{}
+		err := json.Unmarshal([]byte(annotations[clusterv1.ClusterImageRegistriesAnnotationKey]), &imageRegistries)
+		if err != nil {
+			klog.Errorf("failed to unmarshal the annotation %v, err %v", annotations[clusterv1.ClusterImageRegistriesAnnotationKey], err)
+			return nil, err
+		}
+		return imageRegistries.Registries, nil
+	}
+}
+
+// GetAgentImageValues return a func that can use two ways, AddOnDeploymentConfig.spec.Registries and annotation on the
+// ManagedCluster, to override image, then return the overridden value with key imageKey.
+// For example:
+//
+//  1. configure the image registries with the spec of the AddOnDeploymentConfig, if the registries in the spec is:
+//     {...,"spec":{"registries":[{"mirror":"quay.io/ocm/addon-agent","source":"quay.io/open-cluster-management/addon-agent"}]}}
+//     the "imageKey" is "helloWorldImage", the "image" is "quay.io/open-cluster-management/addon-agent:v1"
+//     after transformed, the Values object will be: {"helloWorldImage": "quay.io/ocm/addon-agent:v1"}
+//
+//  2. configure the image registries with the annotation "open-cluster-management.io/image-registries" on the
+//     ManagedCluster, if the annotation on the managed cluster resource is:
+//     "open-cluster-management.io/image-registries": '{"registries":[{"mirror":"quay.io/ocm","source":"quay.io/open-cluster-management"}]}'
+//     the "imageKey" is "helloWorldImage", the "image" is "quay.io/open-cluster-management/addon-agent:v1"
+//     after transformed, the Values object will be: {"helloWorldImage": "quay.io/ocm/addon-agent:v1"}
+//
+// Note:
+//   - the imageKey can support the nested key, for example: "global.imageOverrides.helloWorldImage", the output
+//     will be: {"global": {"imageOverrides": {"helloWorldImage": "quay.io/ocm/addon-agent:v1"}}}
+//   - Image registries configured in the addonDeploymentConfig will take precedence over the managed cluster annotation
+func GetAgentImageValues(getter AddOnDeploymentConfigGetter, imageKey, image string) GetValuesFunc {
+	return func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) (Values, error) {
+
+		// Get image from AddOnDeploymentConfig
+		for _, config := range addon.Status.ConfigReferences {
+			if config.ConfigGroupResource.Group != utils.AddOnDeploymentConfigGVR.Group ||
+				config.ConfigGroupResource.Resource != utils.AddOnDeploymentConfigGVR.Resource {
+				continue
+			}
+
+			addOnDeploymentConfig, err := getter.Get(context.Background(), config.Namespace, config.Name)
+			if err != nil {
+				return nil, err
+			}
+
+			values, overrode, err := overrideImageWithKeyValue(imageKey, image,
+				getRegistriesFromAddonDeploymentConfig(*addOnDeploymentConfig))
+			if err != nil {
+				return values, err
+			}
+
+			// if the image is overrode by AddOnDeploymentConfig, use the overrode value
+			if overrode {
+				klog.V(4).Infof("Overrode image %v with %v", image, values)
+				return values, nil
+			}
+		}
+
+		// If the image is not overrode by AddOnDeploymentConfig, try to get image from cluster annotation
+		values, _, err := overrideImageWithKeyValue(imageKey, image, getRegistriesFromClusterAnnotation(cluster))
+		if err != nil {
+			return values, err
+		}
+		return values, nil
+	}
+}
+
+func overrideImageWithKeyValue(imageKey, image string, getRegistries func() ([]addonapiv1alpha1.ImageMirror, error),
+) (Values, bool, error) {
+
+	if len(imageKey) == 0 {
+		return nil, false, fmt.Errorf("imageKey is empty")
+	}
+	if len(image) == 0 {
+		return nil, false, fmt.Errorf("image is empty")
+	}
+
+	nestedMap := make(map[string]interface{})
+
+	keys := strings.Split(imageKey, ".")
+	currentMap := nestedMap
+
+	for i := 0; i < len(keys)-1; i++ {
+		key := keys[i]
+		nextMap := make(map[string]interface{})
+		currentMap[key] = nextMap
+		currentMap = nextMap
+	}
+
+	lastKey := keys[len(keys)-1]
+	currentMap[lastKey] = image
+
+	registries, err := getRegistries()
+	if err != nil {
+		klog.Errorf("failed to get image registries, err %v", err)
+		return nestedMap, false, err
+	}
+
+	overrode := false
+	klog.V(4).Infof("Image registries values %v", registries)
+	if registries != nil {
+		overrodeImage := OverrideImage(registries, image)
+		currentMap[lastKey] = overrodeImage
+		if overrodeImage != image {
+			overrode = true
+		}
+	}
+
+	return nestedMap, overrode, nil
 }
 
 // OverrideImage checks whether the source configured in registries can match the imagedName, if yes will use the

--- a/vendor/open-cluster-management.io/addon-framework/pkg/addonfactory/addonfactory.go
+++ b/vendor/open-cluster-management.io/addon-framework/pkg/addonfactory/addonfactory.go
@@ -124,6 +124,24 @@ func (f *AgentAddonFactory) WithHostingCluster(cluster *clusterv1.ManagedCluster
 	return f
 }
 
+// WithAgentDeployTriggerClusterFilter defines the filter func to trigger the agent deploy/redploy when cluster info is
+// changed. Addons that need information from the ManagedCluster resource when deploying the agent should use this
+// function to set what information they need, otherwise the expected/up-to-date agent may be deployed delayed since the
+// default filter func returns false when the ManagedCluster resource is updated.
+//
+// For example, the agentAddon needs information from the ManagedCluster annotation, it can set the filter function
+// like:
+//
+//	WithAgentDeployClusterTriggerFilter(func(old, new *clusterv1.ManagedCluster) bool {
+//	 return !equality.Semantic.DeepEqual(old.Annotations, new.Annotations)
+//	})
+func (f *AgentAddonFactory) WithAgentDeployTriggerClusterFilter(
+	filter func(old, new *clusterv1.ManagedCluster) bool,
+) *AgentAddonFactory {
+	f.agentAddonOptions.AgentDeployTriggerClusterFilter = filter
+	return f
+}
+
 // BuildHelmAgentAddon builds a helm agentAddon instance.
 func (f *AgentAddonFactory) BuildHelmAgentAddon() (agent.AgentAddon, error) {
 	if err := validateSupportedConfigGVRs(f.agentAddonOptions.SupportedConfigGVRs); err != nil {

--- a/vendor/open-cluster-management.io/addon-framework/pkg/addonmanager/manager.go
+++ b/vendor/open-cluster-management.io/addon-framework/pkg/addonmanager/manager.go
@@ -158,31 +158,21 @@ func (a *addonManager) Start(ctx context.Context) error {
 		return err
 	}
 
-	// addonConfigController
 	err = addonInformers.Addon().V1alpha1().ManagedClusterAddOns().Informer().AddIndexers(
-		cache.Indexers{index.AddonByConfig: index.IndexAddonByConfig},
+		cache.Indexers{
+			index.ManagedClusterAddonByNamespace: index.IndexManagedClusterAddonByNamespace, // addonDeployController
+			index.ManagedClusterAddonByName:      index.IndexManagedClusterAddonByName,      // addonConfigController
+			index.AddonByConfig:                  index.IndexAddonByConfig,                  // addonConfigController
+		},
 	)
 	if err != nil {
 		return err
 	}
 
-	// managementAddonConfigController
-	err = addonInformers.Addon().V1alpha1().ClusterManagementAddOns().Informer().AddIndexers(
-		cache.Indexers{index.ClusterManagementAddonByConfig: index.IndexClusterManagementAddonByConfig})
-	if err != nil {
-		return err
-	}
-
 	err = addonInformers.Addon().V1alpha1().ClusterManagementAddOns().Informer().AddIndexers(
 		cache.Indexers{
-			index.ClusterManagementAddonByPlacement: index.IndexClusterManagementAddonByPlacement,
-		})
-	if err != nil {
-		return err
-	}
-	err = addonInformers.Addon().V1alpha1().ManagedClusterAddOns().Informer().AddIndexers(
-		cache.Indexers{
-			index.ManagedClusterAddonByName: index.IndexManagedClusterAddonByName,
+			index.ClusterManagementAddonByConfig:    index.IndexClusterManagementAddonByConfig,    // managementAddonConfigController
+			index.ClusterManagementAddonByPlacement: index.IndexClusterManagementAddonByPlacement, // addonConfigController
 		})
 	if err != nil {
 		return err

--- a/vendor/open-cluster-management.io/addon-framework/pkg/agent/inteface.go
+++ b/vendor/open-cluster-management.io/addon-framework/pkg/agent/inteface.go
@@ -52,6 +52,7 @@ type AgentAddonOptions struct {
 	// InstallStrategy defines that addon should be created in which clusters.
 	// Addon will not be installed automatically until a ManagedClusterAddon is applied to the cluster's
 	// namespace if InstallStrategy is nil.
+	// Deprecated: use installStrategy config in ClusterManagementAddOn API instead
 	// +optional
 	InstallStrategy *InstallStrategy
 
@@ -75,6 +76,19 @@ type AgentAddonOptions struct {
 	// SupportedConfigGVRs is a list of addon supported configuration GroupVersionResource
 	// each configuration GroupVersionResource should be unique
 	SupportedConfigGVRs []schema.GroupVersionResource
+
+	// AgentDeployTriggerClusterFilter defines the filter func to trigger the agent deploy/redploy when cluster info is
+	// changed. Addons that need information from the ManagedCluster resource when deploying the agent should use this
+	// field to set what information they need, otherwise the expected/up-to-date agent may be deployed delayed since
+	// the default filter func returns false when the ManagedCluster resource is updated.
+	//
+	// For example, the agentAddon needs information from the ManagedCluster annotation, it can set the filter function
+	// like:
+	//
+	//	AgentDeployTriggerClusterFilter: func(old, new *clusterv1.ManagedCluster) bool {
+	//	 return !equality.Semantic.DeepEqual(old.Annotations, new.Annotations)
+	//	}
+	AgentDeployTriggerClusterFilter func(old, new *clusterv1.ManagedCluster) bool
 }
 
 type CSRSignerFunc func(csr *certificatesv1.CertificateSigningRequest) []byte

--- a/vendor/open-cluster-management.io/addon-framework/pkg/index/index.go
+++ b/vendor/open-cluster-management.io/addon-framework/pkg/index/index.go
@@ -21,6 +21,7 @@ import (
 const (
 	ClusterManagementAddonByPlacement = "clusterManagementAddonByPlacement"
 	ManagedClusterAddonByName         = "managedClusterAddonByName"
+	ManagedClusterAddonByNamespace    = "managedClusterAddonByNamespace"
 )
 
 func IndexClusterManagementAddonByPlacement(obj interface{}) ([]string, error) {
@@ -51,6 +52,16 @@ func IndexManagedClusterAddonByName(obj interface{}) ([]string, error) {
 	}
 
 	return []string{mca.Name}, nil
+}
+
+func IndexManagedClusterAddonByNamespace(obj interface{}) ([]string, error) {
+	mca, ok := obj.(*addonv1alpha1.ManagedClusterAddOn)
+
+	if !ok {
+		return []string{}, fmt.Errorf("obj %T is not a ManagedClusterAddon", obj)
+	}
+
+	return []string{mca.Namespace}, nil
 }
 
 func ClusterManagementAddonByPlacementQueueKey(

--- a/vendor/open-cluster-management.io/addon-framework/pkg/utils/helpers.go
+++ b/vendor/open-cluster-management.io/addon-framework/pkg/utils/helpers.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog/v2"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	"open-cluster-management.io/addon-framework/pkg/agent"
 )
@@ -367,4 +368,26 @@ func GetSpecHash(obj *unstructured.Unstructured) (string, error) {
 	hash := sha256.Sum256(specBytes)
 
 	return fmt.Sprintf("%x", hash), nil
+}
+
+// MapValueChanged returns true if the value of the given key in the new map is different from the old map
+func MapValueChanged(old, new map[string]string, key string) bool {
+	oval, ok := old[key]
+	nval, nk := new[key]
+	if !ok && !nk {
+		return false
+	}
+	if ok && nk {
+		return oval != nval
+	}
+	return true
+}
+
+// ClusterImageRegistriesAnnotationChanged returns true if the value of the ClusterImageRegistriesAnnotationKey
+// in the new managed cluster annotation is different from the old managed cluster annotation
+func ClusterImageRegistriesAnnotationChanged(old, new *clusterv1.ManagedCluster) bool {
+	if new == nil || old == nil {
+		return false
+	}
+	return MapValueChanged(old.Annotations, new.Annotations, clusterv1.ClusterImageRegistriesAnnotationKey)
 }

--- a/vendor/open-cluster-management.io/api/cluster/v1/types.go
+++ b/vendor/open-cluster-management.io/api/cluster/v1/types.go
@@ -234,3 +234,20 @@ const (
 	// ClusterNameLabelKey is the key of a label to set ManagedCluster name.
 	ClusterNameLabelKey = "open-cluster-management.io/cluster-name"
 )
+
+const (
+	// ClusterImageRegistriesAnnotationKey is an annotation key on ManagedCluster to configure image override for addons
+	// running on the ManagedCluster, the value of the annotation should be a json string like this:
+	//
+	// {
+	//   "registries": [
+	//     {
+	//       "source": "quay.io/ocm",
+	//       "mirrors": "quay.io/open-cluster-management"
+	//     }
+	//   ]
+	// }
+	//
+	// Note: Image registries configured in the addonDeploymentConfig will take precedence over this annotation.
+	ClusterImageRegistriesAnnotationKey = "open-cluster-management.io/image-registries"
+)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Make the addon manger support override addon agents' images by the cluster's annotation.
If the managedCluster has annotation `open-cluster-management.io/image-registries` in format:
```
{
   "registries":[
      {
         "mirror":"quay.io/ocm/addon-examples",
         "source":"quay.io/open-cluster-management/addon-examples"
      }
   ]
}
```
For example:
```
apiVersion: cluster.open-cluster-management.io/v1
kind: ManagedCluster
metadata:
  annotations:
    open-cluster-management.io/image-registries: '{"registries":[{"mirror":"quay.io/ocm/addon-examples","source":"quay.io/open-cluster-management/addon-examples"}]}'
```
The addon-manager will override agent images for all the template-type addons whose images can match the `source` field.

## Related issue(s)

Fixes #