### PR TITLE
🌱  Remove ManagedClusterSet webhook registration part

### DIFF
--- a/pkg/registration/webhook/start.go
+++ b/pkg/registration/webhook/start.go
@@ -71,10 +71,6 @@ func (c *Options) RunWebhookServer() error {
 		logger.Error(err, "unable to create ManagedClusterSetBinding webhook", "version", "v1beta2")
 		return err
 	}
-	if err = (&internalv1beta2.ManagedClusterSet{}).SetupWebhookWithManager(mgr); err != nil {
-		logger.Error(err, "unable to create ManagedClusterSet webhook", "version", "v1beta2")
-		return err
-	}
 
 	logger.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/pkg/registration/webhook/v1beta2/webhook.go
+++ b/pkg/registration/webhook/v1beta2/webhook.go
@@ -33,12 +33,6 @@ type ManagedClusterSetBindingWebhook struct {
 	kubeClient kubernetes.Interface
 }
 
-func (src *ManagedClusterSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(src).
-		Complete()
-}
-
 func (b *ManagedClusterSetBindingWebhook) Init(mgr ctrl.Manager) error {
 	err := b.SetupWebhookWithManager(mgr)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
We are not implementing any mutating or validating webhooks for `ManagedClusterSet` here, so we can remove this webhook registration section.
