### PR TITLE
WIP :seedling: Remove nilExcutorValidating flag change to use ginkgo label.

### DIFF
--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -33,7 +33,7 @@ test-e2e: deploy-hub deploy-spoke-operator bootstrap-secret run-e2e
 
 run-e2e:
 	go test -c ./test/e2e
-	./e2e.test -test.v -ginkgo.v -deploy-klusterlet=true -nil-executor-validating=true -registration-image=$(REGISTRATION_IMAGE) -work-image=$(WORK_IMAGE) -singleton-image=$(OPERATOR_IMAGE_NAME) -klusterlet-deploy-mode=$(KLUSTERLET_DEPLOY_MODE)
+	./e2e.test -test.v -ginkgo.v -deploy-klusterlet=true -registration-image=$(REGISTRATION_IMAGE) -work-image=$(WORK_IMAGE) -singleton-image=$(OPERATOR_IMAGE_NAME) -klusterlet-deploy-mode=$(KLUSTERLET_DEPLOY_MODE)
 
 clean-hub: clean-hub-cr clean-hub-operator
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -16,24 +16,22 @@ import (
 var t *Tester
 
 var (
-	clusterName           string
-	klusterletName        string
-	agentNamespace        string
-	hubKubeconfig         string
-	nilExecutorValidating bool
-	deployKlusterlet      bool
-	managedKubeconfig     string
-	eventuallyTimeout     time.Duration
-	registrationImage     string
-	workImage             string
-	singletonImage        string
-	klusterletDeployMode  string
+	clusterName          string
+	klusterletName       string
+	agentNamespace       string
+	hubKubeconfig        string
+	deployKlusterlet     bool
+	managedKubeconfig    string
+	eventuallyTimeout    time.Duration
+	registrationImage    string
+	workImage            string
+	singletonImage       string
+	klusterletDeployMode string
 )
 
 func init() {
 	flag.StringVar(&clusterName, "cluster-name", "", "The name of the managed cluster on which the testing will be run")
 	flag.StringVar(&hubKubeconfig, "hub-kubeconfig", "", "The kubeconfig of the hub cluster")
-	flag.BoolVar(&nilExecutorValidating, "nil-executor-validating", false, "Whether validate the nil executor or not (default false)")
 	flag.BoolVar(&deployKlusterlet, "deploy-klusterlet", false, "Whether deploy the klusterlet on the managed cluster or not (default false)")
 	flag.StringVar(&managedKubeconfig, "managed-kubeconfig", "", "The kubeconfig of the managed cluster")
 	flag.DurationVar(&eventuallyTimeout, "eventually-timeout", 60*time.Second, "The timeout of Gomega's Eventually (default 60 seconds)")
@@ -59,22 +57,13 @@ func TestE2E(tt *testing.T) {
 //
 // - KUBECONFIG is the location of the kubeconfig file to use
 var _ = BeforeSuite(func() {
-	var err error
-
 	Expect(t.Init()).ToNot(HaveOccurred())
 
 	Eventually(t.CheckHubReady, t.EventuallyTimeout, t.EventuallyInterval).Should(Succeed())
 
 	Eventually(t.CheckKlusterletOperatorReady, t.EventuallyTimeout, t.EventuallyInterval).Should(Succeed())
 
-	err = t.SetBootstrapHubSecret("")
-
-	if nilExecutorValidating {
-		Eventually(func() error {
-			return t.EnableWorkFeature("NilExecutorValidating")
-		}, t.EventuallyTimeout*5, t.EventuallyInterval*5).Should(Succeed())
-	}
-	Expect(err).ToNot(HaveOccurred())
+	Expect(t.SetBootstrapHubSecret("")).Should(Succeed())
 
 	Eventually(func() error {
 		return t.EnableWorkFeature("ManifestWorkReplicaSet")

--- a/test/e2e/work_webhook_test.go
+++ b/test/e2e/work_webhook_test.go
@@ -50,17 +50,20 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 			gomega.Expect(errors.IsBadRequest(err)).Should(gomega.BeTrue())
 		})
 
-		ginkgo.Context("executor", func() {
+		ginkgo.Context("executor", ginkgo.Ordered, ginkgo.Label("NilExecutorValidating"), func() {
 			var hubUser string
 			var roleName string
+
+			ginkgo.BeforeAll(func() {
+				gomega.Eventually(func() error {
+					return t.EnableWorkFeature("NilExecutorValidating")
+				}, t.EventuallyTimeout*5, t.EventuallyInterval*5).Should(gomega.Succeed())
+				gomega.Eventually(t.CheckHubReady, t.EventuallyTimeout, t.EventuallyInterval).Should(gomega.Succeed())
+			})
 
 			ginkgo.BeforeEach(func() {
 				hubUser = fmt.Sprintf("sa-%s", nameSuffix)
 				roleName = fmt.Sprintf("role-%s", nameSuffix)
-
-				if !nilExecutorValidating {
-					ginkgo.Skip(fmt.Sprintf("feature gate %q is disabled", "NilExecutorValidating"))
-				}
 
 				// create a temporary role
 				_, err := t.HubKubeClient.RbacV1().Roles(clusterName).Create(


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

As the NilExcutorValidating is by default true, we should change to use label to cohesion this part of logic into one ginkgo spec.