### PR TITLE
:bug: Remove codecov token.

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -35,7 +35,6 @@ jobs:
       - name: report coverage
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./coverage.out
           flags: unit
           name: unit

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -65,7 +65,6 @@ jobs:
       - name: report coverage
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./coverage.out
           flags: unit
           name: unit


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Recently, the codecov push keeps fail, through test we know the token is not required for public repos, so we can remove the token to fix that failure, the approach is verified in cluster-proxy-addon repo: https://github.com/open-cluster-management-io/cluster-proxy/pull/174

Also the OCM_BOT_TOKEN also shows "Bad credentials" when we try to trigger clusteradmin e2e test after PR merged, can we have a check on that token in case it's out-of-date? @qiujian16 

## Related issue(s)

Fixes #

https://github.com/open-cluster-management-io/ocm/actions/runs/7497318242/job/20410721816