### PR TITLE
:bug: CI should pass when on codecov upload fail.

### DIFF
--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -69,7 +69,7 @@ jobs:
           flags: unit
           name: unit
           verbose: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   integration:
     name: integration


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Codecov becomes because github api outage sometimes. Change to pass CI job when the codecov upload is failed.

## Related issue(s)

https://github.com/codecov/codecov-action/issues/926