### PR TITLE
🐛 Refresh external managed token secret if service account is deleted

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,9 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
+      - name: add permisson to docker.sock
+        run: sudo chown runner:docker /var/run/docker.sock
+        if: ${{ env.ACT }} # this step only runs locally when using the https://github.com/nektos/act to debug the e2e
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go
@@ -52,6 +55,9 @@ jobs:
   e2e-hosted:
     runs-on: ubuntu-latest
     steps:
+      - name: add permisson to docker.sock
+        run: sudo chown runner:docker /var/run/docker.sock
+        if: ${{ env.ACT }} # this step only runs locally when using the https://github.com/nektos/act to debug the e2e
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go
@@ -81,6 +87,9 @@ jobs:
   e2e-singleton:
     runs-on: ubuntu-latest
     steps:
+      - name: add permisson to docker.sock
+        run: sudo chown runner:docker /var/run/docker.sock
+        if: ${{ env.ACT }} # this step only runs locally when using the https://github.com/nektos/act to debug the e2e
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Go

--- a/pkg/operator/helpers/sa_syncer_test.go
+++ b/pkg/operator/helpers/sa_syncer_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	clienttesting "k8s.io/client-go/testing"
@@ -19,6 +20,7 @@ import (
 func TestTokenGetter(t *testing.T) {
 	saName := "test-sa"
 	saNamespace := "test-ns"
+	saUID := "test-uid"
 
 	tests := []struct {
 		name           string
@@ -56,6 +58,7 @@ func TestTokenGetter(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      saName,
 						Namespace: saNamespace,
+						UID:       types.UID(saUID),
 					},
 					Secrets: []corev1.ObjectReference{},
 				},
@@ -91,6 +94,9 @@ func TestTokenGetter(t *testing.T) {
 				}
 				if !reflect.DeepEqual(additionalData["serviceaccount_name"], []byte(saName)) {
 					t.Errorf("serviceaccount_name is not correct, got %s", string(additionalData["serviceaccount_name"]))
+				}
+				if !reflect.DeepEqual(additionalData["serviceaccount_uid"], []byte(saUID)) {
+					t.Errorf("serviceaccount_uid is not correct, got %s", string(additionalData["serviceaccount_uid"]))
 				}
 			}
 

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -341,13 +341,14 @@ func ensureSAKubeconfigs(ctx context.Context, clusterManagerName, clusterManager
 	hubKubeConfig *rest.Config, hubClient, managementClient kubernetes.Interface, recorder events.Recorder,
 	mwctrEnabled, addonManagerEnabled bool) error {
 	for _, sa := range getSAs(mwctrEnabled, addonManagerEnabled) {
-		tokenGetter := helpers.SATokenCreater(ctx, sa, clusterManagerNamespace, hubClient)
-		err := helpers.SyncKubeConfigSecret(ctx, sa+"-kubeconfig", clusterManagerNamespace, "/var/run/secrets/hub/kubeconfig", &rest.Config{
-			Host: hubKubeConfig.Host,
-			TLSClientConfig: rest.TLSClientConfig{
-				CAData: hubKubeConfig.CAData,
-			},
-		}, managementClient.CoreV1(), tokenGetter, recorder, nil)
+		tokenGetter := helpers.SATokenGetter(ctx, sa, clusterManagerNamespace, hubClient)
+		err := helpers.SyncKubeConfigSecret(ctx, sa+"-kubeconfig", clusterManagerNamespace,
+			"/var/run/secrets/hub/kubeconfig", &rest.Config{
+				Host: hubKubeConfig.Host,
+				TLSClientConfig: rest.TLSClientConfig{
+					CAData: hubKubeConfig.CAData,
+				},
+			}, managementClient.CoreV1(), tokenGetter, recorder, nil)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -898,7 +898,8 @@ func (t *Tester) CheckManagedClusterAddOnStatus(managedClusterNamespace, addOnNa
 	}
 
 	if !meta.IsStatusConditionTrue(addOn.Status.Conditions, "Available") {
-		return fmt.Errorf("the addon %v/%v available condition is not true", managedClusterNamespace, addOnName)
+		return fmt.Errorf("the addon %v/%v available condition is not true, %v",
+			managedClusterNamespace, addOnName, addOn.Status.Conditions)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Compare the uid of the service account to check if the service account is recreated.

## Related issue(s)

similar PR: https://github.com/open-cluster-management-io/ocm/pull/458

Fixes #https://github.com/open-cluster-management-io/ocm/issues/503