### PR TITLE
🐛 Ignore appliedmanifestwork crd not found error when checking managed cluster connectivity

### DIFF
--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller.go
@@ -220,6 +220,10 @@ func (n *klusterletCleanupController) checkConnectivity(ctx context.Context,
 	if err == nil {
 		return true, nil
 	}
+	if errors.IsNotFound(err) {
+		klog.Infof("AppliedManifestWork not found, klusterlet %s", klusterlet.Name)
+		return true, nil
+	}
 
 	// if the managed cluster is destroyed, the returned err is TCP timeout or TCP no such host,
 	// the k8s.io/apimachinery/pkg/api/errors.IsTimeout,IsServerTimeout can not match this error


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR will fix the bug that detaching cluster gets stuck when appliedManifestWork CRD does not exist on the hosted managed cluster
## Related issue(s)

Fixes #