### PR TITLE
:seedling:Refactor makefile e2e commands.

### DIFF
--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -18,7 +18,7 @@ endif
 hub-kubeconfig:
 	$(KUBECTL) config view --minify --flatten > $(HUB_KUBECONFIG)
 
-deploy-hub: deploy-hub-operator apply-hub-cr hub-kubeconfig
+deploy-hub: deploy-hub-operator apply-hub-cr hub-kubeconfig cluster-ip
 
 deploy-hub-operator: ensure-kustomize
 	cp deploy/cluster-manager/config/kustomization.yaml deploy/cluster-manager/config/kustomization.yaml.tmp
@@ -29,9 +29,9 @@ deploy-hub-operator: ensure-kustomize
 apply-hub-cr:
 	$(SED_CMD) -e "s,quay.io/open-cluster-management/registration:latest,$(REGISTRATION_IMAGE)," -e "s,quay.io/open-cluster-management/work:latest,$(WORK_IMAGE)," -e "s,quay.io/open-cluster-management/placement:latest,$(PLACEMENT_IMAGE)," -e "s,quay.io/open-cluster-management/addon-manager:latest,$(ADDON_MANAGER_IMAGE)," deploy/cluster-manager/config/samples/operator_open-cluster-management_clustermanagers.cr.yaml | $(KUBECTL) apply -f -
 
-test-e2e: deploy-hub deploy-spoke-operator run-e2e
+test-e2e: deploy-hub deploy-spoke-operator bootstrap-secret run-e2e
 
-run-e2e: cluster-ip bootstrap-secret
+run-e2e:
 	go test -c ./test/e2e
 	./e2e.test -test.v -ginkgo.v -deploy-klusterlet=true -nil-executor-validating=true -registration-image=$(REGISTRATION_IMAGE) -work-image=$(WORK_IMAGE) -singleton-image=$(OPERATOR_IMAGE_NAME) -klusterlet-deploy-mode=$(KLUSTERLET_DEPLOY_MODE)
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Except for the standard e2e prepare process: `test-e2e`.

We may also want to customized the process, for example:

```
# deploy ocm hub on hub1
make deploy-hub KUBECONFIG=/home/runner/.kube/hub1 HUB_KUBECONFIG=/home/runner/.kube/hub1-kubeconfig

# deploy ocm hub on hub2
make deploy-hub KUBECONFIG=/home/runner/.kube/hub2 HUB_KUBECONFIG=/home/runner/.kube/hub2-kubeconfig

# deploy ocm agent on spoke
make deploy-spoke-operator KUBECONFIG=/home/runner/.kube/spoke

run-e2e
```

The changes intend to make `deploy-hub` and `run-e2e` commands more independent, so we can reuse them in different e2e prepare processes.