### PR TITLE
:seedling: support set imagepullsecret credential in helm chart and run e2e using helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ update: copy-crd update-csv
 
 test-unit: ensure-kubebuilder-tools
 
-update-csv: ensure-operator-sdk ensure-operator-helm
+update-csv: ensure-operator-sdk ensure-helm
 	bash -x hack/update-csv.sh
 
 	# update the replaces to released version in csv
@@ -126,7 +126,7 @@ else
 	$(info Using existing operator-sdk from "$(OPERATOR_SDK)")
 endif
 
-ensure-operator-helm:
+ensure-helm:
 ifeq "" "$(wildcard $(HELM))"
 	$(info Installing helm into '$(HELM)')
 	mkdir -p '$(helm_gen_dir)'

--- a/deploy/cluster-manager/chart/cluster-manager/templates/_helpers.tpl
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/_helpers.tpl
@@ -3,6 +3,8 @@
 {{- with .Values.images }}
 {{- if and .imageCredentials.userName .imageCredentials.password }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .registry (printf "%s:%s" .imageCredentials.userName .imageCredentials.password | b64enc) | b64enc }}
+{{- else if .imageCredentials.dockerConfigJson }}
+{{- printf "%s" .imageCredentials.dockerConfigJson | b64enc }}
 {{- else }}
 {{- printf "{}" | b64enc }}
 {{- end }}
@@ -15,7 +17,7 @@
 {{- printf "ocmhub" }}
 {{- end }}
 {{- define "tokenSecret" }}
-{{- printf "%s" (randAlphaNum 6) }}
+{{- printf "%s" (randAlphaNum 16) }}
 {{- end }}
 
 {{/* Define the image tag. */}}

--- a/deploy/cluster-manager/chart/cluster-manager/templates/cluster_manager.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/cluster_manager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterManager.create }}
 apiVersion: operator.open-cluster-management.io/v1
 kind: ClusterManager
 metadata:
@@ -31,3 +32,4 @@ spec:
   addOnManagerConfiguration:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/deploy/cluster-manager/chart/cluster-manager/values.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/values.yaml
@@ -10,13 +10,14 @@ images:
   tag: ""
   imagePullPolicy: IfNotPresent
   # The image pull secret name is open-cluster-management-image-pull-credentials.
-  # Please set the userName and password if you use a private image registry.
+  # Please set the userName/password or the dockerConfigJson if you use a private image registry.
   # The image pull secret is fixed into the serviceAccount, you can also set
   # `createImageCredentials` to `false` and create the pull secret manually.
   imageCredentials:
     createImageCredentials: false
     userName: ""
     password: ""
+    dockerConfigJson: ""
 
 # podSecurityContext for clusterManager operator deployment.
 podSecurityContext:
@@ -77,6 +78,8 @@ createBootstrapSA: false
 
 # configurations for clusterManager CR.
 clusterManager:
+  # if false, will not create clusterManager instance, default is true.
+  create: true
   mode: Default
   resourceRequirement:
     type: Default

--- a/deploy/cluster-manager/chart/config.go
+++ b/deploy/cluster-manager/chart/config.go
@@ -2,10 +2,6 @@ package chart
 
 import (
 	"embed"
-
-	corev1 "k8s.io/api/core/v1"
-
-	operatorv1 "open-cluster-management.io/api/operator/v1"
 )
 
 //go:embed cluster-manager
