### PR TITLE
🐛 Add install namespace to built in values

### DIFF
--- a/pkg/addon/templateagent/template_agent.go
+++ b/pkg/addon/templateagent/template_agent.go
@@ -36,7 +36,8 @@ const (
 // to convert it to Values by JsonStructToValues.
 // the built-in values can not be overridden by getValuesFuncs
 type templateCRDBuiltinValues struct {
-	ClusterName string `json:"CLUSTER_NAME,omitempty"`
+	ClusterName      string `json:"CLUSTER_NAME,omitempty"`
+	InstallNamespace string `json:"INSTALL_NAMESPACE,omitempty"`
 }
 
 // templateDefaultValues includes the default values for crd template agentAddon.

--- a/pkg/addon/templateagent/template_agent_test.go
+++ b/pkg/addon/templateagent/template_agent_test.go
@@ -180,6 +180,7 @@ func TestAddonTemplateAgentManifests(t *testing.T) {
 					{Name: "LOG_LEVEL", Value: "4"},
 					{Name: "HUB_KUBECONFIG", Value: "/managed/hub-kubeconfig/kubeconfig"},
 					{Name: "CLUSTER_NAME", Value: clusterName},
+					{Name: "INSTALL_NAMESPACE", Value: "test-install-namespace"},
 				}
 				if !equality.Semantic.DeepEqual(envs, expectedEnvs) {
 					t.Errorf("unexpected envs %v", envs)

--- a/pkg/addon/templateagent/values_test.go
+++ b/pkg/addon/templateagent/values_test.go
@@ -149,9 +149,14 @@ func TestGetValues(t *testing.T) {
 					name:  "CLUSTER_NAME",
 					value: "test-cluster",
 				},
+				{
+					name:  "INSTALL_NAMESPACE",
+					value: "default-ns",
+				},
 			},
 			expectedOverride: map[string]interface{}{
-				"CLUSTER_NAME": "test-cluster",
+				"CLUSTER_NAME":      "test-cluster",
+				"INSTALL_NAMESPACE": "default-ns",
 			},
 			expectedPrivate: map[string]interface{}{
 				InstallNamespacePrivateValueKey: "default-ns",
@@ -169,10 +174,15 @@ func TestGetValues(t *testing.T) {
 					name:  "CLUSTER_NAME",
 					value: "test-cluster",
 				},
+				{
+					name:  "INSTALL_NAMESPACE",
+					value: "default-ns",
+				},
 			},
 			expectedOverride: map[string]interface{}{
-				"CLUSTER_NAME": "test-cluster",
-				"key1":         "value1",
+				"CLUSTER_NAME":      "test-cluster",
+				"INSTALL_NAMESPACE": "default-ns",
+				"key1":              "value1",
 			},
 			expectedPrivate: map[string]interface{}{
 				InstallNamespacePrivateValueKey: "default-ns",
@@ -188,8 +198,7 @@ func TestGetValues(t *testing.T) {
 				},
 			},
 			values: addonfactory.Values{
-				InstallNamespacePrivateValueKey: "default-ns",
-				"HUB_KUBECONFIG":                "/managed/hub-kubeconfig/kubeconfig-test",
+				"HUB_KUBECONFIG": "/managed/hub-kubeconfig/kubeconfig-test",
 			},
 			expectedPreset: orderedValues{
 				{
@@ -205,9 +214,7 @@ func TestGetValues(t *testing.T) {
 				"HUB_KUBECONFIG": "/managed/hub-kubeconfig/kubeconfig-test",
 				"CLUSTER_NAME":   "test-cluster",
 			},
-			expectedPrivate: map[string]interface{}{
-				InstallNamespacePrivateValueKey: "default-ns",
-			},
+			expectedPrivate: map[string]interface{}{},
 		},
 		{
 			name: "builtIn value should not be overridden",
@@ -232,10 +239,15 @@ func TestGetValues(t *testing.T) {
 					name:  "CLUSTER_NAME",
 					value: "test-cluster",
 				},
+				{
+					name:  "INSTALL_NAMESPACE",
+					value: "default-ns",
+				},
 			},
 			expectedOverride: map[string]interface{}{
-				"HUB_KUBECONFIG": "/managed/hub-kubeconfig/kubeconfig-test",
-				"CLUSTER_NAME":   "test-cluster",
+				"HUB_KUBECONFIG":    "/managed/hub-kubeconfig/kubeconfig-test",
+				"CLUSTER_NAME":      "test-cluster",
+				"INSTALL_NAMESPACE": "default-ns",
 			},
 			expectedPrivate: map[string]interface{}{
 				InstallNamespacePrivateValueKey: "default-ns",


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add `INSTALL_NAMESPACE` to the built in values if the private value `__INSTALL_NAMESPACE` is set.

## Related issue(s)

Fixes #