### PR TITLE
:seedling: Add `update-csv` when `make update`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ copy-crd:
 patch-crd: ensure-yaml-patch
 	bash hack/patch/patch-crd.sh $(YAML_PATCH)
 
-update: patch-crd copy-crd
+update: patch-crd copy-crd update-csv
 
 update-csv: ensure-operator-sdk
 	cd deploy/cluster-manager && ../../$(OPERATOR_SDK) generate bundle --manifests --deploy-dir config/ --crds-dir config/crds/ --output-dir olm-catalog/cluster-manager/ --version $(CSV_VERSION)


### PR DESCRIPTION
## Summary

This is a issue when I tried to update Kluterlet in this PR: https://github.com/open-cluster-management-io/ocm/pull/234

After we run `make update`,  the integration-test fails because it depends on the following file:

https://github.com/open-cluster-management-io/ocm/blob/e810520961663f96cc77339d848186039fcb6eb3/test/integration/operator/integration_suite_test.go#L82

But this file needs to update by the `make update-csv` command.

So it's better to combine 2 commands.