### PR TITLE
:seedling: Fix the GitHub stale workflow to correctly state remove the stale label

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: '30 1 * * *' # Runs at 1:30am every day
 
-# `stable` label will be added to issues and PRs that have been inactive for 120 days
+# `stale` label will be added to issues and PRs that have been inactive for 120 days
 # Close stale issues and PRs after 14 days of inactivity
 permissions:
   contents: read
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open for 120 days with no activity. After 14 days of inactivity, it will be closed. Remove the `stable` label to prevent this issue from being closed.'
-          stale-pr-message: 'This pull request is stale because it has been open for 120 days with no activity.  After 14 days of inactivity, it will be closed. Remove the `stable` label to prevent this issue from being closed.'
+          stale-issue-message: 'This issue is stale because it has been open for 120 days with no activity. After 14 days of inactivity, it will be closed. Remove the `stale` label to prevent this issue from being closed.'
+          stale-pr-message: 'This pull request is stale because it has been open for 120 days with no activity.  After 14 days of inactivity, it will be closed. Remove the `stale` label to prevent this issue from being closed.'
           days-before-stale: 120
           days-before-close: 14


### PR DESCRIPTION
## Summary
- Fix the GitHub stale workflow to correctly state remove the `stale` label instead of the `stable` label.
- Renamed the file from stable to stale as well

An example of the `stable` usage: https://github.com/open-cluster-management-io/ocm/issues/514#issuecomment-2463603076

## Related issue(s)
