### PR TITLE
:sparkles: support wildcard in ManifestConfigs

### DIFF
--- a/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
@@ -59,7 +59,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/open-cluster-management/registration-operator:latest
-    createdAt: "2024-10-11T02:21:31Z"
+    createdAt: "2024-11-20T09:03:54Z"
     description: Manages the installation and upgrade of the ClusterManager.
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/open-cluster-management/registration-operator:latest
-    createdAt: "2024-10-11T02:21:31Z"
+    createdAt: "2024-11-20T09:03:55Z"
     description: Manages the installation and upgrade of the Klusterlet.
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	k8s.io/kube-aggregator v0.31.2
 	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6
 	open-cluster-management.io/addon-framework v0.11.0
-	open-cluster-management.io/api v0.15.1-0.20241106012558-db876bf4ff8a
+	open-cluster-management.io/api v0.15.1-0.20241120090202-cb7ce98ab874
 	open-cluster-management.io/sdk-go v0.15.0
 	sigs.k8s.io/cluster-inventory-api v0.0.0-20240730014211-ef0154379848
 	sigs.k8s.io/controller-runtime v0.19.1

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 h1:MDF6h2H/h4tbzmtIKTuctcwZmY0tY
 k8s.io/utils v0.0.0-20240921022957-49e7df575cb6/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 open-cluster-management.io/addon-framework v0.11.0 h1:ZJxphgHQ36VUJF0RIag+nzcEn5PNyep2rsEPdz6wT7o=
 open-cluster-management.io/addon-framework v0.11.0/go.mod h1:ruMU8i/dciz3qCv2CQ46Cu1b7rkK7TpvB+W4bRwHf+I=
-open-cluster-management.io/api v0.15.1-0.20241106012558-db876bf4ff8a h1:QTljOjTR8jDpw/EWhOoakGcStGVftQkBWHVxGZMhEUQ=
-open-cluster-management.io/api v0.15.1-0.20241106012558-db876bf4ff8a/go.mod h1:9erZEWEn4bEqh0nIX2wA7f/s3KCuFycQdBrPrRzi0QM=
+open-cluster-management.io/api v0.15.1-0.20241120090202-cb7ce98ab874 h1:WgkuYXTbJV7EK+qtiMq3soa21faGUKeTG5w0C8Mn1Ok=
+open-cluster-management.io/api v0.15.1-0.20241120090202-cb7ce98ab874/go.mod h1:9erZEWEn4bEqh0nIX2wA7f/s3KCuFycQdBrPrRzi0QM=
 open-cluster-management.io/sdk-go v0.15.0 h1:2IAJnPfUoY6rPC5w7LhqAnvIlgekPoVW03LdZO1unIM=
 open-cluster-management.io/sdk-go v0.15.0/go.mod h1:fi5WBsbC5K3txKb8eRLuP0Sim/Oqz/PHX18skAEyjiA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsAtVhSeUFseziht227YAWYHLGNM8QPwY=

--- a/manifests/cluster-manager/hub/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -210,6 +210,9 @@ spec:
                                   - path
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               type:
                                 description: |-
                                   Type defines the option of how status can be returned.

--- a/manifests/cluster-manager/hub/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -187,6 +187,9 @@ spec:
                               - path
                               type: object
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           type:
                             description: |-
                               Type defines the option of how status can be returned.

--- a/manifests/cluster-manager/hub/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
+++ b/manifests/cluster-manager/hub/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
@@ -203,6 +203,9 @@ spec:
                                   - path
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               type:
                                 description: |-
                                   Type defines the option of how status can be returned.

