### PR TITLE
:bug:  should not stop other reconcilers when failed to sync images

### DIFF
--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_secret_reconcile.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_secret_reconcile.go
@@ -64,7 +64,7 @@ func (c *secretReconcile) reconcile(ctx context.Context, cm *operatorapiv1.Clust
 			Message: fmt.Sprintf("Failed to sync secrets to clusterManager namespace %v: %v",
 				config.ClusterManagerNamespace, utilerrors.NewAggregate(syncedErrs))})
 
-		return cm, reconcileStop, utilerrors.NewAggregate(syncedErrs)
+		return cm, reconcileContinue, utilerrors.NewAggregate(syncedErrs)
 	}
 
 	return cm, reconcileContinue, nil
@@ -78,7 +78,7 @@ func (c *secretReconcile) clean(ctx context.Context, cm *operatorapiv1.ClusterMa
 			if errors.IsNotFound(err) {
 				continue
 			}
-			return cm, reconcileStop, fmt.Errorf("failed to delete secret %s: %v", secretName, err)
+			return cm, reconcileContinue, fmt.Errorf("failed to delete secret %s: %v", secretName, err)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
should not stop other reconcilers when failed to sync images.
## Related issue(s)

Fixes #