### PR TITLE
🐛 Only decorate namespace for namespaced resources

### DIFF
--- a/pkg/addon/templateagent/decorator.go
+++ b/pkg/addon/templateagent/decorator.go
@@ -46,9 +46,10 @@ func (d *namespaceDecorator) decorate(obj *unstructured.Unstructured) (*unstruct
 		return obj, nil
 	}
 
-	// set namespace for all manifests, if the manifest is cluster scoped, namespace will be ignored when
-	// being applied.
-	obj.SetNamespace(d.installNamespace)
+	// If obj has no namespace set, we do not mutate namespace assuming it is cluster scoped.
+	if len(obj.GetNamespace()) > 0 {
+		obj.SetNamespace(d.installNamespace)
+	}
 
 	paths, ok := d.paths[obj.GetKind()]
 	if !ok {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Only decorate namespace for namespaced resources for template addons, otherwise if we set the `namespace` for cluster-scoped resources, and we want to use the annotation `addon.open-cluster-management.io/deletion-orphan` to orphan the resource when deleting the addon, the deleteOption will look like:
```
  deleteOption:
    propagationPolicy: SelectivelyOrphan
    selectivelyOrphans:
      orphaningRules:
      - group: ""
        name: open-cluster-management-agent-addon
        namespace: open-cluster-management-agent-addon # added ns value
        resource: namespaces
```
the extra `namespace` filed will result in the resource being deleted
## Related issue(s)

Fixes #