### PR TITLE
🌱 Debug e2e with an existing cluster

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ on:
 env:
   GO_VERSION: '1.21'
   GO_REQUIRED_MIN_VERSION: ''
+  USE_EXISTING_CLUSTER: false # set to true to use an existing kind cluster for debugging with act
 
 permissions:
   contents: read
@@ -36,6 +37,12 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.22.0
+          skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
+      - name: Set KUBECONFIG
+        run: |
+          mkdir -p /home/runner/.kube
+          kind get kubeconfig > /home/runner/.kube/config
+        if: ${{ env.USE_EXISTING_CLUSTER }}
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: Build images
@@ -68,6 +75,12 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.22.0
+          skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
+      - name: Set KUBECONFIG
+        run: |
+          mkdir -p /home/runner/.kube
+          kind get kubeconfig > /home/runner/.kube/config
+        if: ${{ env.USE_EXISTING_CLUSTER }}
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: Build images
@@ -100,6 +113,12 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.22.0
+          skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
+      - name: Set KUBECONFIG
+        run: |
+          mkdir -p /home/runner/.kube
+          kind get kubeconfig > /home/runner/.kube/config
+        if: ${{ env.USE_EXISTING_CLUSTER }}
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: Build images


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add an environment `USE_EXISTING_CLUSTER` for debugging e2e with act locally.
With this set true, we can create a kind cluster, and use `act -j e2e` to debug repeatedly, even if the test fails, the kind cluster will not be destroyed.
This will not affect the e2e running on the GitHub.

## Related issue(s)

Fixes #