### PR TITLE
:bug: Fix: hello template e2e error.

### DIFF
--- a/hack/e2e_flaky_error_test.sh
+++ b/hack/e2e_flaky_error_test.sh
@@ -32,8 +32,14 @@ do
     kind load docker-image --name=e2e quay.io/open-cluster-management/placement:$IMAGE_TAG
     kind load docker-image --name=e2e quay.io/open-cluster-management/addon-manager:$IMAGE_TAG
 
+    # This is for addon-manager test: /workspaces/OCM/test/e2e/manifests/addon/addon_template.yaml
+    docker pull quay.io/open-cluster-management/addon-examples:latest
+    kind load docker-image --name=e2e quay.io/open-cluster-management/addon-examples:latest
+
+    kind get kubeconfig --name=e2e > .kubeconfig
+
     echo "Running e2e test iteration $((i+1))/$RUN_TIMES with KlusterletDeployMode=$KLUSTERLET_DEPLOY_MODE"
-    test_output=$(IMAGE_TAG=$IMAGE_TAG KLUSTERLET_DEPLOY_MODE=$KLUSTERLET_DEPLOY_MODE make test-e2e 2>&1)
+    test_output=$(IMAGE_TAG=$IMAGE_TAG KLUSTERLET_DEPLOY_MODE=$KLUSTERLET_DEPLOY_MODE KUBECONFIG=.kubeconfig make test-e2e 2>&1)
     test_exit_code=$?
 
     # Determine test result and update the respective list

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -22,7 +22,6 @@ import (
 	workapiv1 "open-cluster-management.io/api/work/v1"
 
 	"open-cluster-management.io/ocm/pkg/addon/templateagent"
-	"open-cluster-management.io/ocm/pkg/operator/helpers"
 	"open-cluster-management.io/ocm/test/e2e/manifests"
 )
 
@@ -50,7 +49,7 @@ var (
 
 var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, ginkgo.Label("addon-manager"), func() {
 	addOnName := "hello-template"
-	var addonInstallNamespace string
+	addonInstallNamespace := "test-addon-template"
 
 	s := runtime.NewScheme()
 	_ = scheme.AddToScheme(s)
@@ -73,8 +72,6 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 
 		// the addon manager deployment should be running
 		gomega.Eventually(t.CheckHubReady, t.EventuallyTimeout, t.EventuallyInterval).Should(gomega.Succeed())
-
-		addonInstallNamespace = helpers.DefaultAddonNamespace
 
 		ginkgo.By(fmt.Sprintf("create addon template resources for cluster %v", clusterName))
 		err = createResourcesFromYamlFiles(context.Background(), t.HubDynamicClient, t.hubRestMapper, s,

--- a/test/e2e/manifests/addon/addon_template.yaml
+++ b/test/e2e/manifests/addon/addon_template.yaml
@@ -15,6 +15,10 @@ spec:
             type: ServerSideApply
       workload:
         manifests:
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: << AddonInstallNamespace >>
           - kind: Deployment
             apiVersion: apps/v1
             metadata:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Recently we got this addon-manager flaky errors very frequently:
```
  [FAILED] Timed out after 300.000s.
  Expected success, but got an error:
      <*errors.errorString | 0xc000b835c0>: 
      the addon e2e-universal-managedcluster-phbngt/hello-template available condition is not true, [{Progressing True 0 2024-07-05 04:47:53 +0000 UTC Progressing progressing... work is not ready} {RegistrationApplied True 0 2024-07-05 04:47:53 +0000 UTC SetPermissionApplied Registration of the addon agent is configured} {ClusterCertificateRotated False 0 2024-07-05 04:47:53 +0000 UTC ClientCertificateUpdateFailed Failed to rotated client certificate namespaces "open-cluster-management-agent-addon" not found} {ManifestApplied False 0 2024-07-05 04:47:53 +0000 UTC AddonManifestAppliedFailed failed to apply the manifests of addon} {Available False 0 2024-07-05 04:47:53 +0000 UTC WorkNotApplied 3 of 4 resources are not available}]
      {
          s: "the addon e2e-universal-managedcluster-phbngt/hello-template available condition is not true, [{Progressing True 0 2024-07-05 04:47:53 +0000 UTC Progressing progressing... work is not ready} {RegistrationApplied True 0 2024-07-05 04:47:53 +0000 UTC SetPermissionApplied Registration of the addon agent is configured} {ClusterCertificateRotated False 0 2024-07-05 04:47:53 +0000 UTC ClientCertificateUpdateFailed Failed to rotated client certificate namespaces \"open-cluster-management-agent-addon\" not found} {ManifestApplied False 0 2024-07-05 04:47:53 +0000 UTC AddonManifestAppliedFailed failed to apply the manifests of addon} {Available False 0 2024-07-05 04:47:53 +0000 UTC WorkNotApplied 3 of 4 resources are not available}]",
      }
```

From the log, you can see the root cause is because:
```
ClusterCertificateRotated False 0 2024-07-05 04:47:53 +0000 UTC ClientCertificateUpdateFailed Failed to rotated client certificate namespaces \"open-cluster-management-agent-addon\" not found
```

This is because currently, the namespace for addons are fixed to be: `open-cluster-management-agent-addon`. Currently we have 5 places to `cleanKlusterletResources`:

![image](https://github.com/open-cluster-management-io/ocm/assets/11444421/14699035-1c41-4a3b-8dac-00a985a5df95)

There are chances that `open-cluster-management-agent` is cleaned up, and then addon-manager start to test its case.

BUT, addon-manager is using the universal klusterlet create at the init of the e2e, that klusterlet is not changed, so the controller won't be reconcile to create `open-cluster-management-agent-addon` again.

That's the reason why we have the `namespaces \"open-cluster-management-agent-addon\" not found` error.

---

A simple way to fix it is using another ns in addon-manager cases.