--- a/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler.go
+++ b/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler.go
@@ -195,8 +195,8 @@ func (m *manifestworkReconciler) applyOneManifest(
 	requiredOwner := manageOwnerRef(ownedByTheWork, owner)
 
 	// find update strategy option.
-	option := helper.FindManifestConiguration(resMeta, workSpec.ManifestConfigs)
-	// strategy is update by default
+	option := helper.FindManifestConfiguration(resMeta, workSpec.ManifestConfigs)
+	// strategy is updated by default
 	strategy := workapiv1.UpdateStrategy{Type: workapiv1.UpdateStrategyTypeUpdate}
 	if option != nil && option.UpdateStrategy != nil {
 		strategy = *option.UpdateStrategy

--- a/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler_test.go
+++ b/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler_test.go
@@ -476,11 +476,32 @@ func TestUpdateStrategy(t *testing.T) {
 				"v1", "NewObject", "ns1", "n1",
 				map[string]interface{}{"spec": map[string]interface{}{"key1": "val2"}})).
 			withManifestConfig(newManifestConfigOption(
-				"", "newobjects", "ns1", "n1",
+				"", "newobjects", "ns*", "*",
 				&workapiv1.UpdateStrategy{Type: workapiv1.UpdateStrategyTypeCreateOnly})).
 			withExpectedWorkAction("patch").
 			withAppliedWorkAction("create").
 			withExpectedDynamicAction("get", "patch").
+			withExpectedManifestCondition(expectedCondition{workapiv1.ManifestApplied, metav1.ConditionTrue}).
+			withExpectedWorkCondition(expectedCondition{workapiv1.WorkApplied, metav1.ConditionTrue}),
+		newTestCase("update multi resources with create only updateStrategy").
+			withWorkManifest(testingcommon.NewUnstructuredWithContent(
+				"v1", "NewObject", "ns1", "n1",
+				map[string]interface{}{"spec": map[string]interface{}{"key1": "val1"}}),
+				testingcommon.NewUnstructuredWithContent(
+					"v1", "NewObject", "ns2", "n2",
+					map[string]interface{}{"spec": map[string]interface{}{"key2": "val2"}})).
+			withSpokeDynamicObject(testingcommon.NewUnstructuredWithContent(
+				"v1", "NewObject", "ns1", "n1",
+				map[string]interface{}{"spec": map[string]interface{}{"key2": "val2"}}),
+				testingcommon.NewUnstructuredWithContent(
+					"v1", "NewObject", "ns2", "n2",
+					map[string]interface{}{"spec": map[string]interface{}{"key1": "val1"}})).
+			withManifestConfig(newManifestConfigOption(
+				"", "newobjects", "ns*", "*",
+				&workapiv1.UpdateStrategy{Type: workapiv1.UpdateStrategyTypeCreateOnly})).
+			withExpectedWorkAction("patch").
+			withAppliedWorkAction("create").
+			withExpectedDynamicAction("get", "patch", "get", "patch").
 			withExpectedManifestCondition(expectedCondition{workapiv1.ManifestApplied, metav1.ConditionTrue}).
 			withExpectedWorkCondition(expectedCondition{workapiv1.WorkApplied, metav1.ConditionTrue}),
 	}

