### PR TITLE
🐛 create migration cr after the cluster manager cr is applied

### DIFF
--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -267,10 +267,11 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	clusterManager.Status.ObservedGeneration = clusterManager.Generation
 	if len(errs) == 0 {
 		meta.SetStatusCondition(&clusterManager.Status.Conditions, metav1.Condition{
-			Type:    clusterManagerApplied,
-			Status:  metav1.ConditionTrue,
-			Reason:  "ClusterManagerApplied",
-			Message: "Components of cluster manager are applied",
+			Type:               clusterManagerApplied,
+			Status:             metav1.ConditionTrue,
+			Reason:             "ClusterManagerApplied",
+			Message:            "Components of cluster manager are applied",
+			ObservedGeneration: clusterManager.Generation,
 		})
 	} else {
 		// When appliedCondition is false, we should not update related resources and resource generations


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR will:
- add the `ObservedGeneration` field for the cluster manager Applied condition
- wait the current generation cluster manager is applied(`Applied` condition is true and the `ObservedGeneration`==`Generation`), then create the migration CR

## Related issue(s)

Fixes #