### PR TITLE
:sparkles: Adding second group for aws auth flow

### DIFF
--- a/pkg/registration/hub/manifests/rbac/managedcluster-clusterrolebinding.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-clusterrolebinding.yaml
@@ -12,3 +12,6 @@ subjects:
 - kind: Group
   apiGroup: rbac.authorization.k8s.io
   name: system:open-cluster-management:{{ .ManagedClusterName }}
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: open-cluster-management:{{ .ManagedClusterName }}

--- a/pkg/registration/hub/manifests/rbac/managedcluster-registration-rolebinding.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-registration-rolebinding.yaml
@@ -15,3 +15,6 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: system:open-cluster-management:{{ .ManagedClusterName }}
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: open-cluster-management:{{ .ManagedClusterName }}

--- a/pkg/registration/hub/manifests/rbac/managedcluster-work-rolebinding.yaml
+++ b/pkg/registration/hub/manifests/rbac/managedcluster-work-rolebinding.yaml
@@ -17,3 +17,6 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: system:open-cluster-management:{{ .ManagedClusterName }}
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: open-cluster-management:{{ .ManagedClusterName }}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Adding a second group, that will be used when the spoke starts registration with aws auth type. The aws solution uses [EKS access entries](https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html) and an access entry cannot contain a group name with "system:" prefix. More details can be found on [this](https://kubernetes.slack.com/archives/C01GE7YSUUF/p1733178937248749) slack thread.

> It can’t start with system:, eks:, aws:, amazon:, or iam:.

## Related issue(s)

Fixes # https://github.com/open-cluster-management-io/ocm/issues/514