### PR TITLE
:sparkles: Add image pullSecret to hub controllers

### DIFF
--- a/deploy/cluster-manager/config/rbac/cluster_role.yaml
+++ b/deploy/cluster-manager/config/rbac/cluster_role.yaml
@@ -25,6 +25,7 @@ rules:
     - "addon-manager-controller-sa-kubeconfig"
     - "external-hub-kubeconfig"
     - "work-driver-config"
+    - "open-cluster-management-image-pull-credentials"
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create"]

--- a/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
@@ -147,6 +147,7 @@ spec:
           - addon-manager-controller-sa-kubeconfig
           - external-hub-kubeconfig
           - work-driver-config
+          - open-cluster-management-image-pull-credentials
           resources:
           - secrets
           verbs:

--- a/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   operator: In
                   values:
                   - clustermanager-addon-manager-controller
+      {{- if .ImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .ImagePullSecret }}
+      {{- end }}
       {{ if not .HostedMode }}
       serviceAccountName: addon-manager-controller-sa
       {{ end }}

--- a/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   operator: In
                   values:
                   - {{ .ClusterManagerName }}-work-controller
+      {{- if .ImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .ImagePullSecret }}
+      {{- end }}
       {{ if not .HostedMode }}
       serviceAccountName: work-controller-sa
       {{ end }}

--- a/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   operator: In
                   values:
                   - clustermanager-placement-controller
+      {{- if .ImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .ImagePullSecret }}
+      {{- end }}
       {{ if not .HostedMode }}
       serviceAccountName: placement-controller-sa
       {{ end }}

--- a/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   operator: In
                   values:
                   - clustermanager-registration-controller
+      {{- if .ImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .ImagePullSecret }}
+      {{- end }}
       {{ if not .HostedMode }}
       serviceAccountName: registration-controller-sa
       {{ end }}

--- a/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   operator: In
                   values:
                   - {{ .ClusterManagerName }}-registration-webhook
+      {{- if .ImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .ImagePullSecret }}
+      {{- end }}
       {{ if not .HostedMode }}
       serviceAccountName: registration-webhook-sa
       {{ end }}

--- a/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   operator: In
                   values:
                   - {{ .ClusterManagerName }}-work-webhook
