### PR TITLE
:bug: Add auto approve annotation for an accepted cluster when auto approval enabled

### DIFF
--- a/pkg/registration/hub/managedcluster/controller_test.go
+++ b/pkg/registration/hub/managedcluster/controller_test.go
@@ -110,6 +110,23 @@ func TestSyncManagedCluster(t *testing.T) {
 				testingcommon.AssertActions(t, actions, "patch")
 			},
 		},
+		{
+			name:                "should add the auto approval annotation to an accepted cluster when auto approval is enabled",
+			autoApprovalEnabled: true,
+			startingObjects:     []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "patch")
+				patch := actions[0].(clienttesting.PatchAction).GetPatch()
+				managedCluster := &v1.ManagedCluster{}
+				err := json.Unmarshal(patch, managedCluster)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, ok := managedCluster.Annotations[clusterAcceptedAnnotationKey]; !ok {
+					t.Errorf("expected auto approval annotation, but failed")
+				}
+			},
+		},
 	}
 
 	features.HubMutableFeatureGate.Add(ocmfeature.DefaultHubRegistrationFeatureGates)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This will fix the below problem

1. The hub has an accepted cluster.
2. Enable the auto approval feature
3. Set the cluster hubAcceptsClient to false

The cluster hubAcceptsClient should be able to set to false
 