### PR TITLE
🐛  Fix "log.SetLogger(...) was never called" in registration webhook

### DIFF
--- a/pkg/registration/webhook/start.go
+++ b/pkg/registration/webhook/start.go
@@ -30,6 +30,10 @@ func init() {
 }
 
 func (c *Options) RunWebhookServer() error {
+	logger := klog.LoggerWithName(klog.FromContext(context.Background()), "Webhook Server")
+	// This line prevents controller-runtime from complaining about log.SetLogger never being called
+	ctrl.SetLogger(logger)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		HealthProbeBindAddress: ":8000",
@@ -43,11 +47,6 @@ func (c *Options) RunWebhookServer() error {
 			},
 		}),
 	})
-	logger := klog.LoggerWithName(klog.FromContext(context.Background()), "Webhook Server") //MYTODO: Recheck it later
-
-	// This line prevents controller-runtime from complaining about log.SetLogger never being called
-	ctrl.SetLogger(logger)
-
 	if err != nil {
 		logger.Error(err, "unable to start manager")
 		return err

--- a/pkg/registration/webhook/start.go
+++ b/pkg/registration/webhook/start.go
@@ -45,6 +45,9 @@ func (c *Options) RunWebhookServer() error {
 	})
 	logger := klog.LoggerWithName(klog.FromContext(context.Background()), "Webhook Server") //MYTODO: Recheck it later
 
+	// This line prevents controller-runtime from complaining about log.SetLogger never being called
+	ctrl.SetLogger(logger)
+
 	if err != nil {
 		logger.Error(err, "unable to start manager")
 		return err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #487 