### PR TITLE
:bug:  Fix: miss handle the err lease-controller.

### DIFF
--- a/pkg/registration/spoke/addon/lease_controller.go
+++ b/pkg/registration/spoke/addon/lease_controller.go
@@ -160,7 +160,7 @@ func (c *managedClusterAddOnLeaseController) syncSingle(ctx context.Context,
 			Type:    addonv1alpha1.ManagedClusterAddOnConditionAvailable,
 			Status:  metav1.ConditionUnknown,
 			Reason:  "ManagedClusterAddOnLeaseNotFound",
-			Message: fmt.Sprintf("The status of %s add-on is unknown.", addOn.Name),
+			Message: fmt.Sprintf("The status of %s add-on is unknown because get lease from hub failed: %v", addOn.Name, err),
 		}
 	case err != nil:
 		return err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When the lease controller get hub lease failed, the error is not handled in any way, change to reporting it via condition msg.