### PR TITLE
:seedling: Explicitly rename and use universal klusterlet/managed cluster.

### DIFF
--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -33,7 +33,7 @@ test-e2e: deploy-hub deploy-spoke-operator bootstrap-secret run-e2e
 
 run-e2e:
 	go test -c ./test/e2e
-	./e2e.test -test.v -ginkgo.v -deploy-klusterlet=true -nil-executor-validating=true -registration-image=$(REGISTRATION_IMAGE) -work-image=$(WORK_IMAGE) -singleton-image=$(OPERATOR_IMAGE_NAME) -klusterlet-deploy-mode=$(KLUSTERLET_DEPLOY_MODE)
+	./e2e.test -test.v -ginkgo.v -nil-executor-validating=true -registration-image=$(REGISTRATION_IMAGE) -work-image=$(WORK_IMAGE) -singleton-image=$(OPERATOR_IMAGE_NAME) -klusterlet-deploy-mode=$(KLUSTERLET_DEPLOY_MODE)
 
 clean-hub: clean-hub-cr clean-hub-operator
 

--- a/test/e2e/addon_lease_test.go
+++ b/test/e2e/addon_lease_test.go
@@ -28,7 +28,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 			// create an addon on created managed cluster
 			addOnName = fmt.Sprintf("addon-%s", rand.String(6))
 			ginkgo.By(fmt.Sprintf("Creating managed cluster addon %q", addOnName))
