### PR TITLE
:bug: fix: put the update into a eventually to avoid flaky error.

### DIFF
--- a/test/integration/registration/spokecluster_autoapproval_test.go
+++ b/test/integration/registration/spokecluster_autoapproval_test.go
@@ -124,14 +124,15 @@ var _ = ginkgo.Describe("Cluster Auto Approval", func() {
 		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 
 		// we can deny the cluster after it is accepted
-		cluster, err := util.GetManagedCluster(clusterClient, clusterName)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(func() error {
+			cluster, err := util.GetManagedCluster(clusterClient, clusterName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		updatedCluster := cluster.DeepCopy()
-		updatedCluster.Spec.HubAcceptsClient = false
-
-		_, err = clusterClient.ClusterV1().ManagedClusters().Update(context.TODO(), updatedCluster, v1.UpdateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			updatedCluster := cluster.DeepCopy()
+			updatedCluster.Spec.HubAcceptsClient = false
+			_, err = clusterClient.ClusterV1().ManagedClusters().Update(context.TODO(), updatedCluster, v1.UpdateOptions{})
+			return err
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 
 		gomega.Consistently(func() error {
 			cluster, err := util.GetManagedCluster(clusterClient, clusterName)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Sometimes the update operation need another try.

To avoid errors like the following:

```
  Event: [hub-managedclustercontroller] NamespaceCreated: Created Namespace/autoapprovaltest-spoke-cluster1 because it was missing 
  [FAILED] in [It] - /home/runner/work/ocm/ocm/test/integration/registration/spokecluster_autoapproval_test.go:134 @ 07/05/24 03:36:20.343
• [FAILED] [0.011 seconds]
Cluster Auto Approval [It] Cluster can be denied by manually after automatically approved
/home/runner/work/ocm/ocm/test/integration/registration/spokecluster_autoapproval_test.go:100

  [FAILED] Unexpected error:
      <*errors.StatusError | 0xc0004cc500>: 
      Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "autoapprovaltest-spoke-cluster1": the object has been modified; please apply your changes to the latest version and try again
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io \"autoapprovaltest-spoke-cluster1\": the object has been modified; please apply your changes to the latest version and try again",
              Reason: "Conflict",
              Details: {
                  Name: "autoapprovaltest-spoke-cluster1",
                  Group: "cluster.open-cluster-management.io",
                  Kind: "managedclusters",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 409,
          },
      }
  occurred
  In [It] at: /home/runner/work/ocm/ocm/test/integration/registration/spokecluster_autoapproval_test.go:134 @ 07/05/24 03:36:20.343
```