### PR TITLE
:bug: fix the mca override cma configs issues

### DIFF
--- a/pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler_test.go
+++ b/pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler_test.go
@@ -312,6 +312,45 @@ func TestAddonConfigReconcile(t *testing.T) {
 					},
 				}, nil, nil),
 				addontesting.NewAddon("test", "cluster2"),
+				// cluster3 already has configs synced to status before spec hash is updated
+				newManagedClusterAddon("test", "cluster3", []addonv1alpha1.AddOnConfig{
+					{
+						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+					},
+					{
+						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test3"},
+					},
+				}, []addonv1alpha1.ConfigReference{
+					{
+						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
+						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
+						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 0,
+					},
+					{
+						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 0,
+					},
+					{
+						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test3"},
+						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test3"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 0,
+					},
+				}, nil),
 			},
 			placements: []runtime.Object{
 				&clusterv1beta1.Placement{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: "default"}},
@@ -327,7 +366,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 						},
 					},
 					Status: clusterv1beta1.PlacementDecisionStatus{
-						Decisions: []clusterv1beta1.ClusterDecision{{ClusterName: "cluster1"}, {ClusterName: "cluster2"}},
+						Decisions: []clusterv1beta1.ClusterDecision{{ClusterName: "cluster1"}, {ClusterName: "cluster2"}, {ClusterName: "cluster3"}},
 					},
 				},
 			},
@@ -343,7 +382,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 				ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 				DesiredConfig: &v1alpha1.ConfigSpecHash{
 					ConfigReferent: v1alpha1.ConfigReferent{Name: "test"},
-					SpecHash:       "hash",
+					SpecHash:       "<core-foo-test-hash>",
 				},
 			}).WithPlacementStrategy(addonv1alpha1.PlacementStrategy{
 				PlacementRef:    addonv1alpha1.PlacementRef{Name: "test-placement", Namespace: "default"},
@@ -355,20 +394,20 @@ func TestAddonConfigReconcile(t *testing.T) {
 						ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
 						DesiredConfig: &v1alpha1.ConfigSpecHash{
 							ConfigReferent: v1alpha1.ConfigReferent{Name: "test1"},
-							SpecHash:       "hash1",
+							SpecHash:       "<core-bar-test1-hash>",
 						},
 					},
 					{
 						ConfigGroupResource: v1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
 						DesiredConfig: &v1alpha1.ConfigSpecHash{
 							ConfigReferent: v1alpha1.ConfigReferent{Name: "test1"},
-							SpecHash:       "hash1",
+							SpecHash:       "<core-foo-test1-hash>",
 						},
 					},
 				},
 			}).Build(),
 			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
-				addontesting.AssertActions(t, actions, "patch", "patch")
+				addontesting.AssertActions(t, actions, "patch", "patch", "patch")
 				sort.Sort(byPatchName(actions))
 				expectPatchConfigurationAction(t, actions[0], []addonv1alpha1.ConfigReference{
 					{
@@ -376,7 +415,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
 						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
-							SpecHash:       "hash1",
+							SpecHash:       "<core-bar-test1-hash>",
 						},
 						LastObservedGeneration: 0,
 					},
@@ -405,7 +444,7 @@ func TestAddonConfigReconcile(t *testing.T) {
 						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
 						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
-							SpecHash:       "hash1",
+							SpecHash:       "<core-bar-test1-hash>",
 						},
 						LastObservedGeneration: 0,
 					},
@@ -414,10 +453,39 @@ func TestAddonConfigReconcile(t *testing.T) {
 						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
 						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
 							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
-							SpecHash:       "hash1",
+							SpecHash:       "<core-foo-test1-hash>",
 						},
 						LastObservedGeneration: 0,
 					}})
+				expectPatchConfigurationAction(t, actions[2], []addonv1alpha1.ConfigReference{
+					{
+						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Bar"},
+						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test1"},
+						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test1"},
+							SpecHash:       "<core-bar-test1-hash>",
+						},
+						LastObservedGeneration: 0,
+					},
+					{
+						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test2"},
+						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test2"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 0,
+					},
+					{
+						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						ConfigReferent:      addonv1alpha1.ConfigReferent{Name: "test3"},
+						DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonv1alpha1.ConfigReferent{Name: "test3"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 0,
+					},
+				})
 				expectPatchConditionAction(t, actions[0], metav1.ConditionTrue)
 				expectPatchConditionAction(t, actions[1], metav1.ConditionTrue)
 			},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The issue is, when configuring configs in mca and cma (mca override part of cma configs), the mca has a chance to hang at progressing and hang at an empty spec hash . For example:
```
apiVersion: addon.open-cluster-management.io/v1alpha1
kind: ClusterManagementAddOn
metadata:
spec:
  addOnMeta:
    description: cluster-proxy
    displayName: cluster-proxy
  installStrategy:
    placements:
    - name: global
      namespace: open-cluster-management-global-set
      rolloutStrategy:
        type: All
    type: Placements
  supportedConfigs: <== set managedproxyconfigurations and addondeploymentconfigs
  - defaultConfig:
      name: cluster-proxy
    group: proxy.open-cluster-management.io
    resource: managedproxyconfigurations
  - defaultConfig:
      name: deploy-config
      namespace: config-namespace
    group: addon.open-cluster-management.io
    resource: addondeploymentconfigs
status:
  defaultconfigReferences:
  - desiredConfig:
      name: cluster-proxy
      specHash: 6daea0b570f867bc5028ff79c061a2d5b55f512856faa673aa8dc0bb52d7a51e
    group: proxy.open-cluster-management.io
    resource: managedproxyconfigurations
  - desiredConfig:
      name: deploy-config
      namespace: config-namespace
      specHash: a92380f1f1a1920399d90859a5d51f5521cecd65752755ba05ece495f551ebd0
    group: addon.open-cluster-management.io
    resource: addondeploymentconfigs
  installProgressions: 
    configReferences: : <== both managedproxyconfigurations and addondeploymentconfigs has spec hash
    - desiredConfig: 
        name: cluster-proxy
        specHash: 6daea0b570f867bc5028ff79c061a2d5b55f512856faa673aa8dc0bb52d7a51e
      group: proxy.open-cluster-management.io
      resource: managedproxyconfigurations
    - desiredConfig:
        name: deploy-config
        namespace: config-namespace
        specHash: a92380f1f1a1920399d90859a5d51f5521cecd65752755ba05ece495f551ebd0
      group: addon.open-cluster-management.io
      resource: addondeploymentconfigs
    name: global
    namespace: open-cluster-management-global-set
```
```
apiVersion: addon.open-cluster-management.io/v1alpha1
kind: ManagedClusterAddOn
metadata:
 name: cluster-proxy
  namespace: local-cluster
spec:
  configs:
  - group: addon.open-cluster-management.io <= mca override cma config
    name: deploy-config
    namespace: config-namespace
    resource: addondeploymentconfigs
  installNamespace: open-cluster-management-agent-addon
status:
  conditions:
  - lastTransitionTime: "2024-09-09T16:08:42Z"
    message: progressing... mca and work configs mismatch <= hangs at progressing
    reason: Progressing
    status: "True"
    type: Progressing
...
  configReferences:
  - desiredConfig:
      name: deploy-config
      namespace: open-cluster-management-hub
      specHash: a92380f1f1a1920399d90859a5d51f5521cecd65752755ba05ece495f551ebd0
    group: addon.open-cluster-management.io
    lastObservedGeneration: 2
    name: deploy-config
    namespace: open-cluster-management-hub
    resource: addondeploymentconfigs
  - desiredConfig: <== managedproxyconfigurations spec hash failed to sync and keeps empty
      name: cluster-proxy
      specHash: ""
    group: proxy.open-cluster-management.io
    lastObservedGeneration: 1
    name: cluster-proxy
    resource: managedproxyconfigurations
  namespace: open-cluster-management-agent-addon
```

**Why the `managedproxyconfigurations` spec hash is empty?** 
This is because the mca status has once synced from cma before the spec hash is generated. This is the expect behavior. 

**Why does the spec hash keep empty and never get updates?** 
This is because the current code always copies all the spec hash from mca status as the desired spec hash and overrides the cma spec hash. While in the issued case, we should not copy the `managedproxyconfigurations` from mca status to override the spec hash in cma, it's not defined in mca and it's spec hash is an old value from cma. 

This PR is to fix this issue.

## Related issue(s)

Fixes #