### PR TITLE
WIP :seedling: Remove klusterlet removal in afterEach to keep more information.

### DIFF
--- a/test/e2e/addon_lease_test.go
+++ b/test/e2e/addon_lease_test.go
@@ -253,8 +253,6 @@ var _ = ginkgo.Describe("Addon Health Check", func() {
 			ginkgo.By(fmt.Sprintf("Cleaning managed cluster addon installation namespace %q", addOnName))
 			err := t.HubKubeClient.CoreV1().Namespaces().Delete(context.TODO(), addOnName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			ginkgo.By(fmt.Sprintf("clean klusterlet %v resources after the test case", klusterletName))
-			gomega.Expect(t.cleanKlusterletResources(klusterletName, clusterName)).To(gomega.BeNil())
 		})
 
 		ginkgo.It("Should update addon status to unknown if managed cluster stops to update its lease", func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -90,10 +90,3 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 })
-
-var _ = AfterSuite(func() {
-	if deployKlusterlet {
-		By(fmt.Sprintf("clean klusterlet %v resources after the test case", klusterletName))
-		Expect(t.cleanKlusterletResources(klusterletName, clusterName)).To(BeNil())
-	}
-})

--- a/test/e2e/klusterlet_hosted_test.go
+++ b/test/e2e/klusterlet_hosted_test.go
@@ -168,9 +168,5 @@ var _ = Describe("Delete hosted klusterlet CR", func() {
 				return err
 			}, t.EventuallyTimeout*5, t.EventuallyInterval*5).Should(Succeed())
 		})
-
-		By("Check manged cluster and klusterlet can be deleted", func() {
-			Expect(t.cleanKlusterletResources(klusterletName, clusterName)).To(BeNil())
-		})
 	})
 })

--- a/test/e2e/klusterlet_test.go
+++ b/test/e2e/klusterlet_test.go
@@ -26,11 +26,6 @@ var _ = Describe("Create klusterlet CR", func() {
 		klusterletNamespace = fmt.Sprintf("open-cluster-management-agent-%s", rand.String(6))
 	})
 
-	AfterEach(func() {
-		By(fmt.Sprintf("clean klusterlet %v resources after the test case", klusterletName))
-		Expect(t.cleanKlusterletResources(klusterletName, clusterName)).To(BeNil())
-	})
-
 	// This test case is helpful for the Backward compatibility
 	It("Create klusterlet CR with install mode empty", func() {
 		By(fmt.Sprintf("create klusterlet %v with managed cluster name %v", klusterletName, clusterName))
@@ -226,5 +221,9 @@ var _ = Describe("Create klusterlet CR", func() {
 			err := t.checkKlusterletStatus(klusterletName, "HubConnectionDegraded", "HubConnectionFunctional", metav1.ConditionFalse)
 			return err
 		}, t.EventuallyTimeout*5, t.EventuallyInterval*5).Should(Succeed())
+	})
+
+	It("Delete klusterlet CR", func() {
+		Expect(t.cleanKlusterletResources(klusterletName, clusterName)).To(BeNil())
 	})
 })


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Currently, if we run a e2e locally, we can troubleshooting when a case is failed because the klusterlet is removal in AfterEach.

But klusterlets doesn't have the same name, and there is no 2 cases affect each other.

This PR is to keep the klusterlet and leave us more information for debugging.