+      {{- if .ImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .ImagePullSecret }}
+      {{- end }}
       {{ if not .HostedMode }}
       serviceAccountName: work-webhook-sa
       {{ end }}

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -22,6 +22,7 @@ type HubConfig struct {
 	CloudEventsDriverEnabled       bool
 	WorkDriver                     string
 	AutoApproveUsers               string
+	ImagePullSecret                string
 	// ResourceRequirementResourceType is the resource requirement resource type for the cluster manager managed containers.
 	ResourceRequirementResourceType operatorapiv1.ResourceQosClass
 	// ResourceRequirements is the resource requirements for the cluster manager managed containers.

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -55,6 +55,9 @@ const (
 	// ImagePullSecret is the image pull secret for operator components, which is synced from the operator ns to hub/spoke/addon ns.
 	ImagePullSecret = "open-cluster-management-image-pull-credentials"
 
+	// WorkDriverConfigSecret is the secret that contains the work driver configuration
+	WorkDriverConfigSecret = "work-driver-config"
+
 	// DefaultComponentNamespace is the default namespace in which the operator is deployed
 	DefaultComponentNamespace = "open-cluster-management"
 )

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
@@ -302,52 +302,128 @@ func ensureObject(t *testing.T, object runtime.Object, hubCore *operatorapiv1.Cl
 }
 
 func TestSyncSecret(t *testing.T) {
-	operatorNamespace := metav1.NamespaceDefault
-	clusterManager := newClusterManager("testhub")
-	clusterManager.Spec.WorkConfiguration.FeatureGates = append(clusterManager.Spec.WorkConfiguration.FeatureGates,
-		operatorapiv1.FeatureGate{
-			Feature: string(ocmfeature.CloudEventsDrivers),
-			Mode:    operatorapiv1.FeatureGateModeTypeEnable,
-		})
-	clusterManager.Spec.WorkConfiguration.WorkDriver = operatorapiv1.WorkDriverTypeGrpc
-	tc := newTestController(t, clusterManager)
-	tc.clusterManagerController.operatorNamespace = operatorNamespace
-	clusterManagerNamespace := helpers.ClusterManagerNamespace(clusterManager.Name, clusterManager.Spec.DeployOption.Mode)
-	setup(t, tc, nil)
-
-	syncContext := testingcommon.NewFakeSyncContext(t, "testhub")
-
-	err := tc.clusterManagerController.sync(ctx, syncContext)
-	if err != nil {
-		t.Fatalf("Expected no error when sync, %v", err)
-	}
-
-	workDriverConfig := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "work-driver-config",
+	operatorNamespace := helpers.DefaultComponentNamespace
+	tests := []struct {
+		name                                    string
+		clusterManager                          func() *operatorapiv1.ClusterManager
+		imagePullSecret, workDriverConfigSecret *corev1.Secret
+	}{
+		{
+			name: "sync imagePullSecret, workDriverConfigSecret",
+			clusterManager: func() *operatorapiv1.ClusterManager {
+				clusterManager := newClusterManager("testhub")
+				clusterManager.Spec.WorkConfiguration.FeatureGates = append(clusterManager.Spec.WorkConfiguration.FeatureGates,
+					operatorapiv1.FeatureGate{
+						Feature: string(ocmfeature.CloudEventsDrivers),
+						Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+					})
+				clusterManager.Spec.WorkConfiguration.WorkDriver = operatorapiv1.WorkDriverTypeGrpc
+				return clusterManager
+			},
+			imagePullSecret: newSecret(helpers.ImagePullSecret, operatorNamespace),
+			workDriverConfigSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: helpers.WorkDriverConfigSecret,
+				},
+				Data: map[string][]byte{
+					"config.yaml": []byte("url: grpc.example.com:8443"),
+				},
+			},
 		},
-		Data: map[string][]byte{
-			"config.yaml": []byte("url: grpc.example.com:8443"),
+		{
+			name: "sync imagePullSecret",
+			clusterManager: func() *operatorapiv1.ClusterManager {
+				return newClusterManager("testhub")
+			},
+			imagePullSecret: newSecret(helpers.ImagePullSecret, operatorNamespace),
+		},
+		{
+			name: "sync workDriverConfigSecret",
+			clusterManager: func() *operatorapiv1.ClusterManager {
+				clusterManager := newClusterManager("testhub")
+				clusterManager.Spec.WorkConfiguration.FeatureGates = append(clusterManager.Spec.WorkConfiguration.FeatureGates,
+					operatorapiv1.FeatureGate{
+						Feature: string(ocmfeature.CloudEventsDrivers),
+						Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+					})
+				clusterManager.Spec.WorkConfiguration.WorkDriver = operatorapiv1.WorkDriverTypeGrpc
+				return clusterManager
+			},
+			workDriverConfigSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: helpers.WorkDriverConfigSecret,
+				},
+				Data: map[string][]byte{
+					"config.yaml": []byte("url: grpc.example.com:8443"),
+				},
+			},
 		},
 	}
