### PR TITLE
🐛 only read the first item when RawFeedbackJsonString is disabled

### DIFF
--- a/pkg/work/spoke/statusfeedback/reader.go
+++ b/pkg/work/spoke/statusfeedback/reader.go
@@ -100,12 +100,11 @@ func (s *StatusReader) getValueByJsonPath(name, path string, obj *unstructured.U
 	}
 
 	var value any
-	switch {
-	case len(results) == 0 || len(results[0]) == 0:
-		return nil, nil
-	case len(results) == 1 && len(results[0]) == 1:
+	// if the RawFeedbackJsonString is disabled, we always get the first item
+	if (len(results) == 1 && len(results[0]) == 1) ||
+		!features.SpokeMutableFeatureGate.Enabled(ocmfeature.RawFeedbackJsonString) {
 		value = results[0][0].Interface()
-	default:
+	} else {
 		var resultList []any
 		// only take care the first item in the results list.
 		for _, r := range results[0] {

--- a/pkg/work/spoke/statusfeedback/reader_test.go
+++ b/pkg/work/spoke/statusfeedback/reader_test.go
@@ -76,6 +76,10 @@ const (
 				{
 					"type":"Available",
 					"status":"true"
+				},
+                {
+					"type":"Ready",
+					"status":"true"
 				}
 			]
 		}
@@ -216,7 +220,7 @@ func TestStatusReader(t *testing.T) {
 			expectedValue: []workapiv1.FeedbackValue{},
 		},
 		{
-			name:   "wrog version set for jsonpaths",
+			name:   "wrong version set for jsonpaths",
 			object: unstrctureObject(deploymentJson),
 			rule: workapiv1.FeedbackRule{
 				Type: workapiv1.JSONPathsType,
@@ -283,6 +287,31 @@ func TestStatusReader(t *testing.T) {
 					Value: workapiv1.FieldValue{
 						Type:   workapiv1.String,
 						String: pointer.String("Succeeded"),
+					},
+				},
+			},
+		},
+		{
+			// this is for a backward compatible test, when rawjson is disabled, and there are multiple match on
+			// json path, it should return the first item.
+			name:   "Return 1st item with multiple patch",
+			object: unstrctureObject(deploymentJson),
+			rule: workapiv1.FeedbackRule{
+				Type: workapiv1.JSONPathsType,
+				JsonPaths: []workapiv1.JsonPath{
+					{
+						Name: "type",
+						Path: ".status.conditions[?(@.status==\"true\")].type ",
+					},
+				},
+			},
+			expectError: false,
+			expectedValue: []workapiv1.FeedbackValue{
+				{
+					Name: "type",
+					Value: workapiv1.FieldValue{
+						Type:   workapiv1.String,
+						String: pointer.String("Available"),
 					},
 				},
 			},


### PR DESCRIPTION
This is to ensure the backward compatible when the feature gate is disabled

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #