### PR TITLE
✨ configurable controller replicas and master node selector

### DIFF
--- a/pkg/cmd/hub/operator.go
+++ b/pkg/cmd/hub/operator.go
@@ -22,6 +22,8 @@ func NewHubOperatorCmd() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVar(&cmOptions.SkipRemoveCRDs, "skip-remove-crds", false, "Skip removing CRDs while ClusterManager is deleting.")
+	flags.StringToStringVar(&cmOptions.MasterNodeLabelSelector, "master-node-label-selector", map[string]string{"node-role.kubernetes.io/master": ""}, "Label selector for master nodes, e.g. 'node-role.kubernetes.io/master='")
+	flags.Int32Var(&cmOptions.ControllerReplicas, "controller-replicas", 0, "Number of controller replicas, operator will automatically determine replicas if not set")
 	opts.AddFlags(flags)
 	return cmd
 }

--- a/pkg/cmd/spoke/operator.go
+++ b/pkg/cmd/spoke/operator.go
@@ -34,6 +34,8 @@ func NewKlusterletOperatorCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&klOptions.SkipPlaceholderHubSecret, "skip-placeholder-hub-secret", false,
 		"If set, will skip ensuring a placeholder hub secret which is originally intended for pulling "+
 			"work image before approved")
+	cmd.Flags().StringToStringVar(&klOptions.MasterNodeLabelSelector, "master-node-label-selector", map[string]string{"node-role.kubernetes.io/master": ""}, "master node label selector. e.g. 'node-role.kubernetes.io/master='")
+	cmd.Flags().Int32Var(&klOptions.ControllerReplicas, "controller-replicas", 0, "Number of controller replicas, operator will automatically determine replicas if not set")
 	opts.AddFlags(flags)
 
 	return cmd

--- a/pkg/operator/helpers/helpers_test.go
+++ b/pkg/operator/helpers/helpers_test.go
@@ -535,7 +535,7 @@ func TestDeterminReplica(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			fakeKubeClient := fakekube.NewSimpleClientset(c.existingNodes...)
-			replica := DetermineReplica(context.Background(), fakeKubeClient, c.mode, c.kubeVersion)
+			replica := DetermineReplica(context.Background(), fakeKubeClient, c.mode, c.kubeVersion, map[string]string{"node-role.kubernetes.io/master": ""})
 			if replica != c.expectedReplica {
 				t.Errorf("Unexpected replica, actual: %d, expected: %d", replica, c.expectedReplica)
 			}

--- a/pkg/operator/operators/clustermanager/options.go
+++ b/pkg/operator/operators/clustermanager/options.go
@@ -23,7 +23,9 @@ import (
 )
 
 type Options struct {
-	SkipRemoveCRDs bool
+	SkipRemoveCRDs          bool
+	MasterNodeLabelSelector map[string]string
+	ControllerReplicas      int32
 }
 
 // RunClusterManagerOperator starts a new cluster manager operator
@@ -75,6 +77,8 @@ func (o *Options) RunClusterManagerOperator(ctx context.Context, controllerConte
 		kubeInformer.Core().V1().ConfigMaps(),
 		controllerContext.EventRecorder,
 		o.SkipRemoveCRDs,
+		o.MasterNodeLabelSelector,
+		o.ControllerReplicas,
 		controllerContext.OperatorNamespace,
 	)
 

--- a/pkg/operator/operators/klusterlet/options.go
+++ b/pkg/operator/operators/klusterlet/options.go
@@ -26,6 +26,8 @@ import (
 
 type Options struct {
 	SkipPlaceholderHubSecret bool
+	MasterNodeLabelSelector  map[string]string
+	ControllerReplicas       int32
 }
 
 // RunKlusterletOperator starts a new klusterlet operator
@@ -96,6 +98,8 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 		workClient.WorkV1().AppliedManifestWorks(),
 		kubeVersion,
 		helpers.GetOperatorNamespace(),
+		o.MasterNodeLabelSelector,
+		o.ControllerReplicas,
 		controllerContext.EventRecorder,
 		o.SkipPlaceholderHubSecret)
 
@@ -109,6 +113,8 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 		workClient.WorkV1().AppliedManifestWorks(),
 		kubeVersion,
 		helpers.GetOperatorNamespace(),
+		o.MasterNodeLabelSelector,
+		o.ControllerReplicas,
 		controllerContext.EventRecorder)
 
 	ssarController := ssarcontroller.NewKlusterletSSARController(


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
In production, operators should be able to controll the replicas of the deployments. Making replicas larger than 1 is very important. So this PR is submitted to make controller replicas and master node selector configurable.

## Related issue(s)

Fixes #