### PR TITLE
:sparkles: operator sdk support arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ ifeq ($(GOHOSTOS),darwin)
 	ifeq ($(GOHOSTARCH),amd64)
 		OPERATOR_SDK_ARCHOS:=darwin_amd64
 	endif
+	ifeq ($(GOHOSTARCH),arm64)
+		OPERATOR_SDK_ARCHOS:=darwin_arm64
+	endif
 endif
 
 # Add packages to do unit test


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
operator-sdk support Mac M2 locally build
## Related issue(s)

$ ./_output/tools/bin/operator-sdk
bash: ./_output/tools/bin/operator-sdk: cannot execute binary file: Exec format error


Fixes #