### PR TITLE
 🐛 Always create default addon namespace

### DIFF
--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -49,6 +49,9 @@ const (
 	FeatureGatesTypeValid             = "ValidFeatureGates"
 	FeatureGatesReasonAllValid        = "FeatureGatesAllValid"
 	FeatureGatesReasonInvalidExisting = "InvalidFeatureGatesExisting"
+
+	// DefaultAddonNamespace is the default namespace for agent addon
+	DefaultAddonNamespace = "open-cluster-management-agent-addon"
 )
 
 const (

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
@@ -66,9 +66,8 @@ func (r *managedReconcile) reconcile(ctx context.Context, klusterlet *operatorap
 	// For now, whether in Default or Hosted mode, the addons will be deployed on the managed cluster.
 	// sync image pull secret from management cluster to managed cluster for addon namespace
 	// TODO(zhujian7): In the future, we may consider deploy addons on the management cluster in Hosted mode.
-	addonNamespace := fmt.Sprintf("%s-addon", config.KlusterletNamespace)
 	// Ensure the addon namespace on the managed cluster
-	err := ensureNamespace(ctx, r.managedClusterClients.kubeClient, klusterlet, addonNamespace, nil, r.recorder)
+	err := ensureNamespace(ctx, r.managedClusterClients.kubeClient, klusterlet, helpers.DefaultAddonNamespace, nil, r.recorder)
 	if err != nil {
 		return klusterlet, reconcileStop, err
 	}
@@ -77,7 +76,7 @@ func (r *managedReconcile) reconcile(ctx context.Context, klusterlet *operatorap
 	// addonsecretcontroller only watch namespaces in the same cluster klusterlet is running on.
 	// And if addons are deployed in default mode on the managed cluster, but klusterlet is deployed in hosted
 	// on management cluster, then we still need to sync the secret here in klusterlet-controller using `managedClusterClients.kubeClient`.
-	err = syncPullSecret(ctx, r.kubeClient, r.managedClusterClients.kubeClient, klusterlet, r.operatorNamespace, addonNamespace, r.recorder)
+	err = syncPullSecret(ctx, r.kubeClient, r.managedClusterClients.kubeClient, klusterlet, r.operatorNamespace, helpers.DefaultAddonNamespace, r.recorder)
 	if err != nil {
 		return klusterlet, reconcileStop, err
 	}

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_namespace_reconcile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_namespace_reconcile.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorapiv1 "open-cluster-management.io/api/operator/v1"
+
+	"open-cluster-management.io/ocm/pkg/operator/helpers"
 )
 
 // namespaceReconcile is the reconciler to handle the case when spec.namespace is changed, and we need to
@@ -37,7 +39,7 @@ func (r *namespaceReconcile) reconcile(
 		return klusterlet, reconcileStop, err
 	}
 	for _, ns := range namespaces.Items {
-		if ns.Name == config.KlusterletNamespace || ns.Name == config.KlusterletNamespace+"-addon" {
+		if ns.Name == config.KlusterletNamespace || ns.Name == helpers.DefaultAddonNamespace {
 			continue
 		}
 		if err := r.managedClusterClients.kubeClient.CoreV1().Namespaces().Delete(

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -22,6 +22,7 @@ import (
 	workapiv1 "open-cluster-management.io/api/work/v1"
 
 	"open-cluster-management.io/ocm/pkg/addon/templateagent"
+	"open-cluster-management.io/ocm/pkg/operator/helpers"
 	"open-cluster-management.io/ocm/test/e2e/manifests"
 )
 
@@ -65,7 +66,6 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 	}
 
 	ginkgo.BeforeEach(func() {
-		addonInstallNamespace = fmt.Sprintf("%s-addon", agentNamespace)
 		ginkgo.By("create addon custom sign secret")
 		err := copySignerSecret(context.TODO(), t.HubKubeClient, "open-cluster-management-hub",
 			"signer-secret", templateagent.AddonManagerNamespace(), customSignerSecretName)
@@ -73,6 +73,8 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 
 		// the addon manager deployment should be running
 		gomega.Eventually(t.CheckHubReady, t.EventuallyTimeout, t.EventuallyInterval).Should(gomega.Succeed())
+
+		addonInstallNamespace = helpers.DefaultAddonNamespace
 
 		ginkgo.By(fmt.Sprintf("create addon template resources for cluster %v", clusterName))
 		err = createResourcesFromYamlFiles(context.Background(), t.HubDynamicClient, t.hubRestMapper, s,

--- a/test/integration/operator/klusterlet_hosted_test.go
+++ b/test/integration/operator/klusterlet_hosted_test.go
@@ -247,9 +247,8 @@ var _ = ginkgo.Describe("Klusterlet Hosted mode", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			// Check addon namespace
-			addonNamespace := fmt.Sprintf("%s-addon", klusterletNamespace)
 			gomega.Eventually(func() bool {
-				if _, err := hostedKubeClient.CoreV1().Namespaces().Get(context.Background(), addonNamespace, metav1.GetOptions{}); err != nil {
+				if _, err := hostedKubeClient.CoreV1().Namespaces().Get(context.Background(), helpers.DefaultAddonNamespace, metav1.GetOptions{}); err != nil {
 					return false
 				}
 				return true

--- a/test/integration/operator/klusterlet_singleton_test.go
+++ b/test/integration/operator/klusterlet_singleton_test.go
@@ -19,7 +19,6 @@ import (
 var _ = ginkgo.Describe("Klusterlet Singleton mode", func() {
 	var cancel context.CancelFunc
 	var klusterlet *operatorapiv1.Klusterlet
-	var klusterletNamespace string
 	var agentNamespace string
 	var registrationManagementRoleName string
 	var registrationManagedRoleName string
@@ -47,7 +46,6 @@ var _ = ginkgo.Describe("Klusterlet Singleton mode", func() {
 				},
 			},
 		}
-		klusterletNamespace = helpers.KlusterletNamespace(klusterlet)
 		agentNamespace = helpers.AgentNamespace(klusterlet)
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -202,9 +200,8 @@ var _ = ginkgo.Describe("Klusterlet Singleton mode", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			// Check addon namespace
-			addonNamespace := fmt.Sprintf("%s-addon", klusterletNamespace)
 			gomega.Eventually(func() bool {
-				if _, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), addonNamespace, metav1.GetOptions{}); err != nil {
+				if _, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), helpers.DefaultAddonNamespace, metav1.GetOptions{}); err != nil {
 					return false
 				}
 				return true

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -244,9 +244,8 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			// Check addon namespace
-			addonNamespace := fmt.Sprintf("%s-addon", klusterletNamespace)
 			gomega.Eventually(func() bool {
-				if _, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), addonNamespace, metav1.GetOptions{}); err != nil {
+				if _, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), helpers.DefaultAddonNamespace, metav1.GetOptions{}); err != nil {
 					return false
 				}
 				return true


### PR DESCRIPTION
The addon namespace should always be default on.
The operator will not create addon ns based
on klusterlet install namespace.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #