### PR TITLE
:sparkles: Add AWS IAM support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ kubectl edit klusterlet klusterlet
 
 ### Integration tests
 
-The integration tests are written in the [test/integration](test/integration) directory. They start a kubenretes
+The integration tests are written in the [test/integration](test/integration) directory. They start a kubernetes
 api server locally with [controller-runtime](https://book.kubebuilder.io/reference/envtest), and run the tests against
 the local api server.
 

--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -109,6 +109,12 @@ spec:
           {{if .AppliedManifestWorkEvictionGracePeriod}}
           - "--appliedmanifestwork-eviction-grace-period={{ .AppliedManifestWorkEvictionGracePeriod }}"
           {{end}}
+          {{if .RegistrationDriver.AuthType}}
+          - "--registration-auth={{ .RegistrationDriver.AuthType }}"
+          {{end}}
+          {{if eq .RegistrationDriver.AuthType "awsirsa"}}
+          - "--hub-cluster-arn={{ .RegistrationDriver.AwsIrsa.HubClusterArn }}"
+          {{end}}
         env:
           - name: POD_NAME
             valueFrom:

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -97,6 +97,12 @@ spec:
           {{if gt .RegistrationKubeAPIBurst 0}}
           - "--kube-api-burst={{ .RegistrationKubeAPIBurst }}"
           {{end}}
+          {{if .RegistrationDriver.AuthType}}
+          - "--registration-auth={{ .RegistrationDriver.AuthType }}"
+          {{end}}
+          {{if eq .RegistrationDriver.AuthType "awsirsa"}}
+          - "--hub-cluster-arn={{ .RegistrationDriver.AwsIrsa.HubClusterArn }}"
+          {{end}}
         env:
           - name: POD_NAME
             valueFrom:

--- a/pkg/registration/helpers/helpers.go
+++ b/pkg/registration/helpers/helpers.go
@@ -160,6 +160,8 @@ func IsCSRSupported(nativeClient kubernetes.Interface) (bool, bool, error) {
 	return v1CSRSupported, v1beta1CSRSupported, nil
 }
 
+// IsEksArnWellFormed checks if the EKS cluster ARN is well-formed
+// Example of a well-formed ARN: arn:aws:eks:us-west-2:123456789012:cluster/my-cluster
 func IsEksArnWellFormed(eksArn string) bool {
 	pattern := "^arn:aws:eks:([a-zA-Z0-9-]+):(\\d{12}):cluster/([a-zA-Z0-9-]+)$"
 	matched, err := regexp.MatchString(pattern, eksArn)

--- a/pkg/registration/helpers/helpers.go
+++ b/pkg/registration/helpers/helpers.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"embed"
 	"net/url"
+	"regexp"
 
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -157,4 +158,13 @@ func IsCSRSupported(nativeClient kubernetes.Interface) (bool, bool, error) {
 		}
 	}
 	return v1CSRSupported, v1beta1CSRSupported, nil
+}
+
+func IsEksArnWellFormed(eksArn string) bool {
+	pattern := "^arn:aws:eks:([a-zA-Z0-9-]+):(\\d{12}):cluster/([a-zA-Z0-9-]+)$"
+	matched, err := regexp.MatchString(pattern, eksArn)
+	if err != nil {
+		return false
+	}
+	return matched
 }

--- a/pkg/registration/helpers/testing/testinghelpers.go
+++ b/pkg/registration/helpers/testing/testinghelpers.go
@@ -421,6 +421,7 @@ type TestCert struct {
 	Key  []byte
 }
 
+// TODO: Remove this struct once we have the function fully implemented for the AWSIRSADriver
 type TestIrsaRequest struct {
 }
 

--- a/pkg/registration/helpers/testing/testinghelpers.go
+++ b/pkg/registration/helpers/testing/testinghelpers.go
@@ -421,6 +421,9 @@ type TestCert struct {
 	Key  []byte
 }
 
+type TestIrsaRequest struct {
+}
+
 func NewHubKubeconfigSecret(namespace, name, resourceVersion string, cert *TestCert, data map[string][]byte) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/registration/register/aws_irsa/aws.go
+++ b/pkg/registration/register/aws_irsa/aws.go
@@ -1,0 +1,68 @@
+package aws_irsa
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	cluster "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	managedclusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1"
+	managedclusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions/cluster"
+	managedclusterv1lister "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
+)
+
+type AWSIRSAControl interface {
+	isApproved(name string) (bool, error)
+	generateEKSKubeConfig(name string) ([]byte, error)
+
+	// Informer is public so we can add indexer outside
+	Informer() cache.SharedIndexInformer
+}
+
+var _ AWSIRSAControl = &v1AWSIRSAControl{}
+
+type v1AWSIRSAControl struct {
+	hubManagedClusterInformer cache.SharedIndexInformer
+	hubManagedClusterLister   managedclusterv1lister.ManagedClusterLister
+	hubManagedClusterClient   managedclusterv1client.ManagedClusterInterface
+}
+
+func (v *v1AWSIRSAControl) isApproved(name string) (bool, error) {
+	// TODO: check if the managedclusuter cr on hub has required condition and is approved
+	approved := false
+
+	return approved, nil
+}
+
+func (v *v1AWSIRSAControl) generateEKSKubeConfig(name string) ([]byte, error) {
+	// TODO: generate and return kubeconfig
+	return nil, nil
+}
+
+func (v *v1AWSIRSAControl) Informer() cache.SharedIndexInformer {
+	return v.hubManagedClusterInformer
+}
+
+//TODO: Uncomment the below once required in the aws irsa authentication implementation
+/*
+func (v *v1AWSIRSAControl) get(name string) (metav1.Object, error) {
+	managedcluster, err := v.hubManagedClusterLister.Get(name)
+	switch {
+	case apierrors.IsNotFound(err):
+		// fallback to fetching managedcluster from hub apiserver in case it is not cached by informer yet
+		managedcluster, err = v.hubManagedClusterClient.Get(context.Background(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("unable to get managedcluster %q. It might have already been deleted", name)
+		}
+	case err != nil:
+		return nil, err
+	}
+	return managedcluster, nil
+}
+*/
+
+func NewAWSIRSAControl(hubManagedClusterInformer managedclusterinformers.Interface, hubManagedClusterClient cluster.Interface) (AWSIRSAControl, error) {
+	return &v1AWSIRSAControl{
+		hubManagedClusterInformer: hubManagedClusterInformer.V1().ManagedClusters().Informer(),
+		hubManagedClusterLister:   hubManagedClusterInformer.V1().ManagedClusters().Lister(),
+		hubManagedClusterClient:   hubManagedClusterClient.ClusterV1().ManagedClusters(),
+	}, nil
+}

--- a/pkg/registration/register/aws_irsa/aws_irsa.go
+++ b/pkg/registration/register/aws_irsa/aws_irsa.go
@@ -1,0 +1,105 @@
+package aws_irsa
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
+
+	"open-cluster-management.io/ocm/pkg/registration/register"
+)
+
+const (
+	// TLSKeyFile is the name of tls key file in kubeconfigSecret
+	TLSKeyFile = "tls.key"
+	// TLSCertFile is the name of the tls cert file in kubeconfigSecret
+	TLSCertFile = "tls.crt"
+)
+
+// AWSOption includes options that is used to monitor ManagedClusters
+type AWSOption struct {
+	EventFilterFunc factory.EventFilterFunc
+
+	AWSIRSAControl AWSIRSAControl
+}
+
+type AWSIRSADriver struct {
+	name string
+}
+
+func (c *AWSIRSADriver) Process(
+	ctx context.Context, controllerName string, secret *corev1.Secret, additionalSecretData map[string][]byte,
+	recorder events.Recorder, opt any) (*corev1.Secret, *metav1.Condition, error) {
+	logger := klog.FromContext(ctx)
+
+	awsOption, ok := opt.(*AWSOption)
+	if !ok {
+		return nil, nil, fmt.Errorf("option type is not correct")
+	}
+
+	// TODO: skip if registration request is not accepted yet, that is the required condition is missing on ManagedCluster CR
+	isApproved, err := awsOption.AWSIRSAControl.isApproved(c.name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !isApproved {
+		return nil, nil, nil
+	}
+
+	// TODO: Generate kubeconfig if the request is accepted
+	eksKubeConfigData, err := awsOption.AWSIRSAControl.generateEKSKubeConfig(c.name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(eksKubeConfigData) == 0 {
+		return nil, nil, nil
+	}
+
+	secret.Data["kubeconfig"] = eksKubeConfigData
+	logger.Info("Store kubeconfig into the secret.")
+
+	recorder.Eventf("EKSHubKubeconfigCreated", "A new eks hub Kubeconfig for %s is available", controllerName)
+	//return secret, cond, err
+	return secret, nil, err
+}
+
+//TODO: Uncomment the below once required in the aws irsa authentication implementation
+
+/*
+func (c *AWSIRSADriver) reset() {
+	c.name = ""
+}
+*/
+
+func (c *AWSIRSADriver) BuildKubeConfigFromTemplate(kubeConfig *clientcmdapi.Config) *clientcmdapi.Config {
+	kubeConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{register.DefaultKubeConfigAuth: {
+		ClientCertificate: TLSCertFile,
+		ClientKey:         TLSKeyFile,
+	}}
+
+	return kubeConfig
+}
+
+func (c *AWSIRSADriver) InformerHandler(option any) (cache.SharedIndexInformer, factory.EventFilterFunc) {
+	awsOption, ok := option.(*AWSOption)
+	if !ok {
+		utilruntime.Must(fmt.Errorf("option type is not correct"))
+	}
+	return awsOption.AWSIRSAControl.Informer(), awsOption.EventFilterFunc
+}
+
+func (c *AWSIRSADriver) IsHubKubeConfigValid(ctx context.Context, secretOption register.SecretOption) (bool, error) {
+	// TODO: implement the logic to validate the kubeconfig
+	return true, nil
+}
+
+func NewAWSIRSADriver() register.RegisterDriver {
+	return &AWSIRSADriver{}
+}

--- a/pkg/registration/register/aws_irsa/aws_irsa.go
+++ b/pkg/registration/register/aws_irsa/aws_irsa.go
@@ -16,6 +16,8 @@ import (
 	"open-cluster-management.io/ocm/pkg/registration/register"
 )
 
+//TODO: Remove these constants in once we have the function fully implemented for the AWSIRSADriver
+
 const (
 	// TLSKeyFile is the name of tls key file in kubeconfigSecret
 	TLSKeyFile = "tls.key"

--- a/pkg/registration/register/aws_irsa/aws_irsa_test.go
+++ b/pkg/registration/register/aws_irsa/aws_irsa_test.go
@@ -1,0 +1,256 @@
+package aws_irsa
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
+	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
+	"open-cluster-management.io/ocm/pkg/registration/register"
+)
+
+const (
+	testNamespace  = "testns"
+	testAgentName  = "testagent"
+	testSecretName = "testsecret"
+	testIrsaName   = "testirsa"
+)
+
+// var commonName = fmt.Sprintf("%s%s:%s", user.SubjectPrefix, testinghelpers.TestManagedClusterName, testAgentName)
+
+func TestProcess(t *testing.T) {
+	cases := []struct {
+		name                string
+		queueKey            string
+		secret              *corev1.Secret
+		approvedIrsaRequest *testinghelpers.TestIrsaRequest
+		keyDataExpected     bool
+		irsaNameExpected    bool
+		expectedCondition   *metav1.Condition
+		validateActions     func(t *testing.T, hubActions []clienttesting.Action, secret *corev1.Secret)
+	}{
+		{},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctrl := &mockAWSIRSAControl{}
+			var irsas []runtime.Object
+
+			hubKubeClient := kubefake.NewSimpleClientset(irsas...)
+
+			additionalSecretData := map[string][]byte{
+				register.ClusterNameFile: []byte(testinghelpers.TestManagedClusterName),
+				register.AgentNameFile:   []byte(testAgentName),
+			}
+
+			awsOption := &AWSOption{
+				AWSIRSAControl: ctrl,
+			}
+
+			driver := &AWSIRSADriver{}
+
+			if c.approvedIrsaRequest != nil {
+				driver.name = testIrsaName
+			}
+
+			syncCtx := testingcommon.NewFakeSyncContext(t, "test")
+
+			klog.Info(hubKubeClient, additionalSecretData, awsOption, syncCtx)
+
+		})
+	}
+}
+
+var _ AWSIRSAControl = &mockAWSIRSAControl{}
+
+//TODO: Uncomment the below once required in the aws irsa authentication implementation
+/*
+func conditionEqual(expected, actual *metav1.Condition) bool {
+ 	if expected == nil && actual == nil {
+ 		return true
+ 	}
+
+ 	if expected == nil || actual == nil {
+ 		return false
+ 	}
+
+ 	if expected.Type != actual.Type {
+ 		return false
+ 	}
+
+ 	if string(expected.Status) != string(actual.Status) {
+ 		return false
+ 	}
+
+ 	return true
+ }
+func (m *mockAWSIRSAControl) create(
+	_ context.Context, _ events.Recorder, objMeta metav1.ObjectMeta, _ []byte, _ string, _ *int32) (string, error) {
+	mockIrsa := &unstructured.Unstructured{}
+	_, err := m.awsIrsaClient.Invokes(clienttesting.CreateActionImpl{
+		ActionImpl: clienttesting.ActionImpl{
+			Verb: "create",
+		},
+		Object: mockIrsa,
+	}, nil)
+	return objMeta.Name + rand.String(4), err
+}
+*/
+type mockAWSIRSAControl struct {
+	approved      bool
+	eksKubeConfig []byte
+	awsIrsaClient *clienttesting.Fake
+}
+
+func (m *mockAWSIRSAControl) isApproved(name string) (bool, error) {
+	_, err := m.awsIrsaClient.Invokes(clienttesting.GetActionImpl{
+		ActionImpl: clienttesting.ActionImpl{
+			Verb: "get",
+			//Resource: schema.GroupVersionResource.GroupVersion().WithResource("aws"),
+		},
+		Name: name,
+	}, nil)
+
+	return m.approved, err
+}
+
+func (m *mockAWSIRSAControl) generateEKSKubeConfig(name string) ([]byte, error) {
+	_, err := m.awsIrsaClient.Invokes(clienttesting.GetActionImpl{
+		ActionImpl: clienttesting.ActionImpl{
+			Verb: "get",
+			//Resource: certificates.SchemeGroupVersion.WithResource("certificatesigningrequests"),
+		},
+		Name: name,
+	}, nil)
+	return m.eksKubeConfig, err
+}
+
+func (m *mockAWSIRSAControl) Informer() cache.SharedIndexInformer {
+	panic("implement me")
+}
+
+func TestIsHubKubeConfigValidFunc(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "testvalidhubclientconfig")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cert1 := testinghelpers.NewTestCert("system:open-cluster-management:cluster1:agent1", 60*time.Second)
+	//cert2 := testinghelpers.NewTestCert("test", 60*time.Second)
+
+	kubeconfig := testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil)
+
+	cases := []struct {
+		name               string
+		clusterName        string
+		agentName          string
+		kubeconfig         []byte
+		bootstapKubeconfig []byte
+		tlsCert            []byte
+		tlsKey             []byte
+		isValid            bool
+	}{
+		{
+			name:    "no kubeconfig",
+			isValid: false,
+		},
+		{
+			name:               "context cluster changes",
+			clusterName:        "cluster1",
+			agentName:          "agent1",
+			kubeconfig:         kubeconfig,
+			bootstapKubeconfig: testinghelpers.NewKubeconfig("c2", "https://127.0.0.1:6001", "", nil, nil, nil),
+			tlsKey:             cert1.Key,
+			tlsCert:            cert1.Cert,
+			isValid:            false,
+		},
+		{
+			name:               "hub server url changes",
+			clusterName:        "cluster1",
+			agentName:          "agent1",
+			kubeconfig:         kubeconfig,
+			bootstapKubeconfig: testinghelpers.NewKubeconfig("c1", "https://127.0.0.2:6001", "", nil, nil, nil),
+			tlsKey:             cert1.Key,
+			tlsCert:            cert1.Cert,
+			isValid:            false,
+		},
+		{
+			name:               "proxy url changes",
+			clusterName:        "cluster1",
+			agentName:          "agent1",
+			kubeconfig:         kubeconfig,
+			bootstapKubeconfig: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "https://127.0.0.1:3129", nil, nil, nil),
+			tlsKey:             cert1.Key,
+			tlsCert:            cert1.Cert,
+			isValid:            false,
+		},
+		{
+			name:               "ca bundle changes",
+			clusterName:        "cluster1",
+			agentName:          "agent1",
+			kubeconfig:         kubeconfig,
+			bootstapKubeconfig: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", []byte("test"), nil, nil),
+			tlsKey:             cert1.Key,
+			tlsCert:            cert1.Cert,
+			isValid:            false,
+		},
+		{
+			name:               "valid hub client config",
+			clusterName:        "cluster1",
+			agentName:          "agent1",
+			kubeconfig:         kubeconfig,
+			bootstapKubeconfig: testinghelpers.NewKubeconfig("c1", "https://127.0.0.1:6001", "", nil, nil, nil),
+			tlsKey:             cert1.Key,
+			tlsCert:            cert1.Cert,
+			isValid:            true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			driver := NewAWSIRSADriver()
+			secretOption := register.SecretOption{
+				ClusterName:       c.clusterName,
+				AgentName:         c.agentName,
+				HubKubeconfigDir:  tempDir,
+				HubKubeconfigFile: path.Join(tempDir, "kubeconfig"),
+			}
+			if c.kubeconfig != nil {
+				testinghelpers.WriteFile(path.Join(tempDir, "kubeconfig"), c.kubeconfig)
+			}
+			if c.tlsKey != nil {
+				testinghelpers.WriteFile(path.Join(tempDir, "tls.key"), c.tlsKey)
+			}
+			if c.tlsCert != nil {
+				testinghelpers.WriteFile(path.Join(tempDir, "tls.crt"), c.tlsCert)
+			}
+			if c.bootstapKubeconfig != nil {
+				bootstrapKubeconfig, err := clientcmd.Load(c.bootstapKubeconfig)
+				if err != nil {
+					t.Fatal(err)
+				}
+				secretOption.BootStrapKubeConfig = bootstrapKubeconfig
+			}
+
+			valid, err := register.IsHubKubeConfigValidFunc(driver, secretOption)(context.TODO())
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if c.isValid != valid {
+				t.Errorf("expect %t, but %t", c.isValid, valid)
+			}
+		})
+	}
+}

--- a/pkg/registration/register/aws_irsa/aws_test.go
+++ b/pkg/registration/register/aws_irsa/aws_test.go
@@ -1,0 +1,132 @@
+package aws_irsa
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/cache"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	managedclusterv1lister "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
+
+	"open-cluster-management.io/ocm/pkg/registration/register"
+)
+
+func TestIsCRApproved(t *testing.T) {
+	cases := []struct {
+		name       string
+		cr         string
+		crApproved bool
+	}{}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(
+				cache.MetaNamespaceKeyFunc,
+				cache.Indexers{
+					cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+				})
+			require.NoError(t, indexer.Add(c.cr))
+			lister := managedclusterv1lister.NewManagedClusterLister(indexer)
+			ctrl := &v1AWSIRSAControl{
+				hubManagedClusterLister: lister,
+			}
+			crApproved, err := ctrl.isApproved(c.name)
+			assert.NoError(t, err)
+			if crApproved != c.crApproved {
+				t.Errorf("expected %t, but got %t", c.crApproved, crApproved)
+			}
+		})
+	}
+}
+
+func TestBuildKubeconfig(t *testing.T) {
+	cases := []struct {
+		name           string
+		server         string
+		proxyURL       string
+		caData         []byte
+		clientCertFile string
+		clientKeyFile  string
+	}{
+		{
+			name:           "without proxy",
+			server:         "https://127.0.0.1:6443",
+			caData:         []byte("fake-ca-bundle"),
+			clientCertFile: "tls.crt",
+			clientKeyFile:  "tls.key",
+		},
+		{
+			name:           "with proxy",
+			server:         "https://127.0.0.1:6443",
+			caData:         []byte("fake-ca-bundle-with-proxy-ca"),
+			proxyURL:       "https://127.0.0.1:3129",
+			clientCertFile: "tls.crt",
+			clientKeyFile:  "tls.key",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bootstrapKubeconfig := &clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"default-cluster": {
+						Server:                   c.server,
+						InsecureSkipTLSVerify:    false,
+						CertificateAuthorityData: c.caData,
+						ProxyURL:                 c.proxyURL,
+					}},
+				// Define a context that connects the auth info and cluster, and set it as the default
+				Contexts: map[string]*clientcmdapi.Context{register.DefaultKubeConfigContext: {
+					Cluster:   "default-cluster",
+					AuthInfo:  register.DefaultKubeConfigAuth,
+					Namespace: "configuration",
+				}},
+				CurrentContext: register.DefaultKubeConfigContext,
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					register.DefaultKubeConfigAuth: {
+						ClientCertificate: c.clientCertFile,
+						ClientKey:         c.clientKeyFile,
+					},
+				},
+			}
+
+			registerImpl := &AWSIRSADriver{}
+			kubeconfig := registerImpl.BuildKubeConfigFromTemplate(bootstrapKubeconfig)
+			currentContext, ok := kubeconfig.Contexts[kubeconfig.CurrentContext]
+			if !ok {
+				t.Errorf("current context %q not found: %v", kubeconfig.CurrentContext, kubeconfig)
+			}
+
+			cluster, ok := kubeconfig.Clusters[currentContext.Cluster]
+			if !ok {
+				t.Errorf("cluster %q not found: %v", currentContext.Cluster, kubeconfig)
+			}
+
+			if cluster.Server != c.server {
+				t.Errorf("expected server %q, but got %q", c.server, cluster.Server)
+			}
+
+			if cluster.ProxyURL != c.proxyURL {
+				t.Errorf("expected proxy URL %q, but got %q", c.proxyURL, cluster.ProxyURL)
+			}
+
+			if !reflect.DeepEqual(cluster.CertificateAuthorityData, c.caData) {
+				t.Errorf("expected ca data %v, but got %v", c.caData, cluster.CertificateAuthorityData)
+			}
+
+			authInfo, ok := kubeconfig.AuthInfos[currentContext.AuthInfo]
+			if !ok {
+				t.Errorf("auth info %q not found: %v", currentContext.AuthInfo, kubeconfig)
+			}
+
+			if authInfo.ClientCertificate != c.clientCertFile {
+				t.Errorf("expected client certificate %q, but got %q", c.clientCertFile, authInfo.ClientCertificate)
+			}
+
+			if authInfo.ClientKey != c.clientKeyFile {
+				t.Errorf("expected client key %q, but got %q", c.clientKeyFile, authInfo.ClientKey)
+			}
+		})
+	}
+}