+	for _, c := range tests {
+		cm := c.clusterManager()
+		tc := newTestController(t, cm)
+		tc.clusterManagerController.operatorNamespace = operatorNamespace
+		clusterManagerNamespace := helpers.ClusterManagerNamespace(cm.Name, cm.Spec.DeployOption.Mode)
+		setup(t, tc, nil)
 
-	if _, err = tc.managementKubeClient.CoreV1().Secrets(operatorNamespace).Create(ctx, workDriverConfig, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create work driver config secret: %v", err)
-	}
+		syncContext := testingcommon.NewFakeSyncContext(t, "testhub")
 
-	err = tc.clusterManagerController.sync(ctx, syncContext)
-	if err != nil {
-		t.Fatalf("Expected no error when sync, %v", err)
-	}
+		if c.imagePullSecret != nil {
+			if _, err := tc.managementKubeClient.CoreV1().Secrets(operatorNamespace).Create(ctx, c.imagePullSecret, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create image pull secret: %v", err)
+			}
+		}
 
-	// TODO: add test for secret sync condition
-	syncedSecret, err := tc.hubKubeClient.CoreV1().Secrets(clusterManagerNamespace).Get(ctx, "work-driver-config", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Failed to get synced work driver config secret: %v", err)
-	}
+		if c.workDriverConfigSecret != nil {
+			if _, err := tc.managementKubeClient.CoreV1().Secrets(operatorNamespace).Create(ctx, c.workDriverConfigSecret, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create work driver config secret: %v", err)
+			}
+		}
 
-	if string(syncedSecret.Data["config.yaml"]) != "url: grpc.example.com:8443" {
-		t.Fatalf("Expected secret data to be url: grpc.example.com:8443")
+		err := tc.clusterManagerController.sync(ctx, syncContext)
+		if err != nil {
+			t.Fatalf("Expected no error when sync, %v", err)
+		}
+
+		syncedSecret, err := tc.hubKubeClient.CoreV1().Secrets(clusterManagerNamespace).Get(ctx, helpers.WorkDriverConfigSecret, metav1.GetOptions{})
+		if c.workDriverConfigSecret == nil && !errors.IsNotFound(err) {
+			t.Fatalf("excpected no secret %v but got: %v", helpers.WorkDriverConfigSecret, err)
+		}
+		if c.workDriverConfigSecret != nil {
+			if err != nil {
+				t.Fatalf("Failed to get synced work driver config secret: %v", err)
+			}
+
+			if string(syncedSecret.Data["config.yaml"]) != "url: grpc.example.com:8443" {
+				t.Fatalf("Expected secret data to be url: grpc.example.com:8443")
+			}
+		}
+
+		_, err = tc.hubKubeClient.CoreV1().Secrets(clusterManagerNamespace).Get(ctx, helpers.ImagePullSecret, metav1.GetOptions{})
+		if c.imagePullSecret == nil && !errors.IsNotFound(err) {
+			t.Fatalf("excpected no secret %v but got: %v", helpers.ImagePullSecret, err)
+		}
+		if c.imagePullSecret != nil && err != nil {
+			t.Fatalf("Failed to get synced image pull secret: %v", err)
+		}
+
+		deploymentList, err := tc.hubKubeClient.AppsV1().Deployments(clusterManagerNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Fatalf("Failed to list deployment: %v", err)
+		}
+		for _, deployment := range deploymentList.Items {
+			if c.imagePullSecret == nil && len(deployment.Spec.Template.Spec.ImagePullSecrets) != 0 {
+				t.Fatalf("Expected no image pull secret in deployment. %v", deployment.Name)
+			}
+
+			if c.imagePullSecret != nil && len(deployment.Spec.Template.Spec.ImagePullSecrets) == 0 {
+				t.Fatalf("Expected image pull secret in deployment. %v", deployment.Name)
+			}
+
+			if c.imagePullSecret != nil && deployment.Spec.Template.Spec.ImagePullSecrets[0].Name != helpers.ImagePullSecret {
+				t.Fatalf("Expected correct image pull secret name in deployment. %v", deployment.Name)
+			}
+		}
 	}
 }
 
@@ -459,7 +535,7 @@ func TestSyncDelete(t *testing.T) {
 			deleteKubeActions = append(deleteKubeActions, deleteKubeAction)
 		}
 	}
-	testingcommon.AssertEqualNumber(t, len(deleteKubeActions), 28) // delete namespace both from the hub cluster and the mangement cluster
+	testingcommon.AssertEqualNumber(t, len(deleteKubeActions), 30) // delete namespace both from the hub cluster and the mangement cluster
 
 	var deleteCRDActions []clienttesting.DeleteActionImpl
 	crdActions := tc.apiExtensionClient.Actions()
