### PR TITLE
🐛 Fix issue with printing `<nil>` for error messages

### DIFF
--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_runtime_reconcile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_runtime_reconcile.go
@@ -230,7 +230,7 @@ func (r *runtimeReconcile) getClusterNameFromHubKubeConfigSecret(ctx context.Con
 	if len(clusterName) == 0 {
 		meta.SetStatusCondition(&klusterlet.Status.Conditions, metav1.Condition{
 			Type: operatorapiv1.ConditionKlusterletApplied, Status: metav1.ConditionFalse, Reason: operatorapiv1.ReasonKlusterletApplyFailed,
-			Message: fmt.Sprintf("Failed to get cluster name from hub kubeconfig secret with error %v", err),
+			Message: fmt.Sprintf("Failed to get cluster name from hub kubeconfig secret with error: %v", fmt.Errorf("the cluster name in the secret is empty")),
 		})
 		return "", fmt.Errorf("the cluster name in the secret is empty")
 	}

--- a/pkg/operator/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/ssarcontroller/klusterlet_ssar_controller.go
@@ -289,7 +289,7 @@ func checkHubConfigSecret(ctx context.Context, kubeClient kubernetes.Interface, 
 				Status: metav1.ConditionTrue,
 				Reason: operatorapiv1.ReasonClusterNameMissing,
 				Message: fmt.Sprintf(
-					"Failed to get cluster name from `kubectl get secret -n %q %q -ojsonpath='{.data.cluster-name}`."+
+					"Failed to get cluster name from `kubectl get secret -n %q %q -ojsonpath='{.data.cluster-name}'`."+
 						" This is set by the klusterlet registration deployment.", hubConfigSecret.Namespace, hubConfigSecret.Name),
 			}
 		}


### PR DESCRIPTION
Before:

```
Message:		Failed to get cluster name from hub kubeconfig secret with error <nil>
```

After:

```
Message:		Failed to get cluster name from hub kubeconfig secret with error: the cluster name in the secret is empty
```