### PR TITLE
🐛 Should use metadata name queue key func for addon informer

### DIFF
--- a/pkg/addon/controllers/addonmanagement/controller.go
+++ b/pkg/addon/controllers/addonmanagement/controller.go
@@ -66,7 +66,7 @@ func NewAddonManagementController(
 	}
 
 	return factory.New().WithInformersQueueKeysFunc(
-		queue.QueueKeyByMetaNamespaceName,
+		queue.QueueKeyByMetaName,
 		addonInformers.Informer(), clusterManagementAddonInformers.Informer()).
 		WithInformersQueueKeysFunc(
 			index.ClusterManagementAddonByPlacementDecisionQueueKey(


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is because in https://github.com/open-cluster-management-io/ocm/pull/654 we change the way to get key, but the missing part is the queuekey func for addon informers.

## Related issue(s)

Fixes #