### PR TITLE
WIP :bug: Fix: make kube a default value of workloadsourcedriver.

### DIFF
--- a/pkg/work/spoke/options.go
+++ b/pkg/work/spoke/options.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/work"
 )
 
 const (
@@ -28,6 +30,8 @@ func NewWorkloadAgentOptions() *WorkloadAgentOptions {
 		MaxJSONRawLength:                       1024,
 		StatusSyncInterval:                     10 * time.Second,
 		AppliedManifestWorkEvictionGracePeriod: 60 * time.Minute,
+		WorkloadSourceDriver:                   work.ConfigTypeKube,
+		WorkloadSourceConfig:                   "/spoke/hub-kubeconfig/kubeconfig",
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

We want use kube as the default driver even no driver set.
