### PR TITLE
:bug:Fix PodSecurity Warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,15 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 )
 
 OPERATOR_SDK?=$(PERMANENT_TMP_GOPATH)/bin/operator-sdk
-OPERATOR_SDK_VERSION?=v1.1.0
+OPERATOR_SDK_VERSION?=v1.28.0
 operatorsdk_gen_dir:=$(dir $(OPERATOR_SDK))
 # CSV_VERSION is used to generate new CSV manifests
 CSV_VERSION?=0.12.0
 
-OPERATOR_SDK_ARCHOS:=x86_64-linux-gnu
+OPERATOR_SDK_ARCHOS:=linux_amd64
 ifeq ($(GOHOSTOS),darwin)
 	ifeq ($(GOHOSTARCH),amd64)
-		OPERATOR_SDK_ARCHOS:=x86_64-apple-darwin
+		OPERATOR_SDK_ARCHOS:=darwin_amd64
 	endif
 endif
 
@@ -57,12 +57,12 @@ patch-crd: ensure-yaml-patch
 update: patch-crd copy-crd update-csv
 
 update-csv: ensure-operator-sdk
-	cd deploy/cluster-manager && ../../$(OPERATOR_SDK) generate bundle --manifests --deploy-dir config/ --crds-dir config/crds/ --output-dir olm-catalog/cluster-manager/ --version $(CSV_VERSION)
-	cd deploy/klusterlet && ../../$(OPERATOR_SDK) generate bundle --manifests --deploy-dir config/ --crds-dir config/crds/ --output-dir olm-catalog/klusterlet/ --version=$(CSV_VERSION)
+	cd deploy/cluster-manager && ../../$(OPERATOR_SDK) generate bundle --version $(CSV_VERSION) --package cluster-manager --input-dir config --output-dir olm-catalog/cluster-manager
+	cd deploy/klusterlet && ../../$(OPERATOR_SDK) generate bundle --version $(CSV_VERSION) --package klusterlet --input-dir config --output-dir olm-catalog/klusterlet
 
-	# delete useless serviceaccounts in manifests although they are copied from config by operator-sdk.
-	rm ./deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager_v1_serviceaccount.yaml
-	rm ./deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet_v1_serviceaccount.yaml
+	# delete bundle.Dockerfile since we do not use it to build image.
+	rm ./deploy/cluster-manager/bundle.Dockerfile
+	rm ./deploy/klusterlet/bundle.Dockerfile
 
 verify-crds: patch-crd
 	bash -x hack/verify-crds.sh
@@ -93,7 +93,7 @@ ensure-operator-sdk:
 ifeq "" "$(wildcard $(OPERATOR_SDK))"
 	$(info Installing operator-sdk into '$(OPERATOR_SDK)')
 	mkdir -p '$(operatorsdk_gen_dir)'
-	curl -s -f -L https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_ARCHOS) -o '$(OPERATOR_SDK)'
+	curl -s -f -L https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$(OPERATOR_SDK_ARCHOS) -o '$(OPERATOR_SDK)'
 	chmod +x '$(OPERATOR_SDK)';
 else
 	$(info Using existing operator-sdk from "$(OPERATOR_SDK)")

--- a/deploy/cluster-manager/PROJECT
+++ b/deploy/cluster-manager/PROJECT
@@ -1,2 +1,4 @@
+version: "3"
+layout:
+- go.kubebuilder.io/v3
 projectName: cluster-manager
-version: 2

--- a/deploy/cluster-manager/config/operator/operator.yaml
+++ b/deploy/cluster-manager/config/operator/operator.yaml
@@ -37,6 +37,10 @@ spec:
                   values:
                   - cluster-manager
       serviceAccountName: cluster-manager
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: registration-operator
         image: quay.io/open-cluster-management/registration-operator:latest
@@ -49,7 +53,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/cluster-manager.clusterserviceversion.yaml
@@ -59,10 +59,10 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/open-cluster-management/registration-operator:latest
-    createdAt: "2023-05-24T20:00:31Z"
+    createdAt: "2023-08-15T09:59:52Z"
     description: Manages the installation and upgrade of the ClusterManager.
-    operators.operatorframework.io/builder: operator-sdk-v1.1.0
-    operators.operatorframework.io/project_layout: go
+    operators.operatorframework.io/builder: operator-sdk-v1.28.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/open-cluster-management-io/registration-operator
     support: Red Hat, Inc.
   name: cluster-manager.v0.12.0
@@ -71,7 +71,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: ClusterManager defines the configurations of controllers running hub that govern registration and work distribution for attached Klusterlets
+    - description: ClusterManager defines the configurations of controllers running
+        hub that govern registration and work distribution for attached Klusterlets
       displayName: ClusterManager
       kind: ClusterManager
       name: clustermanagers.operator.open-cluster-management.io
@@ -499,7 +500,9 @@ spec:
           - get
         serviceAccountName: cluster-manager
       deployments:
-      - name: cluster-manager
+      - label:
+          app: cluster-manager
+        name: cluster-manager
         spec:
           replicas: 3
           selector:
@@ -561,7 +564,10 @@ spec:
                     drop:
                     - ALL
                   privileged: false
-                  runAsNonRoot: true
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: cluster-manager
     strategy: deployment
   installModes:

--- a/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/operator.open-cluster-management.io_clustermanagers.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/manifests/operator.open-cluster-management.io_clustermanagers.yaml
@@ -15,13 +15,21 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: ClusterManager configures the controllers on the hub that govern registration and work distribution for attached Klusterlets. In Default mode, ClusterManager will only be deployed in open-cluster-management-hub namespace. In Hosted mode, ClusterManager will be deployed in the namespace with the same name as cluster manager.
+        description: ClusterManager configures the controllers on the hub that govern
+          registration and work distribution for attached Klusterlets. In Default
+          mode, ClusterManager will only be deployed in open-cluster-management-hub
+          namespace. In Hosted mode, ClusterManager will be deployed in the namespace
+          with the same name as cluster manager.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -29,13 +37,24 @@ spec:
             default:
               deployOption:
                 mode: Default
-            description: Spec represents a desired deployment configuration of controllers that govern registration and work distribution for attached Klusterlets.
+            description: Spec represents a desired deployment configuration of controllers
+              that govern registration and work distribution for attached Klusterlets.
             properties:
               addOnManagerConfiguration:
-                description: AddOnManagerConfiguration contains the configuration of addon manager
+                description: AddOnManagerConfiguration contains the configuration
+                  of addon manager
                 properties:
                   featureGates:
-                    description: 'FeatureGates represents the list of feature gates for addon manager If it is set empty, default feature gates will be used. If it is set, featuregate/Foo is an example of one item in FeatureGates: 1. If featuregate/Foo does not exist, registration-operator will discard it 2. If featuregate/Foo exists and is false by default. It is now possible to set featuregate/Foo=[false|true] 3. If featuregate/Foo exists and is true by default. If a cluster-admin upgrading from 1 to 2 wants to continue having featuregate/Foo=false, he can set featuregate/Foo=false before upgrading. Let''s say the cluster-admin wants featuregate/Foo=false.'
+                    description: 'FeatureGates represents the list of feature gates
+                      for addon manager If it is set empty, default feature gates
+                      will be used. If it is set, featuregate/Foo is an example of
+                      one item in FeatureGates: 1. If featuregate/Foo does not exist,
+                      registration-operator will discard it 2. If featuregate/Foo
+                      exists and is false by default. It is now possible to set featuregate/Foo=[false|true]
+                      3. If featuregate/Foo exists and is true by default. If a cluster-admin
+                      upgrading from 1 to 2 wants to continue having featuregate/Foo=false,
+                      he can set featuregate/Foo=false before upgrading. Let''s say
+                      the cluster-admin wants featuregate/Foo=false.'
                     items:
                       properties:
                         feature:
@@ -43,7 +62,11 @@ spec:
                           type: string
                         mode:
                           default: Disable
-                          description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                          description: Mode is either Enable, Disable, "" where ""
+                            is Disable by default. In Enable mode, a valid feature
+                            gate `featuregate/Foo` will be set to "--featuregate/Foo=true".
+                            In Disable mode, a valid feature gate `featuregate/Foo`
+                            will be set to "--featuregate/Foo=false".
                           enum:
                           - Enable
                           - Disable
@@ -55,26 +78,33 @@ spec:
                 type: object
               addOnManagerImagePullSpec:
                 default: quay.io/open-cluster-management/addon-manager
-                description: AddOnManagerImagePullSpec represents the desired image configuration of addon manager controller/webhook installed on hub.
+                description: AddOnManagerImagePullSpec represents the desired image
+                  configuration of addon manager controller/webhook installed on hub.
                 type: string
               deployOption:
                 default:
                   mode: Default
-                description: DeployOption contains the options of deploying a cluster-manager Default mode is used if DeployOption is not set.
+                description: DeployOption contains the options of deploying a cluster-manager
+                  Default mode is used if DeployOption is not set.
                 properties:
                   hosted:
-                    description: Hosted includes configurations we needs for clustermanager in the Hosted mode.
+                    description: Hosted includes configurations we needs for clustermanager
+                      in the Hosted mode.
                     properties:
                       registrationWebhookConfiguration:
-                        description: RegistrationWebhookConfiguration represents the customized webhook-server configuration of registration.
+                        description: RegistrationWebhookConfiguration represents the
+                          customized webhook-server configuration of registration.
                         properties:
                           address:
-                            description: Address represents the address of a webhook-server. It could be in IP format or fqdn format. The Address must be reachable by apiserver of the hub cluster.
+                            description: Address represents the address of a webhook-server.
+                              It could be in IP format or fqdn format. The Address
+                              must be reachable by apiserver of the hub cluster.
                             pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
                             type: string
                           port:
                             default: 443
-                            description: Port represents the port of a webhook-server. The default value of Port is 443.
+                            description: Port represents the port of a webhook-server.
+                              The default value of Port is 443.
                             format: int32
                             maximum: 65535
                             type: integer
@@ -82,15 +112,19 @@ spec:
                         - address
                         type: object
                       workWebhookConfiguration:
-                        description: WorkWebhookConfiguration represents the customized webhook-server configuration of work.
+                        description: WorkWebhookConfiguration represents the customized
+                          webhook-server configuration of work.
                         properties:
                           address:
-                            description: Address represents the address of a webhook-server. It could be in IP format or fqdn format. The Address must be reachable by apiserver of the hub cluster.
+                            description: Address represents the address of a webhook-server.
+                              It could be in IP format or fqdn format. The Address
+                              must be reachable by apiserver of the hub cluster.
                             pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
                             type: string
                           port:
                             default: 443
-                            description: Port represents the port of a webhook-server. The default value of Port is 443.
+                            description: Port represents the port of a webhook-server.
+                              The default value of Port is 443.
                             format: int32
                             maximum: 65535
                             type: integer