@@ -15,70 +11,3 @@ import (
 var ChartFiles embed.FS
 
 const ChartName = "cluster-manager"
-
-type ChartConfig struct {
-	// CreateNamespace is used in the render function to append the release ns in the objects.
-	CreateNamespace bool `json:"createNamespace,omitempty"`
-	// ReplicaCount is the replicas for the clusterManager operator deployment.
-	ReplicaCount int `json:"replicaCount,omitempty"`
-	// Images is the configurations for all images used in operator deployment and clusterManager CR.
-	Images ImagesConfig `json:"images,omitempty"`
-	// PodSecurityContext is the pod SecurityContext in the operator deployment
-	PodSecurityContext corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
-	// SecurityContext is the container SecurityContext in operator deployment
-	SecurityContext corev1.SecurityContext `json:"securityContext,omitempty"`
-	// Resources is the resource requirements of the operator deployment
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-	// NodeSelector is the nodeSelector of the operator deployment
-	NodeSelector corev1.NodeSelector `json:"nodeSelector,omitempty"`
-	// Tolerations is the tolerations of the operator deployment
-	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// Affinity is the affinity of the operator deployment
-	Affinity corev1.Affinity `json:"affinity,omitempty"`
-	// CreateBootstrapToken is to enable/disable the bootstrap token secret for auto approve.
-	CreateBootstrapToken bool `json:"createBootstrapToken,omitempty"`
-	// CreateBootstrapSA is to create a serviceAccount to generate token.
-	CreateBootstrapSA bool `json:"createBootstrapSA,omitempty"`
-	// ClusterManager is the configuration of clusterManager CR
-	ClusterManager ClusterManagerConfig `json:"clusterManager,omitempty"`
-}
-
-type ImagesConfig struct {
-	// Registry is registry name must NOT contain a trailing slash.
-	Registry string `json:"registry,omitempty"`
-	// Tag is the operator image tag.
-	Tag string `json:"tag,omitempty"`
-	// ImagePullPolicy is the image pull policy of operator image. Default is IfNotPresent.
-	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
-	// The image pull secret name is open-cluster-management-image-pull-credentials.
-	// Please set the userName and password if you use a private image registry.
-	ImageCredentials ImageCredentials `json:"imageCredentials,omitempty"`
-}
-
-type ImageCredentials struct {
-	CreateImageCredentials bool   `json:"createImageCredentials,omitempty"`
-	UserName               string `json:"userName,omitempty"`
-	Password               string `json:"password,omitempty"`
-}
-
-type ClusterManagerConfig struct {
-	// InstallMode represents the mode of deploy cluster-manager
-	Mode operatorv1.InstallMode `json:"mode,omitempty"`
-
-	// RegistrationConfiguration contains the configuration of registration
-	// +optional
-	RegistrationConfiguration operatorv1.RegistrationHubConfiguration `json:"registrationConfiguration,omitempty"`
-
-	// WorkConfiguration contains the configuration of work
-	// +optional
-	WorkConfiguration operatorv1.WorkConfiguration `json:"workConfiguration,omitempty"`
-
-	// AddOnManagerConfiguration contains the configuration of addon manager
-	// +optional
-	AddOnManagerConfiguration operatorv1.AddOnManagerConfiguration `json:"addOnManagerConfiguration,omitempty"`
-
-	// ResourceRequirement specify QoS classes of deployments managed by clustermanager.
-	// It applies to all the containers in the deployments.
-	// +optional
-	ResourceRequirement operatorv1.ResourceRequirement `json:"resourceRequirement,omitempty"`
-}

--- a/deploy/klusterlet/chart/config.go
+++ b/deploy/klusterlet/chart/config.go
@@ -2,10 +2,6 @@ package chart
 
 import (
 	"embed"
-
-	corev1 "k8s.io/api/core/v1"
-
-	operatorv1 "open-cluster-management.io/api/operator/v1"
 )
 
 //go:embed klusterlet
@@ -15,88 +11,3 @@ import (
 var ChartFiles embed.FS
 
 const ChartName = "klusterlet"
-
-type ChartConfig struct {
-	// CreateNamespace is used in the render function to append the release ns in the objects.
-	CreateNamespace bool `json:"createNamespace,omitempty"`
-	// ReplicaCount is the replicas for the klusterlet operator deployment.
-	ReplicaCount int `json:"replicaCount,omitempty"`
-	// Images is the configurations for all images used in operator deployment and klusterlet CR.
-	Images ImagesConfig `json:"images,omitempty"`
-	// PodSecurityContext is the pod SecurityContext in the operator deployment
-	PodSecurityContext corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
-	// SecurityContext is the container SecurityContext in operator deployment
-	SecurityContext corev1.SecurityContext `json:"securityContext,omitempty"`
-	// Resources is the resource requirements of the operator deployment
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-	// NodeSelector is the nodeSelector of the operator deployment
-	NodeSelector corev1.NodeSelector `json:"nodeSelector,omitempty"`
-	// Tolerations is the tolerations of the operator deployment
-	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// Affinity is the affinity of the operator deployment
-	Affinity corev1.Affinity `json:"affinity,omitempty"`
-	// Klusterlet is the configuration of klusterlet CR
-	Klusterlet KlusterletConfig `json:"klusterlet,omitempty"`
-	// PriorityClassName is the name of the PriorityClass that will be used by the deployed klusterlet agent and operator.
-	PriorityClassName string `json:"priorityClassName,omitempty"`
-
-	// EnableSyncLabels is to enable the feature which can sync the labels from klusterlet to all agent resources.
-	EnableSyncLabels bool `json:"enableSyncLabels,omitempty"`
-
-	// BootstrapHubKubeConfig should be the kubeConfig file of the hub cluster via setting --set-file=<the kubeConfig file of hub cluster> optional
-	BootstrapHubKubeConfig string `json:"bootstrapHubKubeConfig,omitempty"`
-
-	// ExternalManagedKubeConfig should be the kubeConfig file of the managed cluster via setting --set-file=<the kubeConfig file of managed cluster>
-	// only need to set in the hosted mode. optional
-	ExternalManagedKubeConfig string `json:"externalManagedKubeConfig,omitempty"`
-
-	// NoOperator is to only deploy the klusterlet CR if set true.
-	NoOperator bool `json:"noOperator,omitempty"`
-}
-
-type ImagesConfig struct {
-	// Registry is registry name must NOT contain a trailing slash.
-	Registry string `json:"registry,omitempty"`
-	// Tag is the operator image tag.
-	Tag string `json:"tag,omitempty"`
-	// ImagePullPolicy is the image pull policy of operator image. Default is IfNotPresent.
-	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
-	// The image pull secret name is open-cluster-management-image-pull-credentials.
-	// Please set the userName and password if you use a private image registry.
-	ImageCredentials ImageCredentials `json:"imageCredentials,omitempty"`
-}
-
-type ImageCredentials struct {
-	CreateImageCredentials bool   `json:"createImageCredentials,omitempty"`
-	UserName               string `json:"userName,omitempty"`
-	Password               string `json:"password,omitempty"`
-}
-
-type KlusterletConfig struct {
-	// InstallMode represents the mode of deploy klusterlet
-	Mode        operatorv1.InstallMode `json:"mode,omitempty"`
-	Name        string                 `json:"name,omitempty"`
-	ClusterName string                 `json:"clusterName,omitempty"`
-	Namespace   string                 `json:"namespace,omitempty"`
-	// ExternalServerURLs represents a list of apiserver urls and ca bundles that is accessible externally
-	// If it is set empty, managed cluster has no externally accessible url that hub cluster can visit.
-	// +optional
-	ExternalServerURLs []operatorv1.ServerURL `json:"externalServerURLs,omitempty"`
-
-	// NodePlacement enables explicit control over the scheduling of the deployed pods.
-	// +optional
-	NodePlacement operatorv1.NodePlacement `json:"nodePlacement,omitempty"`
-
-	// RegistrationConfiguration contains the configuration of registration
-	// +optional
-	RegistrationConfiguration operatorv1.RegistrationConfiguration `json:"registrationConfiguration,omitempty"`
-
-	// WorkConfiguration contains the configuration of work
-	// +optional
-	WorkConfiguration operatorv1.WorkAgentConfiguration `json:"workConfiguration,omitempty"`
-
-	// ResourceRequirement specify QoS classes of deployments managed by clustermanager.
-	// It applies to all the containers in the deployments.
-	// +optional
-	ResourceRequirement operatorv1.ResourceRequirement `json:"resourceRequirement,omitempty"`
-}

--- a/deploy/klusterlet/chart/klusterlet/templates/_helpers.tpl
+++ b/deploy/klusterlet/chart/klusterlet/templates/_helpers.tpl
@@ -6,6 +6,8 @@ Create secret to access docker registry
 {{- with .Values.images }}
 {{- if and .imageCredentials.userName .imageCredentials.password }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .registry (printf "%s:%s" .imageCredentials.userName .imageCredentials.password | b64enc) | b64enc }}
+{{- else if .imageCredentials.dockerConfigJson }}
+{{- printf "%s" .imageCredentials.dockerConfigJson | b64enc }}
 {{- else }}
 {{- printf "{}" | b64enc }}
 {{- end }}

--- a/deploy/klusterlet/chart/klusterlet/templates/klusterlet.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/klusterlet.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.klusterlet.create }}
 apiVersion: operator.open-cluster-management.io/v1
 kind: Klusterlet
 metadata:
@@ -41,3 +42,4 @@ spec:
   {{- if .Values.priorityClassName }}
   priorityClassName: "{{ .Values.priorityClassName }}"
   {{- end }}
+{{- end }}

--- a/deploy/klusterlet/chart/klusterlet/values.yaml
+++ b/deploy/klusterlet/chart/klusterlet/values.yaml
@@ -9,13 +9,14 @@ images:
   tag: ""
   imagePullPolicy: IfNotPresent
   # The image pull secret name is open-cluster-management-image-pull-credentials.
-  # Please set the userName and password if you use a private image registry.
+  # Please set the userName/password or the dockerConfigJson if you use a private image registry.
   # The image pull secret is fixed into the serviceAccount, you can also set
   # `createImageCredentials` to `false` and create the pull secret manually.
   imageCredentials:
     createImageCredentials: false
     userName: ""
     password: ""
+    dockerConfigJson: ""
 
 podSecurityContext:
   runAsNonRoot: true
@@ -80,6 +81,8 @@ noOperator: false
 priorityClassName: ""
 
 klusterlet:
+  # if false, will not create klusterlet CR. default it true.
+  create: true
   # mode can be Default, Hosted, Singleton or SingletonHosted.
   mode: Singleton
   name: "klusterlet"

--- a/pkg/operator/helpers/chart/config.go
+++ b/pkg/operator/helpers/chart/config.go
@@ -1,0 +1,146 @@
+package chart
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	operatorv1 "open-cluster-management.io/api/operator/v1"
+)
+
+type ClusterManagerChartConfig struct {
+	// CreateNamespace is used in the render function to append the release ns in the objects.
+	CreateNamespace bool `json:"createNamespace,omitempty"`
+	// ReplicaCount is the replicas for the clusterManager operator deployment.
+	ReplicaCount int `json:"replicaCount,omitempty"`
+	// Images is the configurations for all images used in operator deployment and clusterManager CR.
+	Images ImagesConfig `json:"images,omitempty"`
+	// PodSecurityContext is the pod SecurityContext in the operator deployment
+	PodSecurityContext corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	// SecurityContext is the container SecurityContext in operator deployment
+	SecurityContext corev1.SecurityContext `json:"securityContext,omitempty"`
+	// Resources is the resource requirements of the operator deployment
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// NodeSelector is the nodeSelector of the operator deployment
+	NodeSelector corev1.NodeSelector `json:"nodeSelector,omitempty"`
+	// Tolerations is the tolerations of the operator deployment
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// Affinity is the affinity of the operator deployment
+	Affinity corev1.Affinity `json:"affinity,omitempty"`
+	// CreateBootstrapToken is to enable/disable the bootstrap token secret for auto approve.
+	CreateBootstrapToken bool `json:"createBootstrapToken,omitempty"`
+	// CreateBootstrapSA is to create a serviceAccount to generate token.
+	CreateBootstrapSA bool `json:"createBootstrapSA,omitempty"`
+	// ClusterManager is the configuration of clusterManager CR
+	ClusterManager ClusterManagerConfig `json:"clusterManager,omitempty"`
+}
+
+type KlusterletChartConfig struct {
+	// CreateNamespace is used in the render function to append the release ns in the objects.
+	CreateNamespace bool `json:"createNamespace,omitempty"`
+	// ReplicaCount is the replicas for the klusterlet operator deployment.
+	ReplicaCount int `json:"replicaCount,omitempty"`
+	// Images is the configurations for all images used in operator deployment and klusterlet CR.
+	Images ImagesConfig `json:"images,omitempty"`
+	// PodSecurityContext is the pod SecurityContext in the operator deployment
+	PodSecurityContext corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	// SecurityContext is the container SecurityContext in operator deployment
+	SecurityContext corev1.SecurityContext `json:"securityContext,omitempty"`
+	// Resources is the resource requirements of the operator deployment
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// NodeSelector is the nodeSelector of the operator deployment
+	NodeSelector corev1.NodeSelector `json:"nodeSelector,omitempty"`
+	// Tolerations is the tolerations of the operator deployment
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// Affinity is the affinity of the operator deployment
+	Affinity corev1.Affinity `json:"affinity,omitempty"`
+	// Klusterlet is the configuration of klusterlet CR
+	Klusterlet KlusterletConfig `json:"klusterlet,omitempty"`
+	// PriorityClassName is the name of the PriorityClass that will be used by the deployed klusterlet agent and operator.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// EnableSyncLabels is to enable the feature which can sync the labels from klusterlet to all agent resources.
+	EnableSyncLabels bool `json:"enableSyncLabels,omitempty"`
+
+	// BootstrapHubKubeConfig should be the kubeConfig file of the hub cluster via setting --set-file=<the kubeConfig file of hub cluster> optional
+	BootstrapHubKubeConfig string `json:"bootstrapHubKubeConfig,omitempty"`
+
+	// ExternalManagedKubeConfig should be the kubeConfig file of the managed cluster via setting --set-file=<the kubeConfig file of managed cluster>
+	// only need to set in the hosted mode. optional
+	ExternalManagedKubeConfig string `json:"externalManagedKubeConfig,omitempty"`
+
+	// NoOperator is to only deploy the klusterlet CR if set true.
+	NoOperator bool `json:"noOperator,omitempty"`
+}
+
+type ImagesConfig struct {
+	// Registry is registry name must NOT contain a trailing slash.
+	Registry string `json:"registry,omitempty"`
+	// Tag is the operator image tag.
+	Tag string `json:"tag,omitempty"`
+	// ImagePullPolicy is the image pull policy of operator image. Default is IfNotPresent.
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// The image pull secret name is open-cluster-management-image-pull-credentials.
+	// Please set the userName and password if you use a private image registry.
+	ImageCredentials ImageCredentials `json:"imageCredentials,omitempty"`
+}
+
+type ImageCredentials struct {
+	CreateImageCredentials bool   `json:"createImageCredentials,omitempty"`
+	UserName               string `json:"userName,omitempty"`
+	Password               string `json:"password,omitempty"`
+	DockerConfigJson       string `json:"dockerConfigJson,omitempty"`
+}
+
+type ClusterManagerConfig struct {
+	// Create determines if create the clusterManager CR, default is true.
+	Create bool `json:"create,omitempty"`
+	// InstallMode represents the mode of deploy cluster-manager
+	Mode operatorv1.InstallMode `json:"mode,omitempty"`
+
+	// RegistrationConfiguration contains the configuration of registration
+	// +optional
+	RegistrationConfiguration operatorv1.RegistrationHubConfiguration `json:"registrationConfiguration,omitempty"`
+
+	// WorkConfiguration contains the configuration of work
+	// +optional
+	WorkConfiguration operatorv1.WorkConfiguration `json:"workConfiguration,omitempty"`
+
+	// AddOnManagerConfiguration contains the configuration of addon manager
+	// +optional
+	AddOnManagerConfiguration operatorv1.AddOnManagerConfiguration `json:"addOnManagerConfiguration,omitempty"`
+
+	// ResourceRequirement specify QoS classes of deployments managed by clustermanager.
+	// It applies to all the containers in the deployments.
+	// +optional
+	ResourceRequirement operatorv1.ResourceRequirement `json:"resourceRequirement,omitempty"`
+}
+
+type KlusterletConfig struct {
+	// Create determines if create the klusterlet CR, default is true.
+	Create bool `json:"create,omitempty"`
+	// InstallMode represents the mode of deploy klusterlet
+	Mode        operatorv1.InstallMode `json:"mode,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	ClusterName string                 `json:"clusterName,omitempty"`
+	Namespace   string                 `json:"namespace,omitempty"`
+	// ExternalServerURLs represents a list of apiserver urls and ca bundles that is accessible externally
+	// If it is set empty, managed cluster has no externally accessible url that hub cluster can visit.
+	// +optional
+	ExternalServerURLs []operatorv1.ServerURL `json:"externalServerURLs,omitempty"`
+
+	// NodePlacement enables explicit control over the scheduling of the deployed pods.
+	// +optional
+	NodePlacement operatorv1.NodePlacement `json:"nodePlacement,omitempty"`
+
+	// RegistrationConfiguration contains the configuration of registration
+	// +optional
+	RegistrationConfiguration operatorv1.RegistrationConfiguration `json:"registrationConfiguration,omitempty"`
+
+	// WorkConfiguration contains the configuration of work
+	// +optional
+	WorkConfiguration operatorv1.WorkAgentConfiguration `json:"workConfiguration,omitempty"`
+
+	// ResourceRequirement specify QoS classes of deployments managed by clustermanager.
+	// It applies to all the containers in the deployments.
+	// +optional
+	ResourceRequirement operatorv1.ResourceRequirement `json:"resourceRequirement,omitempty"`
+}

--- a/pkg/operator/helpers/chart/render.go
+++ b/pkg/operator/helpers/chart/render.go
@@ -22,20 +22,26 @@ import (
 	klusterletchart "open-cluster-management.io/ocm/deploy/klusterlet/chart"
 )
 
-func NewDefaultClusterManagerChartConfig() *clustermanagerchart.ChartConfig {
-	return &clustermanagerchart.ChartConfig{
+func NewDefaultClusterManagerChartConfig() *ClusterManagerChartConfig {
+	return &ClusterManagerChartConfig{
 		ReplicaCount:         3,
 		CreateBootstrapToken: false,
+		ClusterManager: ClusterManagerConfig{
+			Create: true,
+		},
 	}
 }
 
-func NewDefaultKlusterletChartConfig() *klusterletchart.ChartConfig {
-	return &klusterletchart.ChartConfig{
+func NewDefaultKlusterletChartConfig() *KlusterletChartConfig {
+	return &KlusterletChartConfig{
 		ReplicaCount: 3,
+		Klusterlet: KlusterletConfig{
+			Create: true,
+		},
 	}
 }
 
-func RenderClusterManagerChart(config *clustermanagerchart.ChartConfig, namespace string) ([][]byte, error) {
+func RenderClusterManagerChart(config *ClusterManagerChartConfig, namespace string) ([][]byte, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("cluster manager chart namespace is required")
 	}
@@ -43,7 +49,7 @@ func RenderClusterManagerChart(config *clustermanagerchart.ChartConfig, namespac
 		clustermanagerchart.ChartName, clustermanagerchart.ChartFiles)
 }
 
-func RenderKlusterletChart(config *klusterletchart.ChartConfig, namespace string) ([][]byte, error) {
+func RenderKlusterletChart(config *KlusterletChartConfig, namespace string) ([][]byte, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("klusterlet chart namespace is required")
 	}
@@ -51,7 +57,7 @@ func RenderKlusterletChart(config *klusterletchart.ChartConfig, namespace string
 		klusterletchart.ChartName, klusterletchart.ChartFiles)
 }
 
-func renderChart[T *clustermanagerchart.ChartConfig | *klusterletchart.ChartConfig](config T,
+func renderChart[T *ClusterManagerChartConfig | *KlusterletChartConfig](config T,
 	namespace string, createNamespace bool, chartName string, fs embed.FS) ([][]byte, error) {
 	// chartName is the prefix of chart path here
 	operatorChart, err := LoadChart(fs, chartName)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. support set imagepullsecret credential in the helm chart.
2. set the token-secret length to 16 in the chart.
3. use helm chart to deploy in e2e.
4. add a flag to control if create operator CR, because do not need create klusterlet CR in e2e deploy stage.  the default is to create. 
5. move the chart config struct to the helper dir. the consumer will only import the helper dir.

## Related issue(s)

Fixes #