### PR TITLE
 :sparkles: WIP: Add nodeStatus.

### DIFF
--- a/manifests/cluster-manager/hub/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_clusters.open-cluster-management.io_managedclusters.crd.yaml
@@ -263,6 +263,26 @@ spec:
                   - type
                   type: object
                 type: array
+              nodeStatus:
+                description: NodeStatus represents the status of nodes on the managed
+                  cluster.
+                properties:
+                  ready:
+                    description: Ready represents the number of ready nodes on the
+                      managed cluster.
+                    format: int32
+                    type: integer
+                  schedulable:
+                    description: Schedulable represents the number of schedulable
+                      nodes on the managed cluster.
+                    format: int32
+                    type: integer
+                  total:
+                    description: Total represents the total number of nodes on the
+                      managed cluster.
+                    format: int32
+                    type: integer
+                type: object
               version:
                 description: Version represents the kubernetes version of the managed
                   cluster.

--- a/pkg/registration/spoke/managedcluster/nodestatus.go
+++ b/pkg/registration/spoke/managedcluster/nodestatus.go
@@ -1,0 +1,150 @@
+package managedcluster
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+func (r *resoureReconcile) getClusterNodeStatus() (clusterv1.NodeStatus, error) {
+	nodes, err := r.nodeLister.List(labels.Everything())
+	if err != nil {
+		return clusterv1.NodeStatus{}, err
+	}
+
+	var schedulable, ready int32
+	for _, node := range nodes {
+		if IsNodeReady(node) {
+			ready++
+		}
+		if IsNodeSchedulable(node) {
+			schedulable++
+		}
+	}
+
+	return clusterv1.NodeStatus{
+		Total:       int32(len(nodes)),
+		Schedulable: schedulable,
+		Ready:       ready,
+	}, nil
+}
+
+// The code is copy from the kubernetes/kubernetes: https://github.com/kubernetes/kubernetes/blob/138ac71fb12bdd4f24b4b1b10c054e07c55f4364/test/integration/framework/util.go
+// IsNodeSchedulable returns true if:
+// 1) doesn't have "unschedulable" field set
+// 2) it also returns true from IsNodeReady
+func IsNodeSchedulable(node *v1.Node) bool {
+	if node == nil {
+		return false
+	}
+	return !node.Spec.Unschedulable && IsNodeReady(node)
+}
+
+// IsNodeReady returns true if:
+// 1) it's Ready condition is set to true
+// 2) doesn't have NetworkUnavailable condition set to true
+func IsNodeReady(node *v1.Node) bool {
+	nodeReady := IsConditionSetAsExpected(node, v1.NodeReady, true)
+	networkReady := isConditionUnset(node, v1.NodeNetworkUnavailable) ||
+		IsConditionSetAsExpectedSilent(node, v1.NodeNetworkUnavailable, false)
+	return nodeReady && networkReady
+}
+
+// IsConditionSetAsExpected returns a wantTrue value if the node has a match to the conditionType, otherwise returns an opposite value of the wantTrue with detailed logging.
+func IsConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionType, wantTrue bool) bool {
+	return isNodeConditionSetAsExpected(node, conditionType, wantTrue, false)
+}
+
+// IsConditionSetAsExpectedSilent returns a wantTrue value if the node has a match to the conditionType, otherwise returns an opposite value of the wantTrue.
+func IsConditionSetAsExpectedSilent(node *v1.Node, conditionType v1.NodeConditionType, wantTrue bool) bool {
+	return isNodeConditionSetAsExpected(node, conditionType, wantTrue, true)
+}
+
+// isConditionUnset returns true if conditions of the given node do not have a match to the given conditionType, otherwise false.
+func isConditionUnset(node *v1.Node, conditionType v1.NodeConditionType) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == conditionType {
+			return false
+		}
+	}
+	return true
+}
+
+var (
+	// UnreachableTaintTemplate is the taint for when a node becomes unreachable.
+	UnreachableTaintTemplate = &v1.Taint{
+		Key:    v1.TaintNodeUnreachable,
+		Effect: v1.TaintEffectNoExecute,
+	}
+
+	// NotReadyTaintTemplate is the taint for when a node is not ready for
+	// executing pods
+	NotReadyTaintTemplate = &v1.Taint{
+		Key:    v1.TaintNodeNotReady,
+		Effect: v1.TaintEffectNoExecute,
+	}
+)
+
+// isNodeConditionSetAsExpected checks a node for a condition, and returns 'true' if the wanted value is the same as the condition value, useful for polling until a condition on a node is met.
+func isNodeConditionSetAsExpected(node *v1.Node, conditionType v1.NodeConditionType, wantTrue, silent bool) bool {
+	// Check the node readiness condition (logging all).
+	for _, cond := range node.Status.Conditions {
+		// Ensure that the condition type and the status matches as desired.
+		if cond.Type == conditionType {
+			// For NodeReady condition we need to check Taints as well
+			if cond.Type == v1.NodeReady {
+				hasNodeControllerTaints := false
+				// For NodeReady we need to check if Taints are gone as well
+				taints := node.Spec.Taints
+				for _, taint := range taints {
+					if taint.MatchTaint(UnreachableTaintTemplate) || taint.MatchTaint(NotReadyTaintTemplate) {
+						hasNodeControllerTaints = true
+						break
+					}
+				}
+				if wantTrue {
+					if (cond.Status == v1.ConditionTrue) && !hasNodeControllerTaints {
+						return true
+					}
+					msg := ""
+					if !hasNodeControllerTaints {
+						msg = fmt.Sprintf("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
+							conditionType, node.Name, cond.Status == v1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
+					} else {
+						msg = fmt.Sprintf("Condition %s of node %s is %v, but Node is tainted by NodeController with %v. Failure",
+							conditionType, node.Name, cond.Status == v1.ConditionTrue, taints)
+					}
+					if !silent {
+						klog.Infof(msg)
+					}
+					return false
+				}
+				// TODO: check if the Node is tainted once we enable NC notReady/unreachable taints by default
+				if cond.Status != v1.ConditionTrue {
+					return true
+				}
+				if !silent {
+					klog.Infof("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
+						conditionType, node.Name, cond.Status == v1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
+				}
+				return false
+			}
+			if (wantTrue && (cond.Status == v1.ConditionTrue)) || (!wantTrue && (cond.Status != v1.ConditionTrue)) {
+				return true
+			}
+			if !silent {
+				klog.Infof("Condition %s of node %s is %v instead of %t. Reason: %v, message: %v",
+					conditionType, node.Name, cond.Status == v1.ConditionTrue, wantTrue, cond.Reason, cond.Message)
+			}
+			return false
+		}
+
+	}
+	if !silent {
+		klog.Infof("Couldn't find condition %v on node %v", conditionType, node.Name)
+	}
+	return false
+}

--- a/pkg/registration/spoke/managedcluster/resource_reconcile.go
+++ b/pkg/registration/spoke/managedcluster/resource_reconcile.go
@@ -36,6 +36,13 @@ func (r *resoureReconcile) reconcile(ctx context.Context, cluster *clusterv1.Man
 			return cluster, reconcileStop, fmt.Errorf("unable to get capacity and allocatable of managed cluster %q: %w", cluster.Name, err)
 		}
 
+		// update nodeStatus
+		nodeStatus, err := r.getClusterNodeStatus()
+		if err != nil {
+			return cluster, reconcileStop, fmt.Errorf("unable to get nodeStatus of managed cluster %q: %w", cluster.Name, err)
+		}
+		cluster.Status.NodeStatus = nodeStatus
+
 		// we allow other components update the cluster capacity, so we need merge the capacity to this updated, if
 		// one current capacity entry does not exist in this updated capacity, we add it back.
 		for key, val := range cluster.Status.Capacity {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The PR aim to add nodeStatus in managedcluster CRD.

The code to determine whether the node is ready or schedulabe is directly copied from the kubernetes repo: https://github.com/kubernetes/kubernetes/blob/138ac71fb12bdd4f24b4b1b10c054e07c55f4364/test/integration/framework/util.go

## Related issue(s)

Fixes #