--- a/pkg/registration/spoke/options.go
+++ b/pkg/registration/spoke/options.go
@@ -76,6 +76,7 @@ func (o *SpokeAgentOptions) AddFlags(fs *pflag.FlagSet) {
 			"the value of --cluster-signing-duration command-line flag of the kube-controller-manager will be used.")
 	fs.StringToStringVar(&o.ClusterAnnotations, "cluster-annotations", o.ClusterAnnotations, `the annotations with the reserve
 	 prefix "agent.open-cluster-management.io" set on ManagedCluster when creating only, other actors can update it afterwards.`)
+	//Consider grouping these flags for driverOption in a new Option struct and add the flags using function driverOptions.AddFlags(fs).
 	fs.StringVar(&o.RegistrationAuth, "registration-auth", o.RegistrationAuth,
 		"The type of authentication to use to authenticate with hub.")
 	fs.StringVar(&o.EksHubClusterArn, "hub-cluster-arn", o.EksHubClusterArn,

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -59,8 +59,7 @@ type SpokeAgentConfig struct {
 
 	internalHubConfigValidFunc wait.ConditionWithContextFunc
 
-	hubKubeConfigChecker            *hubKubeConfigHealthChecker
-	bootstrapKubeconfigEventHandler *bootstrapKubeconfigEventHandler
+	hubKubeConfigChecker *hubKubeConfigHealthChecker
 
 	// agentStopFunc is the function to stop the agent, and the external system can restart the agent
 	// with the refreshed configuration.
@@ -73,9 +72,6 @@ func NewSpokeAgentConfig(commonOpts *commonoptions.AgentOptions, opts *SpokeAgen
 		agentOptions:       commonOpts,
 		registrationOption: opts,
 		agentStopFunc:      cancel,
-		bootstrapKubeconfigEventHandler: &bootstrapKubeconfigEventHandler{
-			bootstrapKubeconfigSecretName: &opts.BootstrapKubeconfigSecret,
-		},
 	}
 	cfg.hubKubeConfigChecker = &hubKubeConfigHealthChecker{
 		checkFunc: cfg.IsHubKubeConfigValid,

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -26,11 +26,14 @@ import (
 	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ocmfeature "open-cluster-management.io/api/feature"
+	operatorv1 "open-cluster-management.io/api/operator/v1"
 
 	"open-cluster-management.io/ocm/pkg/common/helpers"
 	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 	"open-cluster-management.io/ocm/pkg/features"
+	registrationHelpers "open-cluster-management.io/ocm/pkg/registration/helpers"
 	"open-cluster-management.io/ocm/pkg/registration/register"
+	awsIrsa "open-cluster-management.io/ocm/pkg/registration/register/aws_irsa"
 	"open-cluster-management.io/ocm/pkg/registration/register/csr"
 	"open-cluster-management.io/ocm/pkg/registration/spoke/addon"
 	"open-cluster-management.io/ocm/pkg/registration/spoke/lease"
@@ -38,9 +41,11 @@ import (
 	"open-cluster-management.io/ocm/pkg/registration/spoke/registration"
 )
 
-// AddOnLeaseControllerSyncInterval is exposed so that integration tests can crank up the constroller sync speed.
+// AddOnLeaseControllerSyncInterval is exposed so that integration tests can crank up the controller sync speed.
 // TODO if we register the lease informer to the lease controller, we need to increase this time
 var AddOnLeaseControllerSyncInterval = 30 * time.Second
+
+const AwsIrsaAuthType = "awsirsa"
 
 type SpokeAgentConfig struct {
 	agentOptions       *commonoptions.AgentOptions
@@ -54,7 +59,8 @@ type SpokeAgentConfig struct {
 
 	internalHubConfigValidFunc wait.ConditionWithContextFunc
 
-	hubKubeConfigChecker *hubKubeConfigHealthChecker
+	hubKubeConfigChecker            *hubKubeConfigHealthChecker
+	bootstrapKubeconfigEventHandler *bootstrapKubeconfigEventHandler
 
 	// agentStopFunc is the function to stop the agent, and the external system can restart the agent
 	// with the refreshed configuration.
@@ -63,12 +69,13 @@ type SpokeAgentConfig struct {
 
 // NewSpokeAgentConfig returns a SpokeAgentConfig
 func NewSpokeAgentConfig(commonOpts *commonoptions.AgentOptions, opts *SpokeAgentOptions, cancel context.CancelFunc) *SpokeAgentConfig {
-	registerDriver := csr.NewCSRDriver()
 	cfg := &SpokeAgentConfig{
 		agentOptions:       commonOpts,
 		registrationOption: opts,
-		driver:             registerDriver,
 		agentStopFunc:      cancel,
+		bootstrapKubeconfigEventHandler: &bootstrapKubeconfigEventHandler{
+			bootstrapKubeconfigSecretName: &opts.BootstrapKubeconfigSecret,
+		},
 	}
 	cfg.hubKubeConfigChecker = &hubKubeConfigHealthChecker{
 		checkFunc: cfg.IsHubKubeConfigValid,
@@ -109,7 +116,7 @@ func (o *SpokeAgentConfig) HealthCheckers() []healthz.HealthChecker {
 //	#3. Bootstrap kubeconfig is invalid (e.g. certificate expired) and hub kubeconfig is valid
 //	#4. Neither bootstrap kubeconfig nor hub kubeconfig is valid
 //
-// A temporary BootstrpController with bootstrap kubeconfig is created
+// A temporary BootstrapController with bootstrap kubeconfig is created
 // and started if the hub kubeconfig does not exist or is invalid and used to
 // create a valid hub kubeconfig. Once the hub kubeconfig is valid, the
 // temporary controller is stopped and the main controllers are started.
@@ -122,7 +129,7 @@ func (o *SpokeAgentConfig) RunSpokeAgent(ctx context.Context, controllerContext 
 	kubeConfig := controllerContext.KubeConfig
 
 	// load spoke client config and create spoke clients,
-	// the registration agent may not running in the spoke/managed cluster.
+	// the registration agent may not be running in the spoke/managed cluster.
 	spokeClientConfig, err := o.agentOptions.SpokeKubeConfig(kubeConfig)
 	if err != nil {
 		return err
@@ -186,6 +193,27 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 		logger.Error(err, "Error during Validating")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
+
+	// initiate registration driver
+	var registerDriver register.RegisterDriver
+	if o.registrationOption.RegistrationAuth == AwsIrsaAuthType {
+		// TODO: may consider add additional validations
+		if o.registrationOption.EksHubClusterArn != "" && registrationHelpers.IsEksArnWellFormed(o.registrationOption.EksHubClusterArn) {
+			registerDriver = awsIrsa.NewAWSIRSADriver()
+			if o.registrationOption.ClusterAnnotations == nil {
+				o.registrationOption.ClusterAnnotations = map[string]string{}
+			}
+			o.registrationOption.ClusterAnnotations[operatorv1.ClusterAnnotationsKeyPrefix+"/managed-cluster-arn"] = ""             //TODO: find arn from current context
+			o.registrationOption.ClusterAnnotations[operatorv1.ClusterAnnotationsKeyPrefix+"/managed-cluster-iam-role-suffix"] = "" //TODO: Add role suffix after RE-7249
+
+		} else {
+			panic("A valid EKS Hub Cluster ARN is required with awsirsa based authentication")
+		}
+	} else {
+		registerDriver = csr.NewCSRDriver()
+	}
+
+	o.driver = registerDriver
 
 	// get spoke cluster CA bundle
 	spokeClusterCABundle, err := o.getSpokeClusterCABundle(spokeClientConfig)
@@ -294,19 +322,38 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 		// the bootstrap informers are supposed to be terminated after completing the bootstrap process.
 		bootstrapInformerFactory := informers.NewSharedInformerFactory(bootstrapKubeClient, 10*time.Minute)
 
-		csrOption, err := registration.NewCSROption(logger,
-			secretOption,
-			o.registrationOption.ClientCertExpirationSeconds,
-			bootstrapInformerFactory.Certificates(),
-			bootstrapKubeClient)
-		if err != nil {
-			return err
+		bootstrapClusterInformerFactory := clusterv1informers.NewSharedInformerFactory(bootstrapClusterClient, 10*time.Minute)
+
+		// TODO: Generate csrOption or awsOption based on the value of --registration-auth may be move it under registerdriver as well
+
+		var registrationAuthOption any
+		if o.registrationOption.RegistrationAuth == AwsIrsaAuthType {
+			if o.registrationOption.EksHubClusterArn != "" && registrationHelpers.IsEksArnWellFormed(o.registrationOption.EksHubClusterArn) {
+				registrationAuthOption, err = registration.NewAWSOption(
+					secretOption,
+					bootstrapClusterInformerFactory.Cluster(),
+					bootstrapClusterClient)
+				if err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("please provide EKS Hub Cluster ARN for the awsirsa based authentication")
+			}
+		} else {
+			registrationAuthOption, err = registration.NewCSROption(logger,
+				secretOption,
+				o.registrationOption.ClientCertExpirationSeconds,
+				bootstrapInformerFactory.Certificates(),
+				bootstrapKubeClient)
+			if err != nil {
+				return err
+			}
 		}
 
 		controllerName := fmt.Sprintf("BootstrapController@cluster:%s", o.agentOptions.SpokeClusterName)
 		bootstrapCtx, stopBootstrap := context.WithCancel(ctx)
 		secretController := register.NewSecretController(
-			secretOption, csrOption, o.driver, registration.GenerateBootstrapStatusUpdater(), recorder, controllerName)
+			secretOption, registrationAuthOption, o.driver, registration.GenerateBootstrapStatusUpdater(), recorder, controllerName)
 
 		go bootstrapInformerFactory.Start(bootstrapCtx.Done())
 		go secretController.Run(bootstrapCtx, 1)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The PR adds changes for  AWS IAM based authentication support for Open Cluster Management (OCM) for Amazon EKS clusters. This change updates the Klusterletconfig object by adding the registration driver for awsirsa when the value of registration-auth flag is set as awsirsa from clusteradm join command.

## Related issue(s)

Fixes #