### PR TITLE
:seedling: Refactor Lease controller test cases.

### DIFF
--- a/pkg/registration/spoke/lease/lease_controller.go
+++ b/pkg/registration/spoke/lease/lease_controller.go
@@ -26,7 +26,7 @@ type managedClusterLeaseController struct {
 	clusterName              string
 	hubClusterLister         clusterv1listers.ManagedClusterLister
 	lastLeaseDurationSeconds int32
-	leaseUpdater             *leaseUpdater
+	leaseUpdater             leaseUpdaterInterface
 }
 
 // NewManagedClusterLeaseController creates a new managed cluster lease controller on the managed cluster.
@@ -83,6 +83,11 @@ func (c *managedClusterLeaseController) sync(ctx context.Context, syncCtx factor
 	// ensure there is a starting lease update routine.
 	c.leaseUpdater.start(ctx, time.Duration(c.lastLeaseDurationSeconds)*time.Second)
 	return nil
+}
+
+type leaseUpdaterInterface interface {
+	start(ctx context.Context, leaseDuration time.Duration)
+	stop()
 }
 
 // leaseUpdater periodically updates the lease of a managed cluster


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Nothing change in the real code, all changes is about u-t test cases.

We want to avoid using specific times like:

```go
// wait one cycle (1 ~ 1.25s)
time.Sleep(2000 * time.Millisecond)
```

or:

```go
// wait a few milliseconds to start the lease update routine
time.Sleep(500 * time.Millisecond)
```

When u-t is running on a different environment, it may cause inaccurate results.