### PR TITLE
:bug: remove the creationTimestamp from metadata when using SSA in work

### DIFF
--- a/pkg/work/spoke/apply/server_side_apply_test.go
+++ b/pkg/work/spoke/apply/server_side_apply_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,4 +140,142 @@ func (r *reactor) React(action clienttesting.Action) (handled bool, ret runtime.
 	}
 
 	return true, nil, fmt.Errorf("PatchType is not supported")
+}
+
+func TestRemoveCreationTime(t *testing.T) {
+	cases := []struct {
+		name         string
+		required     *unstructured.Unstructured
+		validateFunc func(t *testing.T, obj *unstructured.Unstructured)
+	}{
+		{
+			name:     "remove creationTimestamp from a kube object",
+			required: newDeployment(),
+			validateFunc: func(t *testing.T, obj *unstructured.Unstructured) {
+				_, existing, err := unstructured.NestedFieldCopy(obj.Object, "metadata", "creationTimestamp")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if existing {
+					t.Errorf("unexpected creationTimestamp in `metadata.creationTimestamp`")
+				}
+				_, existing, err = unstructured.NestedFieldCopy(obj.Object, "spec", "template", "metadata", "creationTimestamp")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if existing {
+					t.Errorf("unexpected creationTimestamp in `spec.template.metadata.creationTimestamp`")
+				}
+			},
+		},
+		{
+			name:     "remove creationTimestamp from a manifestwork",
+			required: newManifestWork(),
+			validateFunc: func(t *testing.T, obj *unstructured.Unstructured) {
+				_, existing, err := unstructured.NestedFieldCopy(obj.Object, "metadata", "creationTimestamp")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if existing {
+					t.Errorf("unexpected creationTimestamp in `metadata.creationTimestamp`")
+				}
+
+				manifests, existing, err := unstructured.NestedSlice(obj.Object, "spec", "workload", "manifests")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !existing {
+					t.Fatalf("no manifests")
+				}
+
+				_, existing, err = unstructured.NestedFieldCopy(manifests[0].(map[string]interface{}), "metadata", "creationTimestamp")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if existing {
+					t.Errorf("unexpected creationTimestamp in `spec.workload.manifests[0].metadata.creationTimestamp`")
+				}
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			removeCreationTimeFromMetadata(c.required.Object)
+			c.validateFunc(t, c.required)
+		})
+	}
+}
+
+func newDeployment() *unstructured.Unstructured {
+	var replicas int32 = 3
+	deploy := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"test": "test"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: "test",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	obj, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func newManifestWork() *unstructured.Unstructured {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-test",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"some": "data",
+		},
+	}
+
+	cmObj, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+	raw, _ := (&unstructured.Unstructured{Object: cmObj}).MarshalJSON()
+	manifest := workapiv1.Manifest{}
+	manifest.Raw = raw
+
+	work := &workapiv1.ManifestWork{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "work.open-cluster-management.io/v1",
+			Kind:       "ManifestWork",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: workapiv1.ManifestWorkSpec{
+			Workload: workapiv1.ManifestsTemplate{
+				Manifests: []workapiv1.Manifest{manifest},
+			},
+		},
+	}
+
+	obj, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(work)
+	return &unstructured.Unstructured{Object: obj}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Currently, if the required object has zero creationTime in metadata, it will cause kube-apiserver to increment generation even if nothing else changes when using SSA to apply work's manifests

## Related issue(s)
https://github.com/kubernetes/kubernetes/issues/67610
