### PR TITLE
🐛 Ensure one cma is processed by one addon worker at the same time

### DIFF
--- a/pkg/addon/controllers/addonconfiguration/controller.go
+++ b/pkg/addon/controllers/addonconfiguration/controller.go
@@ -90,7 +90,7 @@ func NewAddonConfigurationController(
 		queue.QueueKeyByMetaNamespaceName,
 		c.addonFilterFunc,
 		clusterManagementAddonInformers.Informer()).
-		WithInformersQueueKeysFunc(queue.QueueKeyByMetaNamespaceName, addonInformers.Informer()).
+		WithInformersQueueKeysFunc(queue.QueueKeyByMetaName, addonInformers.Informer()).
 		WithInformersQueueKeysFunc(
 			index.ClusterManagementAddonByPlacementDecisionQueueKey(clusterManagementAddonInformers), placementDecisionInformer.Informer()).
 		WithInformersQueueKeysFunc(
@@ -101,12 +101,7 @@ func NewAddonConfigurationController(
 
 func (c *addonConfigurationController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	logger := klog.FromContext(ctx)
-	key := syncCtx.QueueKey()
-	_, addonName, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		// ignore addon whose key is invalid
-		return nil
-	}
+	addonName := syncCtx.QueueKey()
 	logger.V(4).Info("Reconciling addon", "addonName", addonName)
 
 	cma, err := c.clusterManagementAddonLister.Get(addonName)
@@ -157,7 +152,7 @@ func (c *addonConfigurationController) sync(ctx context.Context, syncCtx factory
 	}
 
 	if minRequeue < maxRequeueTime {
-		syncCtx.Queue().AddAfter(key, minRequeue)
+		syncCtx.Queue().AddAfter(addonName, minRequeue)
 	}
 
 	return nil

--- a/pkg/addon/controllers/addonmanagement/controller.go
+++ b/pkg/addon/controllers/addonmanagement/controller.go
@@ -81,13 +81,7 @@ func NewAddonManagementController(
 
 func (c *addonManagementController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	logger := klog.FromContext(ctx)
-	key := syncCtx.QueueKey()
-	_, addonName, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		// ignore addon whose key is invalid
-		return nil
-	}
-
+	addonName := syncCtx.QueueKey()
 	logger.V(4).Info("Reconciling addon", "addonName", addonName)
 
 	cma, err := c.clusterManagementAddonLister.Get(addonName)

--- a/pkg/addon/controllers/addontemplate/controller.go
+++ b/pkg/addon/controllers/addontemplate/controller.go
@@ -13,7 +13,6 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
@@ -106,12 +105,7 @@ func (c *addonTemplateController) stopUnusedManagers(
 
 func (c *addonTemplateController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	logger := klog.FromContext(ctx)
-	key := syncCtx.QueueKey()
-	_, addonName, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		// ignore addon whose key is not in format: namespace/name
-		return nil
-	}
+	addonName := syncCtx.QueueKey()
 
 	cma, err := c.cmaLister.Get(addonName)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Currently, there are [2 workers started for the addonConfigurationController](https://github.com/open-cluster-management-io/ocm/blob/33b409dae87e4b3854726e3d3cb5b2d7af95c166/pkg/addon/manager.go#L201), and this controller watches the ManagedClusterAddOn resource, when mca changes, it enqueues the managedClusterAddon [namespace and name](https://github.com/open-cluster-management-io/ocm/blob/33b409dae87e4b3854726e3d3cb5b2d7af95c166/pkg/addon/controllers/addonconfiguration/controller.go#L93) in the format "{namespace}/{name}", but in the sync func, it only [uses the name to get clusterManagementAddOn](https://github.com/open-cluster-management-io/ocm/blob/33b409dae87e4b3854726e3d3cb5b2d7af95c166/pkg/addon/controllers/addonconfiguration/controller.go#L105-L112).

Think about the case, there is an addon named `addon1`, and we created 2 managedClusterAddon, one is in the `cluster1` namespace, and the other one is in the `cluster2` namespace, so there will be 2 keys enqueued, `cluster1/addon1` and `cluster2/addon1`, because these 2 keys are not the same, the k8s cache queue will not merge them to one, so 2 workers will process these 2 keys at the same time. But finally, these 2 workers will get the same clusterManagementAddon `addon1` simultaneously. This may cause some race condition problems.

This PR changes the enqueue rule for the managedClusterAddon resources only to enqueue the name. so `cluster1/addon1` and `cluster2/addon1` changing will result in only enqueue one key `addon1`, only one worker will be assigned to process it.

## Related issue(s)
https://github.com/open-cluster-management-io/ocm/issues/651

Fixes #