### PR TITLE
:bug:  fix failed update roleRef in clusterrolebinding in upgrade case

### DIFF
--- a/manifests/klusterlet/managed/klusterlet-work-clusterrolebinding-aggregate.yaml
+++ b/manifests/klusterlet/managed/klusterlet-work-clusterrolebinding-aggregate.yaml
@@ -1,12 +1,13 @@
-# deprecated and removed from 0.12
+# ClusterRoleBinding for work execution permissions.
+# TODO: replace this with user defined execution permissions.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: open-cluster-management:{{ .KlusterletName }}-work:execution
+  name: open-cluster-management:{{ .KlusterletName }}-work:aggregate
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: open-cluster-management:{{ .KlusterletName }}-work:execution
+  name: open-cluster-management:{{ .KlusterletName }}-work:aggregate
 subjects:
   - kind: ServiceAccount
     name: {{ .WorkServiceAccount }}

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller_test.go
@@ -50,7 +50,7 @@ func TestSyncDelete(t *testing.T) {
 	}
 
 	// 11 managed static manifests + 12 management static manifests + 1 hub kubeconfig + 2 namespaces + 2 deployments
-	if len(deleteActions) != 28 {
+	if len(deleteActions) != 29 {
 		t.Errorf("Expected 28 delete actions, but got %d", len(deleteActions))
 	}
 
@@ -124,7 +124,7 @@ func TestSyncDeleteHosted(t *testing.T) {
 	}
 
 	// 12 static manifests + 2 namespaces
-	if len(deleteActionsManaged) != 14 {
+	if len(deleteActionsManaged) != 15 {
 		t.Errorf("Expected 14 delete actions, but got %d", len(deleteActionsManaged))
 	}
 

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -1060,7 +1060,7 @@ func TestDeployOnKube111(t *testing.T) {
 	}
 
 	// 12 managed static manifests + 11 management static manifests + 1 hub kubeconfig + 2 namespaces + 2 deployments + 2 kube111 clusterrolebindings
-	if len(deleteActions) != 30 {
+	if len(deleteActions) != 31 {
 		t.Errorf("Expected 30 delete actions, but got %d", len(deleteActions))
 	}
 }

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
@@ -38,9 +38,12 @@ var (
 		"klusterlet/managed/klusterlet-work-clusterrole.yaml",
 		"klusterlet/managed/klusterlet-work-clusterrole-execution.yaml",
 		"klusterlet/managed/klusterlet-work-clusterrolebinding.yaml",
-		"klusterlet/managed/klusterlet-work-clusterrolebinding-execution.yaml",
+		"klusterlet/managed/klusterlet-work-clusterrolebinding-aggregate.yaml",
 		"klusterlet/managed/klusterlet-work-clusterrolebinding-execution-admin.yaml",
 	}
+
+	cleanedManagedStaticResourceFiles = append(managedStaticResourceFiles,
+		"klusterlet/managed/klusterlet-work-clusterrolebinding-execution.yaml")
 
 	kube111StaticResourceFiles = []string{
 		"klusterletkube111/klusterlet-registration-operator-clusterrolebinding.yaml",
@@ -175,7 +178,7 @@ func (r *managedReconcile) clean(ctx context.Context, klusterlet *operatorapiv1.
 	}
 
 	if err := removeStaticResources(ctx, r.managedClusterClients.kubeClient, r.managedClusterClients.apiExtensionClient,
-		managedStaticResourceFiles, config); err != nil {
+		cleanedManagedStaticResourceFiles, config); err != nil {
 		return klusterlet, reconcileStop, err
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the roleRef is changed in work-execution clusterrolebinding, so failed to update the clusterrolebinding during upgrade scenario. 
## Related issue(s)

Fixes #