@@ -655,5 +731,15 @@ func getManifestFiles() []string {
 		"cluster-manager/management/cluster-manager-registration-deployment.yaml",
 		"cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml",
 		"cluster-manager/management/cluster-manager-work-webhook-deployment.yaml",
+	}
+}
+
+func newSecret(name, namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{},
 	}
 }

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_hub_reconcile.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_hub_reconcile.go
@@ -77,13 +77,13 @@ var (
 	hubHostedWebhookEndpointWork         = "cluster-manager/hub/cluster-manager-work-webhook-endpoint-hosted.yaml"
 )
 
-type hubReoncile struct {
+type hubReconcile struct {
 	hubKubeClient kubernetes.Interface
 	cache         resourceapply.ResourceCache
 	recorder      events.Recorder
 }
 
-func (c *hubReoncile) reconcile(ctx context.Context, cm *operatorapiv1.ClusterManager,
+func (c *hubReconcile) reconcile(ctx context.Context, cm *operatorapiv1.ClusterManager,
 	config manifests.HubConfig) (*operatorapiv1.ClusterManager, reconcileState, error) {
 	// If AddOnManager is not enabled, remove related resources
 	if !config.AddOnManagerEnabled {
@@ -140,7 +140,7 @@ func (c *hubReoncile) reconcile(ctx context.Context, cm *operatorapiv1.ClusterMa
 	return cm, reconcileContinue, nil
 }
 
-func (c *hubReoncile) clean(ctx context.Context, cm *operatorapiv1.ClusterManager,
+func (c *hubReconcile) clean(ctx context.Context, cm *operatorapiv1.ClusterManager,
 	config manifests.HubConfig) (*operatorapiv1.ClusterManager, reconcileState, error) {
 	hubResources := getHubResources(cm.Spec.DeployOption.Mode, config)
 	return cleanResources(ctx, c.hubKubeClient, cm, config, hubResources...)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
@@ -166,7 +166,7 @@ func (n *klusterletCleanupController) sync(ctx context.Context, controllerContex
 					managedClusterClients: managedClusterClients,
 					kubeClient:            n.kubeClient,
 					kubeVersion:           n.kubeVersion,
-					opratorNamespace:      n.operatorNamespace,
+					operatorNamespace:     n.operatorNamespace,
 					recorder:              controllerContext.Recorder(),
 				},
 			)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -298,7 +298,7 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 			managedClusterClients: managedClusterClients,
 			kubeClient:            n.kubeClient,
 			kubeVersion:           n.kubeVersion,
-			opratorNamespace:      n.operatorNamespace,
+			operatorNamespace:     n.operatorNamespace,
 			recorder:              controllerContext.Recorder(),
 			cache:                 n.cache},
 		&managementReconcile{

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
@@ -55,7 +55,7 @@ var (
 type managedReconcile struct {
 	managedClusterClients *managedClusterClients
 	kubeClient            kubernetes.Interface
-	opratorNamespace      string
+	operatorNamespace     string
 	kubeVersion           *version.Version
 	recorder              events.Recorder
 	cache                 resourceapply.ResourceCache
@@ -77,7 +77,7 @@ func (r *managedReconcile) reconcile(ctx context.Context, klusterlet *operatorap
 	// addonsecretcontroller only watch namespaces in the same cluster klusterlet is running on.
 	// And if addons are deployed in default mode on the managed cluster, but klusterlet is deployed in hosted
 	// on management cluster, then we still need to sync the secret here in klusterlet-controller using `managedClusterClients.kubeClient`.
-	err = syncPullSecret(ctx, r.kubeClient, r.managedClusterClients.kubeClient, klusterlet, r.opratorNamespace, addonNamespace, r.recorder)
+	err = syncPullSecret(ctx, r.kubeClient, r.managedClusterClients.kubeClient, klusterlet, r.operatorNamespace, addonNamespace, r.recorder)
 	if err != nil {
 		return klusterlet, reconcileStop, err
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Support to sync the imagePullSecret `open-cluster-management-image-pull-credentials` in the operator ns to the hub namespace. 
## Related issue(s)

Fixes #