### PR TITLE
🐛  WIP Fix: should `AcceptFalse` when get cluster forbidden.

### DIFF
--- a/pkg/registration/spoke/registration/hub_accept_controller.go
+++ b/pkg/registration/spoke/registration/hub_accept_controller.go
@@ -2,44 +2,53 @@ package registration
 
 import (
 	"context"
+	"time"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	clientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterv1informer "open-cluster-management.io/api/client/cluster/informers/externalversions/cluster/v1"
-	clusterv1listers "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
 )
 
 // hubAcceptController watch ManagedCluster CR on hub after spoke bootstrap done
 // If the managedCluster.Spec.HubAccetpsClient is false, then mark the connection as failed.
 //
 // Note that: when the HubAcceptsClient is false, the clusterrole and clusterrolebinding will be removed.
-// Then the agent will not be able to get or watch the managedCluster CR.
+// Then the agent will not be able to get or watch the managedCluster CR. This is why we need to resync every minute and check if err is forbidden.
 // That means the controller can only handle the case when the HubAcceptsClient change from true to false.
 type hubAcceptController struct {
 	clusterName       string
-	hubClusterLister  clusterv1listers.ManagedClusterLister
+	hubClusterClient  clientset.Interface
 	handleAcceptFalse func(ctx context.Context) error
 	recorder          events.Recorder
 }
 
 func NewHubAcceptController(clusterName string, hubClusterInformer clusterv1informer.ManagedClusterInformer,
+	hubClusterClient clientset.Interface,
 	handleAcceptFalse func(ctx context.Context) error, recorder events.Recorder) factory.Controller {
 	c := &hubAcceptController{
 		clusterName:       clusterName,
-		hubClusterLister:  hubClusterInformer.Lister(),
+		hubClusterClient:  hubClusterClient,
 		handleAcceptFalse: handleAcceptFalse,
 		recorder:          recorder,
 	}
 	return factory.New().
 		WithInformers(hubClusterInformer.Informer()).
+		ResyncEvery(3*time.Minute).
 		WithSync(c.sync).
 		ToController("HubAcceptController", recorder)
 }
 
 func (c *hubAcceptController) sync(ctx context.Context, _ factory.SyncContext) error {
-	cluster, err := c.hubClusterLister.Get(c.clusterName)
+	cluster, err := c.hubClusterClient.ClusterV1().ManagedClusters().Get(ctx, c.clusterName, metav1.GetOptions{})
 	if err != nil {
+		if apierrors.IsForbidden(err) {
+			// In case the role is removed before the event is propagated, we also need to handle the forbidden case.
+			return c.handleAcceptFalse(ctx)
+		}
 		return err
 	}
 	if !cluster.Spec.HubAcceptsClient {

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -446,6 +446,7 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 		hubAcceptController = registration.NewHubAcceptController(
 			o.agentOptions.SpokeClusterName,
 			hubClusterInformerFactory.Cluster().V1().ManagedClusters(),
+			hubClusterClient,
 			func(ctx context.Context) error {
 				logger.Info("Failed to connect to hub because of hubAcceptClient set to false, restart agent to reselect a new bootstrap kubeconfig")
 				o.reSelectChecker.shouldReSelect = true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

After set `hubAcceptsClient` to `false`, there are chances the rbac resources removed before the event is watched by the agent. If that happens, the change will never captured by the agent side.

So change to use client not lister, and check if error is forbidden, if it's forbidden, treat it as 'accept=false`.