@@ -100,7 +134,14 @@ spec:
                     type: object
                   mode:
                     default: Default
-                    description: 'Mode can be Default or Hosted. In Default mode, the Hub is installed as a whole and all parts of Hub are deployed in the same cluster. In Hosted mode, only crd and configurations are installed on one cluster(defined as hub-cluster). Controllers run in another cluster (defined as management-cluster) and connect to the hub with the kubeconfig in secret of "external-hub-kubeconfig"(a kubeconfig of hub-cluster with cluster-admin permission). Note: Do not modify the Mode field once it''s applied.'
+                    description: 'Mode can be Default or Hosted. In Default mode,
+                      the Hub is installed as a whole and all parts of Hub are deployed
+                      in the same cluster. In Hosted mode, only crd and configurations
+                      are installed on one cluster(defined as hub-cluster). Controllers
+                      run in another cluster (defined as management-cluster) and connect
+                      to the hub with the kubeconfig in secret of "external-hub-kubeconfig"(a
+                      kubeconfig of hub-cluster with cluster-admin permission). Note:
+                      Do not modify the Mode field once it''s applied.'
                     enum:
                     - Default
                     - Hosted
@@ -109,51 +150,89 @@ spec:
                 - mode
                 type: object
               nodePlacement:
-                description: NodePlacement enables explicit control over the scheduling of the deployed pods.
+                description: NodePlacement enables explicit control over the scheduling
+                  of the deployed pods.
                 properties:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector defines which Nodes the Pods are scheduled on. The default is an empty list.
+                    description: NodeSelector defines which Nodes the Pods are scheduled
+                      on. The default is an empty list.
                     type: object
                   tolerations:
-                    description: Tolerations is attached by pods to tolerate any taint that matches the triple <key,value,effect> using the matching operator <operator>. The default is an empty list.
+                    description: Tolerations is attached by pods to tolerate any taint
+                      that matches the triple <key,value,effect> using the matching
+                      operator <operator>. The default is an empty list.
                     items:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                 type: object
               placementImagePullSpec:
                 default: quay.io/open-cluster-management/placement
-                description: PlacementImagePullSpec represents the desired image configuration of placement controller/webhook installed on hub.
+                description: PlacementImagePullSpec represents the desired image configuration
+                  of placement controller/webhook installed on hub.
                 type: string
               registrationConfiguration:
-                description: RegistrationConfiguration contains the configuration of registration
+                description: RegistrationConfiguration contains the configuration
+                  of registration
                 properties:
                   autoApproveUsers:
-                    description: AutoApproveUser represents a list of users that can auto approve CSR and accept client. If the credential of the bootstrap-hub-kubeconfig matches to the users, the cluster created by the bootstrap-hub-kubeconfig will be auto-registered into the hub cluster. This takes effect only when ManagedClusterAutoApproval feature gate is enabled.
+                    description: AutoApproveUser represents a list of users that can
+                      auto approve CSR and accept client. If the credential of the
+                      bootstrap-hub-kubeconfig matches to the users, the cluster created
+                      by the bootstrap-hub-kubeconfig will be auto-registered into
+                      the hub cluster. This takes effect only when ManagedClusterAutoApproval
+                      feature gate is enabled.
                     items:
                       type: string
                     type: array
                   featureGates:
-                    description: 'FeatureGates represents the list of feature gates for registration If it is set empty, default feature gates will be used. If it is set, featuregate/Foo is an example of one item in FeatureGates: 1. If featuregate/Foo does not exist, registration-operator will discard it 2. If featuregate/Foo exists and is false by default. It is now possible to set featuregate/Foo=[false|true] 3. If featuregate/Foo exists and is true by default. If a cluster-admin upgrading from 1 to 2 wants to continue having featuregate/Foo=false, he can set featuregate/Foo=false before upgrading. Let''s say the cluster-admin wants featuregate/Foo=false.'
+                    description: 'FeatureGates represents the list of feature gates
+                      for registration If it is set empty, default feature gates will
+                      be used. If it is set, featuregate/Foo is an example of one
+                      item in FeatureGates: 1. If featuregate/Foo does not exist,
+                      registration-operator will discard it 2. If featuregate/Foo
+                      exists and is false by default. It is now possible to set featuregate/Foo=[false|true]
+                      3. If featuregate/Foo exists and is true by default. If a cluster-admin
+                      upgrading from 1 to 2 wants to continue having featuregate/Foo=false,
+                      he can set featuregate/Foo=false before upgrading. Let''s say
+                      the cluster-admin wants featuregate/Foo=false.'
                     items:
                       properties:
                         feature:
@@ -161,7 +240,11 @@ spec:
                           type: string
                         mode:
                           default: Disable
-                          description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                          description: Mode is either Enable, Disable, "" where ""
+                            is Disable by default. In Enable mode, a valid feature
+                            gate `featuregate/Foo` will be set to "--featuregate/Foo=true".
+                            In Disable mode, a valid feature gate `featuregate/Foo`
+                            will be set to "--featuregate/Foo=false".
                           enum:
                           - Enable
                           - Disable
@@ -173,13 +256,23 @@ spec:
                 type: object
               registrationImagePullSpec:
                 default: quay.io/open-cluster-management/registration
-                description: RegistrationImagePullSpec represents the desired image of registration controller/webhook installed on hub.
+                description: RegistrationImagePullSpec represents the desired image
+                  of registration controller/webhook installed on hub.
                 type: string
               workConfiguration:
                 description: WorkConfiguration contains the configuration of work
                 properties:
                   featureGates:
-                    description: 'FeatureGates represents the list of feature gates for work If it is set empty, default feature gates will be used. If it is set, featuregate/Foo is an example of one item in FeatureGates: 1. If featuregate/Foo does not exist, registration-operator will discard it 2. If featuregate/Foo exists and is false by default. It is now possible to set featuregate/Foo=[false|true] 3. If featuregate/Foo exists and is true by default. If a cluster-admin upgrading from 1 to 2 wants to continue having featuregate/Foo=false, he can set featuregate/Foo=false before upgrading. Let''s say the cluster-admin wants featuregate/Foo=false.'
+                    description: 'FeatureGates represents the list of feature gates
+                      for work If it is set empty, default feature gates will be used.
+                      If it is set, featuregate/Foo is an example of one item in FeatureGates:
+                      1. If featuregate/Foo does not exist, registration-operator
+                      will discard it 2. If featuregate/Foo exists and is false by
+                      default. It is now possible to set featuregate/Foo=[false|true]
+                      3. If featuregate/Foo exists and is true by default. If a cluster-admin
+                      upgrading from 1 to 2 wants to continue having featuregate/Foo=false,
+                      he can set featuregate/Foo=false before upgrading. Let''s say
+                      the cluster-admin wants featuregate/Foo=false.'
                     items:
                       properties:
                         feature:
@@ -187,7 +280,11 @@ spec:
                           type: string
                         mode:
                           default: Disable
-                          description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                          description: Mode is either Enable, Disable, "" where ""
+                            is Disable by default. In Enable mode, a valid feature
+                            gate `featuregate/Foo` will be set to "--featuregate/Foo=true".
+                            In Disable mode, a valid feature gate `featuregate/Foo`
+                            will be set to "--featuregate/Foo=false".
                           enum:
                           - Enable
                           - Disable
@@ -199,32 +296,60 @@ spec:
                 type: object
               workImagePullSpec:
                 default: quay.io/open-cluster-management/work
-                description: WorkImagePullSpec represents the desired image configuration of work controller/webhook installed on hub.
+                description: WorkImagePullSpec represents the desired image configuration
+                  of work controller/webhook installed on hub.
                 type: string
             type: object
           status:
-            description: Status represents the current status of controllers that govern the lifecycle of managed clusters.
+            description: Status represents the current status of controllers that
+              govern the lifecycle of managed clusters.
             properties:
               conditions:
-                description: 'Conditions contain the different condition statuses for this ClusterManager. Valid condition types are: Applied: Components in hub are applied. Available: Components in hub are available and ready to serve. Progressing: Components in hub are in a transitioning state. Degraded: Components in hub do not match the desired configuration and only provide degraded service.'
+                description: 'Conditions contain the different condition statuses
+                  for this ClusterManager. Valid condition types are: Applied: Components
+                  in hub are applied. Available: Components in hub are available and
+                  ready to serve. Progressing: Components in hub are in a transitioning
+                  state. Degraded: Components in hub do not match the desired configuration
+                  and only provide degraded service.'
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -237,7 +362,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -250,42 +379,54 @@ spec:
                   type: object
                 type: array
               generations:
-                description: Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                description: Generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
                 items:
-                  description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
                   properties:
                     group:
-                      description: group is the group of the resource that you're tracking
+                      description: group is the group of the resource that you're
+                        tracking
                       type: string
                     lastGeneration:
-                      description: lastGeneration is the last generation of the resource that controller applies
+                      description: lastGeneration is the last generation of the resource
+                        that controller applies
                       format: int64
                       type: integer
                     name:
                       description: name is the name of the resource that you're tracking
                       type: string
                     namespace:
-                      description: namespace is where the resource that you're tracking is
+                      description: namespace is where the resource that you're tracking
+                        is
                       type: string
                     resource:
-                      description: resource is the resource type of the resource that you're tracking
+                      description: resource is the resource type of the resource that
+                        you're tracking
                       type: string
                     version:
-                      description: version is the version of the resource that you're tracking
+                      description: version is the version of the resource that you're
+                        tracking
                       type: string
                   type: object
                 type: array
               observedGeneration:
-                description: ObservedGeneration is the last generation change you've dealt with
+                description: ObservedGeneration is the last generation change you've
+                  dealt with
                 format: int64
                 type: integer
               relatedResources:
-                description: RelatedResources are used to track the resources that are related to this ClusterManager.
+                description: RelatedResources are used to track the resources that
+                  are related to this ClusterManager.
                 items:
-                  description: RelatedResourceMeta represents the resource that is managed by an operator
+                  description: RelatedResourceMeta represents the resource that is
+                    managed by an operator
                   properties:
                     group:
-                      description: group is the group of the resource that you're tracking
+                      description: group is the group of the resource that you're
+                        tracking
                       type: string
                     name:
                       description: name is the name of the resource that you're tracking
@@ -294,7 +435,8 @@ spec:
                       description: namespace is where the thing you're tracking is
                       type: string
                     resource:
-                      description: resource is the resource type of the resource that you're tracking
+                      description: resource is the resource type of the resource that
+                        you're tracking
                       type: string
                     version:
                       description: version is the version of the thing you're tracking

--- a/deploy/cluster-manager/olm-catalog/cluster-manager/metadata/annotations.yaml
+++ b/deploy/cluster-manager/olm-catalog/cluster-manager/metadata/annotations.yaml
@@ -1,7 +1,10 @@
 annotations:
-    operators.operatorframework.io.bundle.channel.default.v1: stable
-    operators.operatorframework.io.bundle.channels.v1: stable
-    operators.operatorframework.io.bundle.manifests.v1: manifests/
-    operators.operatorframework.io.bundle.mediatype.v1: registry+v1
-    operators.operatorframework.io.bundle.metadata.v1: metadata/
-    operators.operatorframework.io.bundle.package.v1: cluster-manager
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: cluster-manager
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3

--- a/deploy/klusterlet/PROJECT
+++ b/deploy/klusterlet/PROJECT
@@ -1,2 +1,4 @@
+version: "3"
+layout:
+- go.kubebuilder.io/v3
 projectName: klusterlet
-version: 2

--- a/deploy/klusterlet/config/operator/operator.yaml
+++ b/deploy/klusterlet/config/operator/operator.yaml
@@ -39,12 +39,22 @@ spec:
                   values:
                   - klusterlet
       serviceAccountName: klusterlet
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: klusterlet
         image: quay.io/open-cluster-management/registration-operator:latest
         args:
           - "/registration-operator"
           - "klusterlet"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/klusterlet.clusterserviceversion.yaml
@@ -39,10 +39,10 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/open-cluster-management/registration-operator:latest
-    createdAt: "2023-05-24T20:00:31Z"
+    createdAt: "2023-08-15T09:59:53Z"
     description: Manages the installation and upgrade of the Klusterlet.
-    operators.operatorframework.io/builder: operator-sdk-v1.1.0
-    operators.operatorframework.io/project_layout: go
+    operators.operatorframework.io/builder: operator-sdk-v1.28.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/open-cluster-management-io/registration-operator
     support: Red Hat, Inc.
   name: klusterlet.v0.12.0
@@ -51,7 +51,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Klusterlet defines the configurations of agents running on the managed cluster
+    - description: Klusterlet defines the configurations of agents running on the
+        managed cluster
       displayName: Klusterlet
       kind: Klusterlet
       name: klusterlets.operator.open-cluster-management.io
@@ -235,7 +236,9 @@ spec:
           - patch
         serviceAccountName: klusterlet
       deployments:
-      - name: klusterlet
+      - label:
+          app: klusterlet
+        name: klusterlet
         spec:
           replicas: 3
           selector:
@@ -293,6 +296,16 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: klusterlet
     strategy: deployment
   installModes:

--- a/deploy/klusterlet/olm-catalog/klusterlet/manifests/operator.open-cluster-management.io_klusterlets.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/manifests/operator.open-cluster-management.io_klusterlets.yaml
@@ -15,21 +15,33 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Klusterlet represents controllers to install the resources for a managed cluster. When configured, the Klusterlet requires a secret named bootstrap-hub-kubeconfig in the agent namespace to allow API requests to the hub for the registration protocol. In Hosted mode, the Klusterlet requires an additional secret named external-managed-kubeconfig in the agent namespace to allow API requests to the managed cluster for resources installation.
+        description: Klusterlet represents controllers to install the resources for
+          a managed cluster. When configured, the Klusterlet requires a secret named
+          bootstrap-hub-kubeconfig in the agent namespace to allow API requests to
+          the hub for the registration protocol. In Hosted mode, the Klusterlet requires
+          an additional secret named external-managed-kubeconfig in the agent namespace
+          to allow API requests to the managed cluster for resources installation.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Spec represents the desired deployment configuration of Klusterlet agent.
+            description: Spec represents the desired deployment configuration of Klusterlet
+              agent.
             properties:
               clusterName:
-                description: ClusterName is the name of the managed cluster to be created on hub. The Klusterlet agent generates a random name if it is not set, or discovers the appropriate cluster name on OpenShift.
+                description: ClusterName is the name of the managed cluster to be
+                  created on hub. The Klusterlet agent generates a random name if
+                  it is not set, or discovers the appropriate cluster name on OpenShift.
                 maxLength: 63
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
@@ -37,25 +49,43 @@ spec:
                 description: DeployOption contains the options of deploying a klusterlet
                 properties:
                   mode:
-                    description: 'Mode can be Default, Hosted or Singleton. It is Default mode if not specified In Default mode, all klusterlet related resources are deployed on the managed cluster. In Hosted mode, only crd and configurations are installed on the spoke/managed cluster. Controllers run in another cluster (defined as management-cluster) and connect to the mangaged cluster with the kubeconfig in secret of "external-managed-kubeconfig"(a kubeconfig of managed-cluster with cluster-admin permission). In Singleton mode, registration/work agent is started as a single deployment. Note: Do not modify the Mode field once it''s applied.'
+                    description: 'Mode can be Default, Hosted or Singleton. It is
+                      Default mode if not specified In Default mode, all klusterlet
+                      related resources are deployed on the managed cluster. In Hosted
+                      mode, only crd and configurations are installed on the spoke/managed
+                      cluster. Controllers run in another cluster (defined as management-cluster)
+                      and connect to the mangaged cluster with the kubeconfig in secret
+                      of "external-managed-kubeconfig"(a kubeconfig of managed-cluster
+                      with cluster-admin permission). In Singleton mode, registration/work
+                      agent is started as a single deployment. Note: Do not modify
+                      the Mode field once it''s applied.'
                     type: string
                 type: object
               externalServerURLs:
-                description: ExternalServerURLs represents the a list of apiserver urls and ca bundles that is accessible externally If it is set empty, managed cluster has no externally accessible url that hub cluster can visit.
+                description: ExternalServerURLs represents the a list of apiserver
+                  urls and ca bundles that is accessible externally If it is set empty,
+                  managed cluster has no externally accessible url that hub cluster
+                  can visit.
                 items:
-                  description: ServerURL represents the apiserver url and ca bundle that is accessible externally
+                  description: ServerURL represents the apiserver url and ca bundle
+                    that is accessible externally
                   properties:
                     caBundle:
-                      description: CABundle is the ca bundle to connect to apiserver of the managed cluster. System certs are used if it is not set.
+                      description: CABundle is the ca bundle to connect to apiserver
+                        of the managed cluster. System certs are used if it is not
+                        set.
                       format: byte
                       type: string
                     url:
-                      description: URL is the url of apiserver endpoint of the managed cluster.
+                      description: URL is the url of apiserver endpoint of the managed
+                        cluster.
                       type: string
                   type: object
                 type: array
               hubApiServerHostAlias:
-                description: HubApiServerHostAlias contains the host alias for hub api server. registration-agent and work-agent will use it to communicate with hub api server.
+                description: HubApiServerHostAlias contains the host alias for hub
+                  api server. registration-agent and work-agent will use it to communicate
+                  with hub api server.
                 properties:
                   hostname:
                     description: Hostname for the above IP address.
@@ -70,59 +100,108 @@ spec:
                 - ip
                 type: object
               imagePullSpec:
-                description: ImagePullSpec represents the desired image configuration of agent, it takes effect only when singleton mode is set. quay.io/open-cluster-management.io/registration-operator:latest will be used if unspecified
+                description: ImagePullSpec represents the desired image configuration
+                  of agent, it takes effect only when singleton mode is set. quay.io/open-cluster-management.io/registration-operator:latest
+                  will be used if unspecified
                 type: string
               namespace:
-                description: Namespace is the namespace to deploy the agent on the managed cluster. The namespace must have a prefix of "open-cluster-management-", and if it is not set, the namespace of "open-cluster-management-agent" is used to deploy agent. In addition, the add-ons are deployed to the namespace of "{Namespace}-addon". In the Hosted mode, this namespace still exists on the managed cluster to contain necessary resources, like service accounts, roles and rolebindings, while the agent is deployed to the namespace with the same name as klusterlet on the management cluster.
+                description: Namespace is the namespace to deploy the agent on the
+                  managed cluster. The namespace must have a prefix of "open-cluster-management-",
+                  and if it is not set, the namespace of "open-cluster-management-agent"
+                  is used to deploy agent. In addition, the add-ons are deployed to
+                  the namespace of "{Namespace}-addon". In the Hosted mode, this namespace
+                  still exists on the managed cluster to contain necessary resources,
+                  like service accounts, roles and rolebindings, while the agent is
+                  deployed to the namespace with the same name as klusterlet on the
+                  management cluster.
                 maxLength: 63
                 pattern: ^open-cluster-management-[-a-z0-9]*[a-z0-9]$
                 type: string
               nodePlacement:
-                description: NodePlacement enables explicit control over the scheduling of the deployed pods.
+                description: NodePlacement enables explicit control over the scheduling
+                  of the deployed pods.
                 properties:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector defines which Nodes the Pods are scheduled on. The default is an empty list.
+                    description: NodeSelector defines which Nodes the Pods are scheduled
+                      on. The default is an empty list.
                     type: object
                   tolerations:
-                    description: Tolerations is attached by pods to tolerate any taint that matches the triple <key,value,effect> using the matching operator <operator>. The default is an empty list.
+                    description: Tolerations is attached by pods to tolerate any taint
+                      that matches the triple <key,value,effect> using the matching
+                      operator <operator>. The default is an empty list.
                     items:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
                       properties:
                         effect:
-                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
                           type: string
                         operator:
-                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
                           type: string
                         tolerationSeconds:
-                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                 type: object
               registrationConfiguration:
-                description: RegistrationConfiguration contains the configuration of registration
+                description: RegistrationConfiguration contains the configuration
+                  of registration
                 properties:
                   clientCertExpirationSeconds:
-                    description: clientCertExpirationSeconds represents the seconds of a client certificate to expire. If it is not set or 0, the default duration seconds will be set by the hub cluster. If the value is larger than the max signing duration seconds set on the hub cluster, the max signing duration seconds will be set.
+                    description: clientCertExpirationSeconds represents the seconds
+                      of a client certificate to expire. If it is not set or 0, the
+                      default duration seconds will be set by the hub cluster. If
+                      the value is larger than the max signing duration seconds set
+                      on the hub cluster, the max signing duration seconds will be
+                      set.
                     format: int32
                     type: integer
                   clusterAnnotations:
                     additionalProperties:
                       type: string
-                    description: ClusterAnnotations is annotations with the reserve prefix "agent.open-cluster-management.io" set on ManagedCluster when creating only, other actors can update it afterwards.
+                    description: ClusterAnnotations is annotations with the reserve
+                      prefix "agent.open-cluster-management.io" set on ManagedCluster
+                      when creating only, other actors can update it afterwards.
                     type: object
                   featureGates:
-                    description: 'FeatureGates represents the list of feature gates for registration If it is set empty, default feature gates will be used. If it is set, featuregate/Foo is an example of one item in FeatureGates: 1. If featuregate/Foo does not exist, registration-operator will discard it 2. If featuregate/Foo exists and is false by default. It is now possible to set featuregate/Foo=[false|true] 3. If featuregate/Foo exists and is true by default. If a cluster-admin upgrading from 1 to 2 wants to continue having featuregate/Foo=false, he can set featuregate/Foo=false before upgrading. Let''s say the cluster-admin wants featuregate/Foo=false.'
+                    description: 'FeatureGates represents the list of feature gates
+                      for registration If it is set empty, default feature gates will
+                      be used. If it is set, featuregate/Foo is an example of one
+                      item in FeatureGates: 1. If featuregate/Foo does not exist,
+                      registration-operator will discard it 2. If featuregate/Foo
+                      exists and is false by default. It is now possible to set featuregate/Foo=[false|true]
+                      3. If featuregate/Foo exists and is true by default. If a cluster-admin
+                      upgrading from 1 to 2 wants to continue having featuregate/Foo=false,
+                      he can set featuregate/Foo=false before upgrading. Let''s say
+                      the cluster-admin wants featuregate/Foo=false.'
                     items:
                       properties:
                         feature:
@@ -130,7 +209,11 @@ spec:
                           type: string
                         mode:
                           default: Disable
-                          description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                          description: Mode is either Enable, Disable, "" where ""
+                            is Disable by default. In Enable mode, a valid feature
+                            gate `featuregate/Foo` will be set to "--featuregate/Foo=true".
+                            In Disable mode, a valid feature gate `featuregate/Foo`
+                            will be set to "--featuregate/Foo=false".
                           enum:
                           - Enable
                           - Disable
@@ -141,13 +224,24 @@ spec:
                     type: array
                 type: object
               registrationImagePullSpec:
-                description: RegistrationImagePullSpec represents the desired image configuration of registration agent. quay.io/open-cluster-management.io/registration:latest will be used if unspecified.
+                description: RegistrationImagePullSpec represents the desired image
+                  configuration of registration agent. quay.io/open-cluster-management.io/registration:latest
+                  will be used if unspecified.
                 type: string
               workConfiguration:
                 description: WorkConfiguration contains the configuration of work
                 properties:
                   featureGates:
-                    description: 'FeatureGates represents the list of feature gates for work If it is set empty, default feature gates will be used. If it is set, featuregate/Foo is an example of one item in FeatureGates: 1. If featuregate/Foo does not exist, registration-operator will discard it 2. If featuregate/Foo exists and is false by default. It is now possible to set featuregate/Foo=[false|true] 3. If featuregate/Foo exists and is true by default. If a cluster-admin upgrading from 1 to 2 wants to continue having featuregate/Foo=false, he can set featuregate/Foo=false before upgrading. Let''s say the cluster-admin wants featuregate/Foo=false.'
+                    description: 'FeatureGates represents the list of feature gates
+                      for work If it is set empty, default feature gates will be used.
+                      If it is set, featuregate/Foo is an example of one item in FeatureGates:
+                      1. If featuregate/Foo does not exist, registration-operator
+                      will discard it 2. If featuregate/Foo exists and is false by
+                      default. It is now possible to set featuregate/Foo=[false|true]
+                      3. If featuregate/Foo exists and is true by default. If a cluster-admin
+                      upgrading from 1 to 2 wants to continue having featuregate/Foo=false,
+                      he can set featuregate/Foo=false before upgrading. Let''s say
+                      the cluster-admin wants featuregate/Foo=false.'
                     items:
                       properties:
                         feature:
@@ -155,7 +249,11 @@ spec:
                           type: string
                         mode:
                           default: Disable
-                          description: Mode is either Enable, Disable, "" where "" is Disable by default. In Enable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=true". In Disable mode, a valid feature gate `featuregate/Foo` will be set to "--featuregate/Foo=false".
+                          description: Mode is either Enable, Disable, "" where ""
+                            is Disable by default. In Enable mode, a valid feature
+                            gate `featuregate/Foo` will be set to "--featuregate/Foo=true".
+                            In Disable mode, a valid feature gate `featuregate/Foo`
+                            will be set to "--featuregate/Foo=false".
                           enum:
                           - Enable
                           - Disable
@@ -166,32 +264,61 @@ spec:
                     type: array
                 type: object
               workImagePullSpec:
-                description: WorkImagePullSpec represents the desired image configuration of work agent. quay.io/open-cluster-management.io/work:latest will be used if unspecified.
+                description: WorkImagePullSpec represents the desired image configuration
+                  of work agent. quay.io/open-cluster-management.io/work:latest will
+                  be used if unspecified.
                 type: string
             type: object
           status:
             description: Status represents the current status of Klusterlet agent.
             properties:
               conditions:
-                description: 'Conditions contain the different condition statuses for this Klusterlet. Valid condition types are: Applied: Components have been applied in the managed cluster. Available: Components in the managed cluster are available and ready to serve. Progressing: Components in the managed cluster are in a transitioning state. Degraded: Components in the managed cluster do not match the desired configuration and only provide degraded service.'
+                description: 'Conditions contain the different condition statuses
+                  for this Klusterlet. Valid condition types are: Applied: Components
+                  have been applied in the managed cluster. Available: Components
+                  in the managed cluster are available and ready to serve. Progressing:
+                  Components in the managed cluster are in a transitioning state.
+                  Degraded: Components in the managed cluster do not match the desired
+                  configuration and only provide degraded service.'
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -204,7 +331,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -217,42 +348,54 @@ spec:
                   type: object
                 type: array
               generations:
-                description: Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                description: Generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
                 items:
-                  description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
                   properties:
                     group:
-                      description: group is the group of the resource that you're tracking
+                      description: group is the group of the resource that you're
+                        tracking
                       type: string
                     lastGeneration:
-                      description: lastGeneration is the last generation of the resource that controller applies
+                      description: lastGeneration is the last generation of the resource
+                        that controller applies
                       format: int64
                       type: integer
                     name:
                       description: name is the name of the resource that you're tracking
                       type: string
                     namespace:
-                      description: namespace is where the resource that you're tracking is
+                      description: namespace is where the resource that you're tracking
+                        is
                       type: string
                     resource:
-                      description: resource is the resource type of the resource that you're tracking
+                      description: resource is the resource type of the resource that
+                        you're tracking
                       type: string
                     version:
-                      description: version is the version of the resource that you're tracking
+                      description: version is the version of the resource that you're
+                        tracking
                       type: string
                   type: object
                 type: array
               observedGeneration:
-                description: ObservedGeneration is the last generation change you've dealt with
+                description: ObservedGeneration is the last generation change you've
+                  dealt with
                 format: int64
                 type: integer
               relatedResources:
-                description: RelatedResources are used to track the resources that are related to this Klusterlet.
+                description: RelatedResources are used to track the resources that
+                  are related to this Klusterlet.
                 items:
-                  description: RelatedResourceMeta represents the resource that is managed by an operator
+                  description: RelatedResourceMeta represents the resource that is
+                    managed by an operator
                   properties:
                     group:
-                      description: group is the group of the resource that you're tracking
+                      description: group is the group of the resource that you're
+                        tracking
                       type: string
                     name:
                       description: name is the name of the resource that you're tracking
@@ -261,7 +404,8 @@ spec:
                       description: namespace is where the thing you're tracking is
                       type: string
                     resource:
-                      description: resource is the resource type of the resource that you're tracking
+                      description: resource is the resource type of the resource that
+                        you're tracking
                       type: string
                     version:
                       description: version is the version of the thing you're tracking

--- a/deploy/klusterlet/olm-catalog/klusterlet/metadata/annotations.yaml
+++ b/deploy/klusterlet/olm-catalog/klusterlet/metadata/annotations.yaml
@@ -1,7 +1,10 @@
 annotations:
-    operators.operatorframework.io.bundle.channel.default.v1: stable
-    operators.operatorframework.io.bundle.channels.v1: stable
-    operators.operatorframework.io.bundle.manifests.v1: manifests/
-    operators.operatorframework.io.bundle.mediatype.v1: registry+v1
-    operators.operatorframework.io.bundle.metadata.v1: metadata/
-    operators.operatorframework.io.bundle.package.v1: klusterlet
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: klusterlet
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3

--- a/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{ if not .HostedMode }}
       serviceAccountName: addon-manager-controller-sa
       {{ end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: addon-manager-controller
         image: {{ .AddOnManagerImage }}
@@ -59,7 +63,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{ if not .HostedMode }}
       serviceAccountName: work-controller-sa
       {{ end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: {{ .ClusterManagerName }}-work-controller
         image:  {{ .WorkImage }}
@@ -55,7 +59,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{ if not .HostedMode }}
       serviceAccountName: placement-controller-sa
       {{ end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: placement-controller
         image: {{ .PlacementImage }}
@@ -54,7 +58,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{ if not .HostedMode }}
       serviceAccountName: registration-controller-sa
       {{ end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: hub-registration-controller
         image: {{ .RegistrationImage }}
@@ -62,7 +66,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{ if not .HostedMode }}
       serviceAccountName: registration-webhook-sa
       {{ end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: {{ .ClusterManagerName }}-webhook
         image: {{ .RegistrationImage }}
@@ -66,7 +70,6 @@ spec:
             drop:
             - ALL
           privileged: false
-          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{ if not .HostedMode }}
       serviceAccountName: work-webhook-sa
       {{ end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: {{ .ClusterManagerName }}-webhook
         image: {{ .WorkImage }}
@@ -60,7 +64,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -46,6 +46,10 @@ spec:
                   values:
                   - klusterlet-registration-agent
       serviceAccountName: {{ .KlusterletName }}-agent-sa
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: klusterlet-agent
         image: {{ .SingletonImage }}
@@ -84,7 +88,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         volumeMounts:
         - name: bootstrap-secret
           mountPath: "/spoke/bootstrap"

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -46,6 +46,10 @@ spec:
                   values:
                   - klusterlet-registration-agent
       serviceAccountName: {{ .KlusterletName }}-registration-sa
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: registration-controller
         image: {{ .RegistrationImage }}
@@ -82,7 +86,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         volumeMounts:
         - name: bootstrap-secret
           mountPath: "/spoke/bootstrap"

--- a/manifests/klusterlet/management/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-deployment.yaml
@@ -46,6 +46,10 @@ spec:
                   values:
                   - klusterlet-manifestwork-agent
       serviceAccountName: {{ .KlusterletName }}-work-sa
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: klusterlet-manifestwork-agent
         image: {{ .WorkImage }}
@@ -74,7 +78,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          runAsNonRoot: true
         volumeMounts:
         - name: hub-kubeconfig-secret
           mountPath: "/spoke/hub-kubeconfig"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
fix the securityContext warning when apply deployments.
```
Warning: would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "klusterlet" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "klusterlet" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "klusterlet" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "klusterlet" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")

```