### PR TITLE
:sparkles: Adding aws-cli to docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,15 @@ REGISTRATION_IMAGE ?= $(IMAGE_REGISTRY)/registration:$(IMAGE_TAG)
 PLACEMENT_IMAGE ?= $(IMAGE_REGISTRY)/placement:$(IMAGE_TAG)
 # ADDON_MANAGER_IMAGE can be set in the env to override calculated value
 ADDON_MANAGER_IMAGE ?= $(IMAGE_REGISTRY)/addon-manager:$(IMAGE_TAG)
+# AWS_CLI_IMAGE can be set in the env to override calculated value
+AWS_CLI_IMAGE ?= $(IMAGE_REGISTRY)/aws-cli:$(IMAGE_TAG)
 
 $(call build-image,registration,$(REGISTRATION_IMAGE),./build/Dockerfile.registration,.)
 $(call build-image,work,$(WORK_IMAGE),./build/Dockerfile.work,.)
 $(call build-image,placement,$(PLACEMENT_IMAGE),./build/Dockerfile.placement,.)
 $(call build-image,registration-operator,$(OPERATOR_IMAGE_NAME),./build/Dockerfile.registration-operator,.)
 $(call build-image,addon-manager,$(ADDON_MANAGER_IMAGE),./build/Dockerfile.addon,.)
+$(call build-image,aws-cli,$(AWS_CLI_IMAGE),./build/Dockerfile.aws-cli,.)
 
 copy-crd:
 	bash -x hack/copy-crds.sh $(YAML_PATCH)

--- a/build/Dockerfile.aws-cli
+++ b/build/Dockerfile.aws-cli
@@ -1,13 +1,13 @@
 FROM golang:1.22-bullseye AS builder
 ARG OS=linux
-ARG ARCH=amd64
+ARG ARCH=x86_64
 
 # Downloading aws-cli
 WORKDIR /tmp
 RUN apt-get update
 RUN apt-get install unzip
 RUN unzip -v
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN curl "https://awscli.amazonaws.com/awscli-exe-${OS}-${ARCH}.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 
 

--- a/build/Dockerfile.aws-cli
+++ b/build/Dockerfile.aws-cli
@@ -1,13 +1,14 @@
 FROM golang:1.22-bullseye AS builder
 ARG OS=linux
 ARG ARCH=x86_64
+ARG VERSION=2.22.8
 
 # Downloading aws-cli
 WORKDIR /tmp
 RUN apt-get update
 RUN apt-get install unzip
 RUN unzip -v
-RUN curl "https://awscli.amazonaws.com/awscli-exe-${OS}-${ARCH}.zip" -o "awscliv2.zip"
+RUN curl "https://awscli.amazonaws.com/awscli-exe-${OS}-${ARCH}-${VERSION}.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 
 

--- a/build/Dockerfile.aws-cli
+++ b/build/Dockerfile.aws-cli
@@ -1,0 +1,25 @@
+FROM golang:1.22-bullseye AS builder
+ARG OS=linux
+ARG ARCH=amd64
+
+# Downloading aws-cli
+WORKDIR /tmp
+RUN apt-get update
+RUN apt-get install unzip
+RUN unzip -v
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+ENV USER_UID=10001
+
+# Installing aws-cli
+RUN mkdir -p ./aws
+COPY --from=builder /tmp/aws ./aws
+RUN ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
+RUN rm -rf ./aws/*
+RUN rmdir ./aws
+RUN aws --version
+
+USER ${USER_UID}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This image will be use as initContainer to copy the aws-cli to klusterlet-agent when initialized with awsirsa auth type.
This will allow us to keep registration-operator docker image clean.

## Related issue(s)

Fixes # https://github.com/open-cluster-management-io/ocm/issues/514