### PR TITLE
:seedling: enable leader election of klusterlet-agent on single node managed cluster

### DIFF
--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -87,7 +87,6 @@ spec:
           - "--spoke-external-server-urls={{ .ExternalServerURL }}"
           {{end}}
           {{if eq .Replica 1}}
-          - "--disable-leader-election"
           - "--status-sync-interval=60s"
           {{end}}
           {{if gt .ClientCertExpirationSeconds 0}}

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -82,9 +82,6 @@ spec:
           - "--spoke-kubeconfig=/spoke/config/kubeconfig"
           - "--terminate-on-files=/spoke/config/kubeconfig"
           {{end}}
-          {{if eq .Replica 1}}
-          - "--disable-leader-election"
-          {{end}}
           {{if gt .ClientCertExpirationSeconds 0}}
           - "--client-cert-expiration-seconds={{ .ClientCertExpirationSeconds }}"
           {{end}}

--- a/manifests/klusterlet/management/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-deployment.yaml
@@ -76,7 +76,6 @@ spec:
           {{end}}
           - "--terminate-on-files=/spoke/hub-kubeconfig/kubeconfig"
           {{if eq .Replica 1}}
-          - "--disable-leader-election"
           - "--status-sync-interval=60s"
           {{end}}
           {{if gt .WorkKubeAPIQPS 0.0}}

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -398,13 +398,8 @@ func assertKlusterletDeployment(t *testing.T, actions []clienttesting.Action, ve
 		expectedArgs = append(expectedArgs, fmt.Sprintf("--spoke-external-server-urls=%s", serverURL))
 	}
 
-	expectedArgs = append(expectedArgs, "--agent-id=", "--workload-source-driver=kube", "--workload-source-config=/spoke/hub-kubeconfig/kubeconfig")
-
-	if *deployment.Spec.Replicas == 1 {
-		expectedArgs = append(expectedArgs, "--disable-leader-election")
-	}
-
-	expectedArgs = append(expectedArgs, "--status-sync-interval=60s", "--kube-api-qps=20", "--kube-api-burst=60",
+	expectedArgs = append(expectedArgs, "--agent-id=", "--workload-source-driver=kube", "--workload-source-config=/spoke/hub-kubeconfig/kubeconfig",
+		"--status-sync-interval=60s", "--kube-api-qps=20", "--kube-api-burst=60",
 		"--registration-auth=awsirsa", "--hub-cluster-arn=arneks:us-west-2:123456789012:cluster/hub-cluster1")
 
 	if !equality.Semantic.DeepEqual(args, expectedArgs) {
@@ -435,10 +430,6 @@ func assertRegistrationDeployment(t *testing.T, actions []clienttesting.Action, 
 
 	if serverURL != "" {
 		expectedArgs = append(expectedArgs, fmt.Sprintf("--spoke-external-server-urls=%s", serverURL))
-	}
-
-	if *deployment.Spec.Replicas == 1 {
-		expectedArgs = append(expectedArgs, "--disable-leader-election")
 	}
 
 	expectedArgs = append(expectedArgs, "--kube-api-qps=10", "--kube-api-burst=60")
@@ -484,7 +475,7 @@ func assertWorkDeployment(t *testing.T, actions []clienttesting.Action, verb, cl
 	expectArgs = append(expectArgs, "--terminate-on-files=/spoke/hub-kubeconfig/kubeconfig")
 
 	if *deployment.Spec.Replicas == 1 {
-		expectArgs = append(expectArgs, "--disable-leader-election", "--status-sync-interval=60s")
+		expectArgs = append(expectArgs, "--status-sync-interval=60s")
 	}
 
 	expectArgs = append(expectArgs, "--kube-api-qps=20", "--kube-api-burst=50")

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -592,7 +592,7 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
 				// klusterlet has no condition, replica is 0
 				gomega.Expect(actual.Status.Replicas).Should(gomega.Equal(int32(0)))
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(9))
+				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(8))
 				return actual.Spec.Template.Spec.Containers[0].Args[2] != "--spoke-cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
@@ -602,7 +602,7 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 					return false
 				}
 				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(6))
+				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(5))
 				return actual.Spec.Template.Spec.Containers[0].Args[2] == "--spoke-cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The leader election of the klusterlet-agent is disabled on the single node managed cluster to speed up the restart procedure. While it might cause that two pods with different configuration, such as images or bootstrap config, running at the same time. Some unexpected behavior happens in this situation, for example, when old and new agents both exist, they override hub-kubeconfig-secret with different value and trigger each other create csr constantly.

To fix those issues, it is necessary to enable the leader election of the klusterlet-agent on the single node managed cluster.

## Related issue(s)

Fixes #