### PR TITLE
:seedling:  Rename and relocate cluster related roles files.

### DIFF
--- a/pkg/registration/hub/clusterrole/controller.go
+++ b/pkg/registration/hub/clusterrole/controller.go
@@ -25,11 +25,6 @@ const (
 	workClusterRole         = "open-cluster-management:managedcluster:work"
 )
 
-var clusterRoleFiles = []string{
-	"rbac/managedcluster-registration-clusterrole.yaml",
-	"rbac/managedcluster-work-clusterrole.yaml",
-}
-
 // clusterroleController maintains the necessary clusterroles for registration and work agent on hub cluster.
 type clusterroleController struct {
 	kubeClient    kubernetes.Interface
@@ -81,7 +76,7 @@ func (c *clusterroleController) sync(ctx context.Context, syncCtx factory.SyncCo
 			resourceapply.NewKubeClientHolder(c.kubeClient),
 			c.eventRecorder,
 			manifests.RBACManifests.ReadFile,
-			clusterRoleFiles...,
+			manifests.CommonClusterRoleFiles...,
 		)
 		for _, result := range results {
 			if result.Error != nil {
@@ -96,7 +91,7 @@ func (c *clusterroleController) sync(ctx context.Context, syncCtx factory.SyncCo
 		ctx,
 		syncCtx.Recorder(),
 		manifests.RBACManifests.ReadFile,
-		clusterRoleFiles...,
+		manifests.CommonClusterRoleFiles...,
 	)
 
 	for _, result := range results {

--- a/pkg/registration/hub/gc/gc_cluster_rbac.go
+++ b/pkg/registration/hub/gc/gc_cluster_rbac.go
@@ -25,13 +25,6 @@ import (
 	"open-cluster-management.io/ocm/pkg/registration/register"
 )
 
-var clusterRbacFiles = []string{
-	"rbac/managedcluster-clusterrole.yaml",
-	"rbac/managedcluster-clusterrolebinding.yaml",
-	"rbac/managedcluster-registration-rolebinding.yaml",
-	"rbac/managedcluster-work-rolebinding.yaml",
-}
-
 const (
 	manifestWorkFinalizer = "cluster.open-cluster-management.io/manifest-work-cleanup"
 )
@@ -136,7 +129,7 @@ func (r *gcClusterRbacController) removeClusterRbac(ctx context.Context, cluster
 	// Clean up managed cluster manifests
 	assetFn := helpers.ManagedClusterAssetFn(manifests.RBACManifests, clusterName)
 	resourceResults := resourceapply.DeleteAll(ctx, resourceapply.NewKubeClientHolder(r.kubeClient),
-		r.eventRecorder, assetFn, clusterRbacFiles...)
+		r.eventRecorder, assetFn, manifests.ClusterSpecificRBACFiles...)
 	for _, result := range resourceResults {
 		if result.Error != nil {
 			errs = append(errs, fmt.Errorf("%q (%T): %v", result.File, result.Type, result.Error))

--- a/pkg/registration/hub/manifests/fs.go
+++ b/pkg/registration/hub/manifests/fs.go
@@ -4,3 +4,18 @@ import "embed"
 
 //go:embed rbac
 var RBACManifests embed.FS
+
+// ClusterSpecificRBACFiles are cluster-specific RBAC manifests.
+// Created when a managed cluster is accepted and removed when a managed cluster is removed or not accepted.
+var ClusterSpecificRBACFiles = []string{
+	"rbac/managedcluster-clusterrole.yaml",
+	"rbac/managedcluster-clusterrolebinding.yaml",
+	"rbac/managedcluster-registration-rolebinding.yaml",
+	"rbac/managedcluster-work-rolebinding.yaml",
+}
+
+// CommonClusterRoleFiles are common clusterroles needed by any managed cluster.
+var CommonClusterRoleFiles = []string{
+	"rbac/managedcluster-registration-clusterrole.yaml",
+	"rbac/managedcluster-work-clusterrole.yaml",
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Rename the clusterrole related files varibles to better reflect its usage. For the clusterrole that every mangaed cluster needs, use `CommonClusterRoleFiles`, and for the cluster specificed rbac files, we use `ClusterSpecificRbacFiles`.