-			err := t.CreateManagedClusterAddOn(clusterName, addOnName, addOnName)
+			err := t.CreateManagedClusterAddOn(universalClusterName, addOnName, addOnName)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// create addon installation namespace
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
+				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 
 			// check if the cluster has a label for addon with expected value
 			gomega.Eventually(func() bool {
-				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
+				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -111,7 +111,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 
 			// check if the cluster has a label for addon with expected value
 			gomega.Eventually(func() bool {
-				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
+				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -142,7 +142,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 
 			// check if the cluster has a label for addon with expected value
 			gomega.Eventually(func() bool {
-				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
@@ -168,7 +168,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
+				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -180,7 +180,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 
 			// check if the cluster has a label for addon with expected value
 			gomega.Eventually(func() bool {
-				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
@@ -196,7 +196,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
+				found, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -208,7 +208,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 
 			// check if the cluster has a label for addon with expected value
 			gomega.Eventually(func() bool {
-				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), clusterName, metav1.GetOptions{})
+				cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 				if err != nil {
 					return false
 				}
@@ -224,9 +224,6 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 	ginkgo.Context("Checking managed cluster status to update addon status", func() {
 		var klusterletName, clusterName, addOnName string
 		ginkgo.BeforeEach(func() {
-			if !deployKlusterlet {
-				ginkgo.Skip("skip if disabling deploy klusterlet")
-			}
 			klusterletName = fmt.Sprintf("e2e-klusterlet-%s", rand.String(6))
 			clusterName = fmt.Sprintf("e2e-managedcluster-%s", rand.String(6))
 			agentNamespace := fmt.Sprintf("open-cluster-management-agent-%s", rand.String(6))

--- a/test/e2e/addon_test.go
+++ b/test/e2e/addon_test.go
@@ -17,13 +17,13 @@ var _ = Describe("Manage the managed cluster addons", Label("addon"), func() {
 	})
 
 	AfterEach(func() {
-		err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Delete(context.TODO(), addOnName, metav1.DeleteOptions{})
+		err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Delete(context.TODO(), addOnName, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("Create one managed cluster addon and make sure it is available", func() {
-		By(fmt.Sprintf("create the addon %v on the managed cluster namespace %v", addOnName, clusterName))
-		err := t.CreateManagedClusterAddOn(clusterName, addOnName, addOnName)
+		By(fmt.Sprintf("create the addon %v on the managed cluster namespace %v", addOnName, universalClusterName))
+		err := t.CreateManagedClusterAddOn(universalClusterName, addOnName, addOnName)
 		Expect(err).ToNot(HaveOccurred())
 
 		By(fmt.Sprintf("create the addon lease %v on addon install namespace %v", addOnName, addOnName))
@@ -32,13 +32,13 @@ var _ = Describe("Manage the managed cluster addons", Label("addon"), func() {
 
 		By(fmt.Sprintf("wait the addon %v available condition to be true", addOnName))
 		Eventually(func() error {
-			return t.CheckManagedClusterAddOnStatus(clusterName, addOnName)
+			return t.CheckManagedClusterAddOnStatus(universalClusterName, addOnName)
 		}).Should(Succeed())
 	})
 
 	It("Create one managed cluster addon and make sure it is available in Hosted mode", func() {
-		By(fmt.Sprintf("create the addon %v on the managed cluster namespace %v", addOnName, clusterName))
-		err := t.CreateManagedClusterAddOn(clusterName, addOnName, addOnName)
+		By(fmt.Sprintf("create the addon %v on the managed cluster namespace %v", addOnName, universalClusterName))
+		err := t.CreateManagedClusterAddOn(universalClusterName, addOnName, addOnName)
 		Expect(err).ToNot(HaveOccurred())
 
 		By(fmt.Sprintf("create the addon lease %v on addon install namespace %v", addOnName, addOnName))
@@ -47,7 +47,7 @@ var _ = Describe("Manage the managed cluster addons", Label("addon"), func() {
 
 		By(fmt.Sprintf("wait the addon %v available condition to be true", addOnName))
 		Eventually(func() error {
-			return t.CheckManagedClusterAddOnStatus(clusterName, addOnName)
+			return t.CheckManagedClusterAddOnStatus(universalClusterName, addOnName)
 		}).Should(Succeed())
 	})
 })

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -73,10 +73,10 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		// the addon manager deployment should be running
 		gomega.Eventually(t.CheckHubReady).Should(gomega.Succeed())
 
-		ginkgo.By(fmt.Sprintf("create addon template resources for cluster %v", clusterName))
+		ginkgo.By(fmt.Sprintf("create addon template resources for cluster %v", universalClusterName))
 		err = createResourcesFromYamlFiles(context.Background(), t.HubDynamicClient, t.hubRestMapper, s,
 			defaultAddonTemplateReaderManifestsFunc(manifests.AddonManifestFiles, map[string]interface{}{
-				"Namespace":              clusterName,
+				"Namespace":              universalClusterName,
 				"AddonInstallNamespace":  addonInstallNamespace,
 				"CustomSignerName":       customSignerName,
 				"AddonManagerNamespace":  templateagent.AddonManagerNamespace(),
@@ -86,29 +86,29 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("create the addon %v on the managed cluster namespace %v", addOnName, clusterName))
-		err = t.CreateManagedClusterAddOn(clusterName, addOnName, "test-ns") // the install namespace will be ignored
+		ginkgo.By(fmt.Sprintf("create the addon %v on the managed cluster namespace %v", addOnName, universalClusterName))
+		err = t.CreateManagedClusterAddOn(universalClusterName, addOnName, "test-ns") // the install namespace will be ignored
 		if err != nil {
-			klog.Errorf("failed to create managed cluster addon %v on the managed cluster namespace %v: %v", addOnName, clusterName, err)
+			klog.Errorf("failed to create managed cluster addon %v on the managed cluster namespace %v: %v", addOnName, universalClusterName, err)
 			gomega.Expect(errors.IsAlreadyExists(err)).To(gomega.BeTrue())
 		}
 
-		ginkgo.By(fmt.Sprintf("wait the addon %v/%v available condition to be true", clusterName, addOnName))
+		ginkgo.By(fmt.Sprintf("wait the addon %v/%v available condition to be true", universalClusterName, addOnName))
 		gomega.Eventually(func() error {
-			return t.CheckManagedClusterAddOnStatus(clusterName, addOnName)
+			return t.CheckManagedClusterAddOnStatus(universalClusterName, addOnName)
 		}).Should(gomega.Succeed())
 	})
 
 	ginkgo.AfterEach(func() {
-		ginkgo.By(fmt.Sprintf("delete the addon %v on the managed cluster namespace %v", addOnName, clusterName))
-		err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Delete(
+		ginkgo.By(fmt.Sprintf("delete the addon %v on the managed cluster namespace %v", addOnName, universalClusterName))
+		err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Delete(
 			context.TODO(), addOnName, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
-			ginkgo.Fail(fmt.Sprintf("failed to delete managed cluster addon %v on cluster %v: %v", addOnName, clusterName, err))
+			ginkgo.Fail(fmt.Sprintf("failed to delete managed cluster addon %v on cluster %v: %v", addOnName, universalClusterName, err))
 		}
 
 		gomega.Eventually(func() error {
-			_, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(
+			_, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(
 				context.TODO(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -120,10 +120,10 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 			return fmt.Errorf("the managedClusterAddon should be deleted")
 		}).ShouldNot(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("delete addon template resources for cluster %v", clusterName))
+		ginkgo.By(fmt.Sprintf("delete addon template resources for cluster %v", universalClusterName))
 		err = deleteResourcesFromYamlFiles(context.Background(), t.HubDynamicClient, t.hubRestMapper, s,
 			defaultAddonTemplateReaderManifestsFunc(manifests.AddonManifestFiles, map[string]interface{}{
-				"Namespace":              clusterName,
+				"Namespace":              universalClusterName,
 				"AddonInstallNamespace":  addonInstallNamespace,
 				"CustomSignerName":       customSignerName,
 				"AddonManagerNamespace":  templateagent.AddonManagerNamespace(),
@@ -147,7 +147,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 			csrs, err := t.HubKubeClient.CertificatesV1().CertificateSigningRequests().List(context.TODO(),
 				metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("%s=%s,%s=%s", addonapiv1alpha1.AddonLabelKey, addOnName,
-						clusterv1.ClusterNameLabelKey, clusterName),
+						clusterv1.ClusterNameLabelKey, universalClusterName),
 				})
 			if err != nil {
 				return err
@@ -184,7 +184,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		configmap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("config-%s", rand.String(6)),
-				Namespace: clusterName,
+				Namespace: universalClusterName,
 			},
 			Data: map[string]string{
 				"key1": rand.String(6),
@@ -192,7 +192,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 			},
 		}
 
-		_, err := t.HubKubeClient.CoreV1().ConfigMaps(clusterName).Create(
+		_, err := t.HubKubeClient.CoreV1().ConfigMaps(universalClusterName).Create(
 			context.Background(), configmap, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		}).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Make sure manifestwork config is configured")
-		manifestWork, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(context.Background(),
+		manifestWork, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(context.Background(),
 			fmt.Sprintf("addon-%s-deploy-0", addOnName), metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		foundDeploymentConfig := false
@@ -241,8 +241,8 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 				manifestWork.Spec.ManifestConfigs)).ToNot(gomega.HaveOccurred())
 		}
 
-		ginkgo.By(fmt.Sprintf("delete the addon %v on the managed cluster namespace %v", addOnName, clusterName))
-		err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Delete(
+		ginkgo.By(fmt.Sprintf("delete the addon %v on the managed cluster namespace %v", addOnName, universalClusterName))
+		err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Delete(
 			context.TODO(), addOnName, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -261,7 +261,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		}).ShouldNot(gomega.HaveOccurred())
 
 		gomega.Eventually(func() error {
-			_, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(
+			_, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(
 				context.TODO(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -304,7 +304,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Eventually(func() error {
 			cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(
-				context.Background(), clusterName, metav1.GetOptions{})
+				context.Background(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -325,12 +325,12 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 
 		ginkgo.By("Prepare a AddOnDeploymentConfig for addon image override config")
 		gomega.Eventually(func() error {
-			return prepareImageOverrideAddOnDeploymentConfig(clusterName, addonInstallNamespace)
+			return prepareImageOverrideAddOnDeploymentConfig(universalClusterName, addonInstallNamespace)
 		}).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Add the configs to ManagedClusterAddOn")
 		gomega.Eventually(func() error {
-			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(
+			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(
 				context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -343,12 +343,12 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 						Resource: "addondeploymentconfigs",
 					},
 					ConfigReferent: addonapiv1alpha1.ConfigReferent{
-						Namespace: clusterName,
+						Namespace: universalClusterName,
 						Name:      imageOverrideDeploymentConfigName,
 					},
 				},
 			}
-			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Update(
+			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Update(
 				context.Background(), newAddon, metav1.UpdateOptions{})
 			if err != nil {
 				return err
@@ -379,7 +379,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		ginkgo.By("Restore the managed cluster annotation")
 		gomega.Eventually(func() error {
 			cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(
-				context.Background(), clusterName, metav1.GetOptions{})
+				context.Background(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -395,14 +395,14 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		// but it is needed by the pre-delete job
 		ginkgo.By("Restore the configs to ManagedClusterAddOn")
 		gomega.Eventually(func() error {
-			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(
+			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(
 				context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			newAddon := addon.DeepCopy()
 			newAddon.Spec.Configs = []addonapiv1alpha1.AddOnConfig{}
-			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Update(
+			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Update(
 				context.Background(), newAddon, metav1.UpdateOptions{})
 			if err != nil {
 				return err
@@ -434,12 +434,12 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 	ginkgo.It("Template type addon should be configured by addon deployment config for node placement", func() {
 		ginkgo.By("Prepare a AddOnDeploymentConfig for addon image override config")
 		gomega.Eventually(func() error {
-			return prepareNodePlacementAddOnDeploymentConfig(clusterName, addonInstallNamespace)
+			return prepareNodePlacementAddOnDeploymentConfig(universalClusterName, addonInstallNamespace)
 		}).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Add the configs to ManagedClusterAddOn")
 		gomega.Eventually(func() error {
-			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(
+			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(
 				context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -452,12 +452,12 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 						Resource: "addondeploymentconfigs",
 					},
 					ConfigReferent: addonapiv1alpha1.ConfigReferent{
-						Namespace: clusterName,
+						Namespace: universalClusterName,
 						Name:      nodePlacementDeploymentConfigName,
 					},
 				},
 			}
-			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Update(
+			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Update(
 				context.Background(), newAddon, metav1.UpdateOptions{})
 			if err != nil {
 				return err
@@ -496,12 +496,12 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		_, err := t.SpokeKubeClient.CoreV1().Namespaces().Create(context.TODO(), overrideNamespace, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Eventually(func() error {
-			return prepareInstallNamespace(clusterName, overrideNamespace.Name)
+			return prepareInstallNamespace(universalClusterName, overrideNamespace.Name)
 		}).ShouldNot(gomega.HaveOccurred())
 
 		ginkgo.By("Add the configs to ManagedClusterAddOn")
 		gomega.Eventually(func() error {
-			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(
+			addon, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(
 				context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
@@ -514,12 +514,12 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 						Resource: "addondeploymentconfigs",
 					},
 					ConfigReferent: addonapiv1alpha1.ConfigReferent{
-						Namespace: clusterName,
+						Namespace: universalClusterName,
 						Name:      namespaceOverrideConfigName,
 					},
 				},
 			}
-			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Update(
+			_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Update(
 				context.Background(), newAddon, metav1.UpdateOptions{})
 			if err != nil {
 				return err
@@ -544,7 +544,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		gomega.Eventually(func() error {
 			cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(
-				context.Background(), clusterName, metav1.GetOptions{})
+				context.Background(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -588,7 +588,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		ginkgo.By("Restore the managed cluster annotation")
 		gomega.Eventually(func() error {
 			cluster, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(
-				context.Background(), clusterName, metav1.GetOptions{})
+				context.Background(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"testing"
@@ -8,38 +9,50 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/util/rand"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	operatorapiv1 "open-cluster-management.io/api/operator/v1"
 )
 
 var t *Tester
 
 var (
-	clusterName           string
-	klusterletName        string
-	agentNamespace        string
-	hubKubeconfig         string
-	nilExecutorValidating bool
-	deployKlusterlet      bool
-	managedKubeconfig     string
-	registrationImage     string
-	workImage             string
-	singletonImage        string
+	// kubeconfigs
+	hubKubeconfig     string
+	managedKubeconfig string
+
+	// customized test parameters
 	klusterletDeployMode  string
+	nilExecutorValidating bool
+
+	// images
+	registrationImage string
+	workImage         string
+	singletonImage    string
 )
 
 func init() {
-	flag.StringVar(&clusterName, "cluster-name", "", "The name of the managed cluster on which the testing will be run")
 	flag.StringVar(&hubKubeconfig, "hub-kubeconfig", "", "The kubeconfig of the hub cluster")
-	flag.BoolVar(&nilExecutorValidating, "nil-executor-validating", false, "Whether validate the nil executor or not (default false)")
-	flag.BoolVar(&deployKlusterlet, "deploy-klusterlet", false, "Whether deploy the klusterlet on the managed cluster or not (default false)")
 	flag.StringVar(&managedKubeconfig, "managed-kubeconfig", "", "The kubeconfig of the managed cluster")
+
+	flag.StringVar(&klusterletDeployMode, "klusterlet-deploy-mode", string(operatorapiv1.InstallModeDefault), "The image of the work")
+	flag.BoolVar(&nilExecutorValidating, "nil-executor-validating", false, "Whether validate the nil executor or not (default false)")
+
 	flag.StringVar(&registrationImage, "registration-image", "", "The image of the registration")
 	flag.StringVar(&workImage, "work-image", "", "The image of the work")
 	flag.StringVar(&singletonImage, "singleton-image", "", "The image of the klusterlet agent")
-	flag.StringVar(&klusterletDeployMode, "klusterlet-deploy-mode", string(operatorapiv1.InstallModeDefault), "The image of the work")
 }
+
+// The e2e will always create one universal klusterlet, the developers can reuse this klusterlet in their case
+// but also pay attention, because the klusterlet is shared, so the developers should not delete the klusterlet.
+// And there might be some side effects on other cases if the developers change the klusterlet's spec for their cases.
+const (
+	universalClusterName    = "e2e-universal-managedcluster"            //nolint:gosec
+	universalKlusterletName = "e2e-universal-klusterlet"                //nolint:gosec
+	universalAgentNamespace = "open-cluster-management-agent-universal" //nolint:gosec
+	universalClusterSetName = "universal"                               //nolint:gosec
+)
 
 func TestE2E(tt *testing.T) {
 	t = NewTester(hubKubeconfig, managedKubeconfig, registrationImage, workImage, singletonImage)
@@ -84,19 +97,41 @@ var _ = BeforeSuite(func() {
 	}).Should(Succeed())
 	Eventually(t.CheckHubReady).Should(Succeed())
 
-	if deployKlusterlet {
-		klusterletName = fmt.Sprintf("e2e-klusterlet-%s", rand.String(6))
-		clusterName = fmt.Sprintf("e2e-managedcluster-%s", rand.String(6))
-		agentNamespace = fmt.Sprintf("open-cluster-management-agent-%s", rand.String(6))
-		_, err := t.CreateApprovedKlusterlet(
-			klusterletName, clusterName, agentNamespace, operatorapiv1.InstallMode(klusterletDeployMode))
-		Expect(err).ToNot(HaveOccurred())
-	}
+	By("Create a universal Klusterlet/managedcluster")
+	_, err = t.CreateApprovedKlusterlet(
+		universalKlusterletName, universalClusterName, universalAgentNamespace, operatorapiv1.InstallMode(klusterletDeployMode))
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Create a universal ClusterSet and bind it with the universal managedcluster")
+	_, err = t.ClusterClient.ClusterV1beta2().ManagedClusterSets().Create(context.TODO(), &clusterv1beta2.ManagedClusterSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: universalClusterSetName,
+		},
+		Spec: clusterv1beta2.ManagedClusterSetSpec{
+			ClusterSelector: clusterv1beta2.ManagedClusterSelector{
+				SelectorType: clusterv1beta2.ExclusiveClusterSetLabel,
+			},
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		umc, err := t.ClusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), universalClusterName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		labels := umc.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[clusterv1beta2.ClusterSetLabel] = universalClusterSetName
+		umc.SetLabels(labels)
+		_, err = t.ClusterClient.ClusterV1().ManagedClusters().Update(context.TODO(), umc, metav1.UpdateOptions{})
+		return err
+	}).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {
-	if deployKlusterlet {
-		By(fmt.Sprintf("clean klusterlet %v resources after the test case", klusterletName))
-		Expect(t.cleanKlusterletResources(klusterletName, clusterName)).To(BeNil())
-	}
+	By(fmt.Sprintf("clean klusterlet %v resources after the test case", universalKlusterletName))
+	Expect(t.cleanKlusterletResources(universalKlusterletName, universalClusterName)).To(BeNil())
 })

--- a/test/e2e/managedcluster_loopback_test.go
+++ b/test/e2e/managedcluster_loopback_test.go
@@ -71,10 +71,10 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 			managedClusters = t.ClusterClient.ClusterV1().ManagedClusters()
 		)
 
-		ginkgo.By(fmt.Sprintf("Waiting for ManagedCluster %q to exist", clusterName))
+		ginkgo.By(fmt.Sprintf("Waiting for ManagedCluster %q to exist", universalClusterName))
 		err = wait.Poll(1*time.Second, 90*time.Second, func() (bool, error) {
 			var err error
-			managedCluster, err = managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			managedCluster, err = managedClusters.Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 			if errors.IsNotFound(err) {
 				return false, nil
 			}
@@ -88,7 +88,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		ginkgo.By("Waiting for ManagedCluster to have HubAccepted=true")
 		err = wait.Poll(1*time.Second, 90*time.Second, func() (bool, error) {
 			var err error
-			managedCluster, err := managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			managedCluster, err := managedClusters.Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -104,7 +104,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		ginkgo.By("Waiting for ManagedCluster to join the hub cluser")
 		err = wait.Poll(1*time.Second, 90*time.Second, func() (bool, error) {
 			var err error
-			managedCluster, err := managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			managedCluster, err := managedClusters.Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -115,7 +115,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 
 		ginkgo.By("Waiting for ManagedCluster available")
 		err = wait.Poll(1*time.Second, 90*time.Second, func() (bool, error) {
-			managedCluster, err := managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			managedCluster, err := managedClusters.Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -128,7 +128,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		ginkgo.By(fmt.Sprintf("Make sure ManagedCluster lease %q exists", leaseName))
 		var lastRenewTime *metav1.MicroTime
 		err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
-			lease, err := t.HubKubeClient.CoordinationV1().Leases(clusterName).Get(context.TODO(), leaseName, metav1.GetOptions{})
+			lease, err := t.HubKubeClient.CoordinationV1().Leases(universalClusterName).Get(context.TODO(), leaseName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -139,7 +139,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 
 		ginkgo.By(fmt.Sprintf("Make sure ManagedCluster lease %q is updated", leaseName))
 		err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
-			lease, err := t.HubKubeClient.CoordinationV1().Leases(clusterName).Get(context.TODO(), leaseName, metav1.GetOptions{})
+			lease, err := t.HubKubeClient.CoordinationV1().Leases(universalClusterName).Get(context.TODO(), leaseName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -153,7 +153,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 
 		ginkgo.By(fmt.Sprintf("Make sure ManagedCluster lease %q is updated again", leaseName))
 		err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
-			lease, err := t.HubKubeClient.CoordinationV1().Leases(clusterName).Get(context.TODO(), leaseName, metav1.GetOptions{})
+			lease, err := t.HubKubeClient.CoordinationV1().Leases(universalClusterName).Get(context.TODO(), leaseName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -163,7 +163,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 
 		ginkgo.By("Make sure ManagedCluster is still available")
 		err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
-			managedCluster, err := managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			managedCluster, err := managedClusters.Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		// make sure the cpu and memory are still in the status, for compatibility
 		ginkgo.By("Make sure cpu and memory exist in status")
 		err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
-			managedCluster, err := managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			managedCluster, err := managedClusters.Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -208,7 +208,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 			},
 		}
 		err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
-			managedCluster, err := managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			managedCluster, err := managedClusters.Get(context.TODO(), universalClusterName, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -232,16 +232,16 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		addOn := &addonv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      addOnName,
-				Namespace: clusterName,
+				Namespace: universalClusterName,
 			},
 			Spec: addonv1alpha1.ManagedClusterAddOnSpec{
 				InstallNamespace: addOnName,
 			},
 		}
-		_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Create(context.TODO(), addOn, metav1.CreateOptions{})
+		_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Create(context.TODO(), addOn, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		created, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
+		created, err := t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		created.Status = addonv1alpha1.ManagedClusterAddOnStatus{
 			Registrations: []addonv1alpha1.RegistrationConfig{
@@ -250,7 +250,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 				},
 			},
 		}
-		_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).UpdateStatus(context.TODO(), created, metav1.UpdateOptions{})
+		_, err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).UpdateStatus(context.TODO(), created, metav1.UpdateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		var (
@@ -262,7 +262,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		err = wait.Poll(1*time.Second, 90*time.Second, func() (bool, error) {
 			var err error
 			csrs, err = csrClient.List(context.TODO(), metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("open-cluster-management.io/cluster-name=%s,open-cluster-management.io/addon-name=%s", clusterName, addOnName),
+				LabelSelector: fmt.Sprintf("open-cluster-management.io/cluster-name=%s,open-cluster-management.io/addon-name=%s", universalClusterName, addOnName),
 			})
 			if err != nil {
 				return false, err
@@ -334,7 +334,7 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		}).Should(gomega.Succeed())
 
 		ginkgo.By("Delete the addon and check if secret is gone")
-		err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(clusterName).Delete(context.TODO(), addOnName, metav1.DeleteOptions{})
+		err = t.AddOnClinet.AddonV1alpha1().ManagedClusterAddOns(universalClusterName).Delete(context.TODO(), addOnName, metav1.DeleteOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		gomega.Eventually(func() bool {

--- a/test/e2e/manifestworkreplicaset_test.go
+++ b/test/e2e/manifestworkreplicaset_test.go
@@ -69,10 +69,10 @@ var _ = ginkgo.Describe("Test ManifestWorkReplicaSet", ginkgo.Label("manifestwor
 			csb := &clusterapiv1beta2.ManagedClusterSetBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: metav1.NamespaceDefault,
-					Name:      "default",
+					Name:      universalClusterSetName,
 				},
 				Spec: clusterapiv1beta2.ManagedClusterSetBindingSpec{
-					ClusterSet: "default",
+					ClusterSet: universalClusterSetName,
 				},
 			}
 			_, err = t.ClusterClient.ClusterV1beta2().ManagedClusterSetBindings(metav1.NamespaceDefault).Create(
@@ -83,6 +83,9 @@ var _ = ginkgo.Describe("Test ManifestWorkReplicaSet", ginkgo.Label("manifestwor
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      placementRef.Name,
 					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: clusterv1beta1.PlacementSpec{
+					ClusterSets: []string{universalClusterSetName},
 				},
 			}
 

--- a/test/e2e/work_webhook_test.go
+++ b/test/e2e/work_webhook_test.go
@@ -31,21 +31,21 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 	})
 
 	ginkgo.AfterEach(func() {
-		ginkgo.By(fmt.Sprintf("delete manifestwork %v/%v", clusterName, workName))
-		gomega.Expect(t.cleanManifestWorks(clusterName, workName)).To(gomega.BeNil())
+		ginkgo.By(fmt.Sprintf("delete manifestwork %v/%v", universalClusterName, workName))
+		gomega.Expect(t.cleanManifestWorks(universalClusterName, workName)).To(gomega.BeNil())
 	})
 
 	ginkgo.Context("Creating a manifestwork", func() {
 		ginkgo.It("Should respond bad request when creating a manifestwork with no manifests", func() {
-			work := newManifestWork(clusterName, workName)
-			_, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work := newManifestWork(universalClusterName, workName)
+			_, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(errors.IsBadRequest(err)).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("Should respond bad request when creating a manifest with no name", func() {
-			work := newManifestWork(clusterName, workName, []runtime.Object{util.NewConfigmap("default", "", nil, nil)}...)
-			_, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work := newManifestWork(universalClusterName, workName, []runtime.Object{util.NewConfigmap("default", "", nil, nil)}...)
+			_, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(errors.IsBadRequest(err)).Should(gomega.BeTrue())
 		})
@@ -63,10 +63,10 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 				}
 
 				// create a temporary role
-				_, err := t.HubKubeClient.RbacV1().Roles(clusterName).Create(
+				_, err := t.HubKubeClient.RbacV1().Roles(universalClusterName).Create(
 					context.TODO(), &rbacv1.Role{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: clusterName,
+							Namespace: universalClusterName,
 							Name:      roleName,
 						},
 						Rules: []rbacv1.PolicyRule{
@@ -80,16 +80,16 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 				// create a temporary rolebinding
-				_, err = t.HubKubeClient.RbacV1().RoleBindings(clusterName).Create(
+				_, err = t.HubKubeClient.RbacV1().RoleBindings(universalClusterName).Create(
 					context.TODO(), &rbacv1.RoleBinding{
 						ObjectMeta: metav1.ObjectMeta{
-							Namespace: clusterName,
+							Namespace: universalClusterName,
 							Name:      roleName,
 						},
 						Subjects: []rbacv1.Subject{
 							{
 								Kind:      "ServiceAccount",
-								Namespace: clusterName,
+								Namespace: universalClusterName,
 								Name:      hubUser,
 							},
 						},
@@ -104,27 +104,27 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 
 			ginkgo.AfterEach(func() {
 				// delete the temporary role
-				err := t.HubKubeClient.RbacV1().Roles(clusterName).Delete(context.TODO(), roleName, metav1.DeleteOptions{})
+				err := t.HubKubeClient.RbacV1().Roles(universalClusterName).Delete(context.TODO(), roleName, metav1.DeleteOptions{})
 				if !errors.IsNotFound(err) {
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				}
 
 				// delete the temporary rolebinding
-				err = t.HubKubeClient.RbacV1().RoleBindings(clusterName).Delete(context.TODO(), roleName, metav1.DeleteOptions{})
+				err = t.HubKubeClient.RbacV1().RoleBindings(universalClusterName).Delete(context.TODO(), roleName, metav1.DeleteOptions{})
 				if !errors.IsNotFound(err) {
 					gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				}
 			})
 
 			ginkgo.It("Should respond bad request when no permission for nil executor", func() {
-				work := newManifestWork(clusterName, workName, []runtime.Object{util.NewConfigmap("default", "cm1", nil, nil)}...)
+				work := newManifestWork(universalClusterName, workName, []runtime.Object{util.NewConfigmap("default", "cm1", nil, nil)}...)
 
 				// impersonate as a hub user without execute-as permission
 				impersonatedConfig := *t.HubClusterCfg
-				impersonatedConfig.Impersonate.UserName = fmt.Sprintf("system:serviceaccount:%s:%s", clusterName, hubUser)
+				impersonatedConfig.Impersonate.UserName = fmt.Sprintf("system:serviceaccount:%s:%s", universalClusterName, hubUser)
 				impersonatedHubWorkClient, err := workclientset.NewForConfig(&impersonatedConfig)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				_, err = impersonatedHubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
+				_, err = impersonatedHubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(
 					context.Background(), work, metav1.CreateOptions{})
 				gomega.Expect(err).To(gomega.HaveOccurred())
 				if !errors.IsBadRequest(err) {
@@ -139,8 +139,8 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 		var err error
 
 		ginkgo.BeforeEach(func() {
-			work := newManifestWork(clusterName, workName, []runtime.Object{util.NewConfigmap("default", "cm1", nil, nil)}...)
-			_, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work := newManifestWork(universalClusterName, workName, []runtime.Object{util.NewConfigmap("default", "cm1", nil, nil)}...)
+			_, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
@@ -148,11 +148,11 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 			manifest := workapiv1.Manifest{}
 			manifest.Object = util.NewConfigmap("default", "", nil, nil)
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				work, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(context.Background(), workName, metav1.GetOptions{})
+				work, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(context.Background(), workName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				work.Spec.Workload.Manifests = append(work.Spec.Workload.Manifests, manifest)
-				_, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Update(context.Background(), work, metav1.UpdateOptions{})
+				_, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
 				return err
 			})
 
@@ -190,11 +190,11 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 			}
 
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				work, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(context.Background(), workName, metav1.GetOptions{})
+				work, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(context.Background(), workName, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				work.Spec.Workload.Manifests = append(work.Spec.Workload.Manifests, manifests...)
-				_, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Update(context.Background(), work, metav1.UpdateOptions{})
+				_, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
 				return err
 			})
 

--- a/test/e2e/work_workload_test.go
+++ b/test/e2e/work_workload_test.go
@@ -156,8 +156,8 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 	})
 
 	ginkgo.AfterEach(func() {
-		ginkgo.By(fmt.Sprintf("delete manifestwork %v/%v", clusterName, workName))
-		gomega.Expect(t.cleanManifestWorks(clusterName, workName)).To(gomega.BeNil())
+		ginkgo.By(fmt.Sprintf("delete manifestwork %v/%v", universalClusterName, workName))
+		gomega.Expect(t.cleanManifestWorks(universalClusterName, workName)).To(gomega.BeNil())
 	})
 
 	ginkgo.Context("Work CRUD", func() {
@@ -204,8 +204,8 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 				util.NewConfigmap(ns1, "cm2", nil, nil),
 				util.NewConfigmap(ns2, "cm3", nil, cmFinalizers),
 			}
-			work := newManifestWork(clusterName, workName, objects...)
-			work, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work := newManifestWork(universalClusterName, workName, objects...)
+			work, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// check if resources are applied for manifests
@@ -234,7 +234,7 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 				// check manifest status conditions
 				expectedManifestStatuses := []metav1.ConditionStatus{
 					metav1.ConditionTrue, metav1.ConditionTrue, metav1.ConditionTrue, metav1.ConditionTrue}
-				return assertManifestWorkAppliedSuccessfully(clusterName, workName, expectedManifestStatuses)
+				return assertManifestWorkAppliedSuccessfully(universalClusterName, workName, expectedManifestStatuses)
 			}).ShouldNot(gomega.HaveOccurred())
 
 			// get the corresponding AppliedManifestWork
@@ -283,15 +283,15 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 				objects[2],
 				util.NewConfigmap(ns2, "cm3", cmData, cmFinalizers),
 			}
-			newWork := newManifestWork(clusterName, workName, newObjects...)
+			newWork := newManifestWork(universalClusterName, workName, newObjects...)
 			gomega.Eventually(func() error {
-				work, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(context.Background(), workName, metav1.GetOptions{})
+				work, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(context.Background(), workName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
 				work.Spec.Workload.Manifests = newWork.Spec.Workload.Manifests
-				work, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Update(context.Background(), work, metav1.UpdateOptions{})
+				work, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
 				return err
 			}).Should(gomega.Succeed())
 
@@ -312,7 +312,7 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 				// check manifest status conditions
 				expectedManifestStatuses := []metav1.ConditionStatus{
 					metav1.ConditionTrue, metav1.ConditionTrue, metav1.ConditionTrue}
-				return assertManifestWorkAppliedSuccessfully(clusterName, workName, expectedManifestStatuses)
+				return assertManifestWorkAppliedSuccessfully(universalClusterName, workName, expectedManifestStatuses)
 			}).ShouldNot(gomega.HaveOccurred())
 
 			// check if cm1 is deleted
@@ -334,7 +334,7 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			}).ShouldNot(gomega.HaveOccurred())
 
 			ginkgo.By("delete manifestwork")
-			err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Delete(context.Background(), workName, metav1.DeleteOptions{})
+			err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Delete(context.Background(), workName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// remove finalizer from cm3 in 2 seconds
@@ -350,7 +350,7 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 
 			// wait for deletion of manifest work
 			gomega.Eventually(func() bool {
-				_, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(context.Background(), workName, metav1.GetOptions{})
+				_, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(context.Background(), workName, metav1.GetOptions{})
 				return errors.IsNotFound(err)
 			}).Should(gomega.BeTrue())
 
@@ -385,13 +385,13 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			objects := []runtime.Object{
 				newJob(jobName),
 			}
-			work := newManifestWork(clusterName, workName, objects...)
-			work, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work := newManifestWork(universalClusterName, workName, objects...)
+			work, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// check status conditions in manifestwork status
 			gomega.Eventually(func() error {
-				work, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(context.Background(), workName, metav1.GetOptions{})
+				work, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(context.Background(), workName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -421,7 +421,7 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			}).ShouldNot(gomega.HaveOccurred())
 
 			ginkgo.By("delete manifestwork")
-			err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Delete(context.Background(), workName, metav1.DeleteOptions{})
+			err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Delete(context.Background(), workName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// pods should be all cleaned.
@@ -472,15 +472,15 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			objects := []runtime.Object{crd, clusterRole, cr}
-			work := newManifestWork(clusterName, workName, objects...)
-			_, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			work := newManifestWork(universalClusterName, workName, objects...)
+			_, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// check status conditions in manifestwork status
 			gomega.Eventually(func() error {
 				expectedManifestStatuses := []metav1.ConditionStatus{
 					metav1.ConditionTrue, metav1.ConditionTrue, metav1.ConditionTrue}
-				return assertManifestWorkAppliedSuccessfully(clusterName, workName, expectedManifestStatuses)
+				return assertManifestWorkAppliedSuccessfully(universalClusterName, workName, expectedManifestStatuses)
 			}).ShouldNot(gomega.HaveOccurred())
 
 			// Upgrade crd/cr and check if cr resource is recreated.
@@ -497,13 +497,13 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			cr, err = newCr(upgradedGuestBookCRJson, crNamespace, "cr1")
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			objects = []runtime.Object{crd, clusterRole, cr}
-			work = newManifestWork(clusterName, workName, objects...)
+			work = newManifestWork(universalClusterName, workName, objects...)
 
 			// Update work
-			existingWork, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(context.Background(), workName, metav1.GetOptions{})
+			existingWork, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(context.Background(), workName, metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			work.ResourceVersion = existingWork.ResourceVersion
-			_, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Update(context.Background(), work, metav1.UpdateOptions{})
+			_, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Update(context.Background(), work, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// check if v2 cr is applied
@@ -533,7 +533,7 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 		ginkgo.It("should return wellkown status of deployment", func() {
 			deployment := newDeployment("busybox")
 			objects := []runtime.Object{deployment}
-			work := newManifestWork(clusterName, workName, objects...)
+			work := newManifestWork(universalClusterName, workName, objects...)
 			work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
 				{
 					ResourceIdentifier: workapiv1.ResourceIdentifier{
@@ -558,12 +558,12 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 					},
 				},
 			}
-			_, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			_, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// Check deployment status
 			gomega.Eventually(func() error {
-				work, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(context.Background(), workName, metav1.GetOptions{})
+				work, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(context.Background(), workName, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -631,8 +631,8 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			objects := []runtime.Object{
 				util.NewConfigmap(nsName, cmName, nil, nil),
 			}
-			work := newManifestWork(clusterName, workName, objects...)
-			_, err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
+			work := newManifestWork(universalClusterName, workName, objects...)
+			_, err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		})
@@ -648,14 +648,14 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			objects := []runtime.Object{
 				util.NewConfigmap(nsName, cmName, nil, nil),
 			}
-			work2 := newManifestWork(clusterName, work2Name, objects...)
-			_, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Create(ctx, work2, metav1.CreateOptions{})
+			work2 := newManifestWork(universalClusterName, work2Name, objects...)
+			_, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Create(ctx, work2, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			for _, name := range []string{workName, work2Name} {
 				// check status conditions in manifestwork status
 				gomega.Eventually(func() error {
-					work, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(
+					work, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(
 						ctx, name, metav1.GetOptions{})
 					if err != nil {
 						return err
@@ -663,7 +663,7 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 
 					// check manifest status conditions
 					expectedManifestStatuses := []metav1.ConditionStatus{metav1.ConditionTrue}
-					return assertManifestWorkAppliedSuccessfully(clusterName, work.Name, expectedManifestStatuses)
+					return assertManifestWorkAppliedSuccessfully(universalClusterName, work.Name, expectedManifestStatuses)
 				}).ShouldNot(gomega.HaveOccurred())
 			}
 
@@ -683,12 +683,12 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			}).ShouldNot(gomega.HaveOccurred())
 
 			ginkgo.By("delete manifestwork mw1")
-			err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Delete(ctx, workName, metav1.DeleteOptions{})
+			err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Delete(ctx, workName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// wait for deletion of manifest work
 			gomega.Eventually(func() bool {
-				_, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(ctx, workName, metav1.GetOptions{})
+				_, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(ctx, workName, metav1.GetOptions{})
 				return errors.IsNotFound(err)
 			}).Should(gomega.BeTrue())
 
@@ -697,12 +697,12 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			gomega.Expect(cm.UID).To(gomega.Equal(cmUID))
 
 			ginkgo.By("delete manifestwork mw2")
-			err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Delete(ctx, work2Name, metav1.DeleteOptions{})
+			err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Delete(ctx, work2Name, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// wait for deletion of manifest work
 			gomega.Eventually(func() bool {
-				_, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(ctx, work2Name, metav1.GetOptions{})
+				_, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(ctx, work2Name, metav1.GetOptions{})
 				return errors.IsNotFound(err)
 			}).Should(gomega.BeTrue())
 
@@ -714,7 +714,7 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			// check status conditions in manifestwork status
 			gomega.Eventually(func() error { // check manifest status conditions
 				expectedManifestStatuses := []metav1.ConditionStatus{metav1.ConditionTrue}
-				return assertManifestWorkAppliedSuccessfully(clusterName, workName, expectedManifestStatuses)
+				return assertManifestWorkAppliedSuccessfully(universalClusterName, workName, expectedManifestStatuses)
 			}).ShouldNot(gomega.HaveOccurred())
 
 			ginkgo.By("check if resources are applied for manifests")
@@ -747,12 +747,12 @@ var _ = ginkgo.Describe("Work agent", ginkgo.Label("work-agent", "sanity-check")
 			gomega.Expect(len(cm.OwnerReferences) == 2).To(gomega.BeTrue())
 
 			ginkgo.By("delete manifestwork mw1")
-			err = t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Delete(ctx, workName, metav1.DeleteOptions{})
+			err = t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Delete(ctx, workName, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			ginkgo.By("wait for deletion of manifest work")
 			gomega.Eventually(func() bool {
-				_, err := t.HubWorkClient.WorkV1().ManifestWorks(clusterName).Get(ctx, workName, metav1.GetOptions{})
+				_, err := t.HubWorkClient.WorkV1().ManifestWorks(universalClusterName).Get(ctx, workName, metav1.GetOptions{})
 				return errors.IsNotFound(err)
 			}).Should(gomega.BeTrue())
 


### PR DESCRIPTION
## Summary

Cases are using a shared, universal klusterlet/managed cluster, rename the field to expilicitly hight this point.

Also:
* Remove the clusterName, klusterletName, agentNamespace from flags since they will always be named by: 

https://github.com/open-cluster-management-io/ocm/blob/b3f15c14f483884bb12fee7528321ef6e1d53608/test/e2e/e2e_suite_test.go#L85-L87

* Remove deploy-klusterlet from the flags since it's always true in our test.