--- a/pkg/work/spoke/controllers/statuscontroller/availablestatus_controller.go
+++ b/pkg/work/spoke/controllers/statuscontroller/availablestatus_controller.go
@@ -208,7 +208,7 @@ func (c *AvailableStatusController) getFeedbackValues(
 	var errs []error
 	var values []workapiv1.FeedbackValue
 
-	option := helper.FindManifestConiguration(resourceMeta, manifestOptions)
+	option := helper.FindManifestConfiguration(resourceMeta, manifestOptions)
 
 	if option == nil || len(option.FeedbackRules) == 0 {
 		return values, metav1.Condition{

--- a/test/integration/work/statusfeedback_test.go
+++ b/test/integration/work/statusfeedback_test.go
@@ -242,8 +242,8 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 					ResourceIdentifier: workapiv1.ResourceIdentifier{
 						Group:     "apps",
 						Resource:  "deployments",
-						Namespace: commOptions.SpokeClusterName,
-						Name:      "deploy1",
+						Namespace: "*",
+						Name:      "*1",
 					},
 					FeedbackRules: []workapiv1.FeedbackRule{
 						{
@@ -747,6 +747,285 @@ var _ = ginkgo.Describe("ManifestWork Status Feedback", func() {
 				}
 
 				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("Deployments Status feedback with wildcard", func() {
+		ginkgo.BeforeEach(func() {
+			deployment1, _, err := util.NewDeployment(commOptions.SpokeClusterName, "deploy1", "sa")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			manifests = append(manifests, util.ToManifest(deployment1))
+			deployment2, _, err := util.NewDeployment(commOptions.SpokeClusterName, "deploy2", "sa")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			manifests = append(manifests, util.ToManifest(deployment2))
+
+			err = features.SpokeMutableFeatureGate.Set(fmt.Sprintf("%s=true", ocmfeature.RawFeedbackJsonString))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			var ctx context.Context
+			ctx, cancel = context.WithCancel(context.Background())
+			go startWorkAgent(ctx, o, commOptions)
+		})
+
+		ginkgo.AfterEach(func() {
+			if cancel != nil {
+				cancel()
+			}
+		})
+
+		ginkgo.It("wildcard option should match all deployments", func() {
+			work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
+				{
+					ResourceIdentifier: workapiv1.ResourceIdentifier{
+						Group:     "apps",
+						Resource:  "deployments",
+						Namespace: "*",
+						Name:      "deploy*",
+					},
+					FeedbackRules: []workapiv1.FeedbackRule{
+						{
+							Type: workapiv1.WellKnownStatusType,
+						},
+						{
+							Type: workapiv1.JSONPathsType,
+							JsonPaths: []workapiv1.JsonPath{
+								{Name: "name", Path: ".metadata.name"},
+							},
+						},
+					},
+				},
+			}
+
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
+				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
+				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
+
+			// Update Deployment status on spoke
+			gomega.Eventually(func() error {
+				deploy, err := spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).Get(context.Background(), "deploy1", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				deploy.Status.AvailableReplicas = 3
+				deploy.Status.Replicas = 3
+				deploy.Status.ReadyReplicas = 3
+
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				if err != nil {
+					return err
+				}
+
+				deploy, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).Get(context.Background(), "deploy2", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				deploy.Status.AvailableReplicas = 4
+				deploy.Status.Replicas = 4
+				deploy.Status.ReadyReplicas = 4
+
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				return err
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+			// Check if we get status of deployment on work api
+			gomega.Eventually(func() error {
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Get(context.Background(), work.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if len(work.Status.ResourceStatus.Manifests) != 2 {
+					return fmt.Errorf("the size of resource status is not correct, expect to be 2 but got %d", len(work.Status.ResourceStatus.Manifests))
+				}
+
+				values := work.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values
+				for _, v := range values {
+					switch v.Name {
+					case "ReadyReplicas", "Replicas", "AvailableReplicas":
+						if *v.Value.Integer != 3 {
+							return fmt.Errorf("ReadyReplicas expected 3,but got %v", *v.Value.Integer)
+						}
+					case "name":
+						if *v.Value.String != "deploy1" {
+							return fmt.Errorf("named value is not correct, we got %v", *v.Value.String)
+						}
+					default:
+						return fmt.Errorf("not expected value type: %v", v.Name)
+					}
+				}
+				values = work.Status.ResourceStatus.Manifests[1].StatusFeedbacks.Values
+				for _, v := range values {
+					switch v.Name {
+					case "ReadyReplicas", "Replicas", "AvailableReplicas":
+						if *v.Value.Integer != 4 {
+							return fmt.Errorf("ReadyReplicas expected 4,but got %v", *v.Value.Integer)
+						}
+					case "name":
+						if *v.Value.String != "deploy2" {
+							return fmt.Errorf("named value is not correct, we got %v", *v.Value.String)
+						}
+					default:
+						return fmt.Errorf("not expected value type: %v", v.Name)
+					}
+
+				}
+
+				if !util.HaveManifestCondition(work.Status.ResourceStatus.Manifests, "StatusFeedbackSynced",
+					[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}) {
+					return fmt.Errorf("status sync condition should be True")
+				}
+
+				return err
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+		})
+
+		ginkgo.It("matched multi options only the first works ", func() {
+			work.Spec.ManifestConfigs = []workapiv1.ManifestConfigOption{
+				{
+					ResourceIdentifier: workapiv1.ResourceIdentifier{
+						Group:     "apps",
+						Resource:  "deployments",
+						Namespace: "*",
+						Name:      "deploy1",
+					},
+					FeedbackRules: []workapiv1.FeedbackRule{
+						{
+							Type: workapiv1.JSONPathsType,
+							JsonPaths: []workapiv1.JsonPath{
+								{Name: "conditions", Path: ".status.conditions"},
+							},
+						},
+						{
+							Type: workapiv1.JSONPathsType,
+							JsonPaths: []workapiv1.JsonPath{
+								{Name: "name", Path: ".metadata.name"},
+							},
+						},
+					},
+				},
+				{
+					ResourceIdentifier: workapiv1.ResourceIdentifier{
+						Group:     "apps",
+						Resource:  "deployments",
+						Namespace: "*",
+						Name:      "deploy*",
+					},
+					FeedbackRules: []workapiv1.FeedbackRule{
+						{Type: workapiv1.WellKnownStatusType},
+						{
+							Type: workapiv1.JSONPathsType,
+							JsonPaths: []workapiv1.JsonPath{
+								{Name: "name", Path: ".metadata.name"},
+							},
+						},
+					},
+				},
+			}
+
+			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(context.Background(),
+				work, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied, metav1.ConditionTrue,
+				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
+			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkAvailable, metav1.ConditionTrue,
+				[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}, eventuallyTimeout, eventuallyInterval)
+
+			// Update Deployment status on spoke
+			gomega.Eventually(func() error {
+				deploy, err := spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).
+					Get(context.Background(), "deploy1", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				deploy.Status.Conditions = []appsv1.DeploymentCondition{
+					{
+						Type:   "Available",
+						Status: "True",
+					},
+				}
+
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).
+					UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				if err != nil {
+					return err
+				}
+
+				deploy, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).
+					Get(context.Background(), "deploy2", metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				deploy.Status.AvailableReplicas = 4
+				deploy.Status.Replicas = 4
+				deploy.Status.ReadyReplicas = 4
+
+				_, err = spokeKubeClient.AppsV1().Deployments(commOptions.SpokeClusterName).
+					UpdateStatus(context.Background(), deploy, metav1.UpdateOptions{})
+				return err
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+			// Check if we get status of deployment on work api
+			gomega.Eventually(func() error {
+				work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).
+					Get(context.Background(), work.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				if len(work.Status.ResourceStatus.Manifests) != 2 {
+					return fmt.Errorf("the size of resource status is not correct, expect to be 2 but got %d",
+						len(work.Status.ResourceStatus.Manifests))
+				}
+
+				// deploy1 feedback result is condition
+				values := work.Status.ResourceStatus.Manifests[0].StatusFeedbacks.Values
+				for _, v := range values {
+					switch v.Name {
+					case "name":
+						if *v.Value.String != "deploy1" {
+							return fmt.Errorf("named value is not correct, we got %v", *v.Value.String)
+						}
+					case "conditions":
+						if v.Value.Type != workapiv1.JsonRaw {
+							return fmt.Errorf("expected JsonRaw,but got %v", v.Value.Type)
+						}
+					default:
+						return fmt.Errorf("not expected value type: %v", v.Value.Type)
+
+					}
+				}
+				// deploy2 feedback result is wellKnown
+				values = work.Status.ResourceStatus.Manifests[1].StatusFeedbacks.Values
+				for _, v := range values {
+					switch v.Name {
+					case "ReadyReplicas", "Replicas", "AvailableReplicas":
+						if *v.Value.Integer != 4 {
+							return fmt.Errorf("ReadyReplicas expected 3,but got %v", *v.Value.Integer)
+						}
+					case "name":
+						if *v.Value.String != "deploy2" {
+							return fmt.Errorf("named value is not correct, we got %v", *v.Value.String)
+						}
+					default:
+						return fmt.Errorf("not expected value type: %v", v.Name)
+					}
+				}
+
+				if !util.HaveManifestCondition(work.Status.ResourceStatus.Manifests, "StatusFeedbackSynced",
+					[]metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue}) {
+					return fmt.Errorf("status sync condition should be True")
+				}
+				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 		})
 	})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1580,7 +1580,7 @@ open-cluster-management.io/addon-framework/pkg/agent
 open-cluster-management.io/addon-framework/pkg/assets
 open-cluster-management.io/addon-framework/pkg/index
 open-cluster-management.io/addon-framework/pkg/utils
-# open-cluster-management.io/api v0.15.1-0.20241106012558-db876bf4ff8a
+# open-cluster-management.io/api v0.15.1-0.20241120090202-cb7ce98ab874
 ## explicit; go 1.22.0
 open-cluster-management.io/api/addon/v1alpha1
 open-cluster-management.io/api/client/addon/clientset/versioned

--- a/vendor/open-cluster-management.io/api/addon/v1alpha1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
+++ b/vendor/open-cluster-management.io/api/addon/v1alpha1/0000_03_addon.open-cluster-management.io_addontemplates.crd.yaml
@@ -203,6 +203,9 @@ spec:
                                   - path
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               type:
                                 description: |-
                                   Type defines the option of how status can be returned.

--- a/vendor/open-cluster-management.io/api/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
+++ b/vendor/open-cluster-management.io/api/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
@@ -187,6 +187,9 @@ spec:
                               - path
                               type: object
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           type:
                             description: |-
                               Type defines the option of how status can be returned.

--- a/vendor/open-cluster-management.io/api/work/v1/types.go
+++ b/vendor/open-cluster-management.io/api/work/v1/types.go
@@ -226,6 +226,8 @@ type FeedbackRule struct {
 	Type FeedBackType `json:"type"`
 
 	// JsonPaths defines the json path under status field to be synced.
+	// +listType:=map
+	// +listMapKey:=name
 	// +optional
 	JsonPaths []JsonPath `json:"jsonPaths,omitempty"`
 }

--- a/vendor/open-cluster-management.io/api/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
+++ b/vendor/open-cluster-management.io/api/work/v1alpha1/0000_00_work.open-cluster-management.io_manifestworkreplicasets.crd.yaml
@@ -210,6 +210,9 @@ spec:
                                   - path
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
                               type:
                                 description: |-
                                   Type defines the option of how status can be returned.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Support wildcard in the name and namespace of ManifestConfigs.ResourceIdentifier for feedbackRule and updateStrategy.
if the a resource matches more than 1 options, only the first one works.
## Related issue(s)
https://github.com/open-cluster-management-io/ocm/issues/705
Fixes #