### PR TITLE
✨ Add a configmap to handle the proxy ca bundle

### DIFF
--- a/pkg/addon/templateagent/decorator.go
+++ b/pkg/addon/templateagent/decorator.go
@@ -2,11 +2,14 @@ package templateagent
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/utils"
@@ -99,7 +102,7 @@ func newDeploymentDecorator(
 			newVolumeDecorator(addonName, template),
 			newNodePlacementDecorator(privateValues),
 			newImageDecorator(privateValues),
-			newProxyDecorator(privateValues),
+			newProxyHandler(addonName, privateValues),
 		},
 	}
 }
@@ -142,7 +145,7 @@ func newDaemonSetDecorator(
 			newVolumeDecorator(addonName, template),
 			newNodePlacementDecorator(privateValues),
 			newImageDecorator(privateValues),
-			newProxyDecorator(privateValues),
+			newProxyHandler(addonName, privateValues),
 		},
 	}
 }
@@ -331,25 +334,36 @@ func (d *imageDecorator) decorate(pod *corev1.PodTemplateSpec) error {
 	return nil
 }
 
-type proxyDecorator struct {
+// objectsInjector injects additional runtime objects to the manifests, these objects will be created
+// in the managed clusters
+type objectsInjector interface {
+	// inject returns a list of runtime objects to be created in the managed cluster
+	inject() ([]runtime.Object, error)
+}
+
+// podTemplateHandler is a combination of podTemplateSpecDecorator and objectsInjector, it can decorate
+// the pod in the deployments/daemonsets and inject additional runtime objects into the manifests
+type podTemplateHandler interface {
+	podTemplateSpecDecorator
+	objectsInjector
+}
+
+type proxyHandler struct {
+	addonName     string
 	privateValues addonfactory.Values
 }
 
-func newProxyDecorator(privateValues addonfactory.Values) podTemplateSpecDecorator {
-	return &proxyDecorator{
+func newProxyHandler(addonName string, privateValues addonfactory.Values) podTemplateHandler {
+	return &proxyHandler{
+		addonName:     addonName,
 		privateValues: privateValues,
 	}
 }
 
-func (d *proxyDecorator) decorate(pod *corev1.PodTemplateSpec) error {
-	proxyConfig, ok := d.privateValues[ProxyPrivateValueKey]
+func (d *proxyHandler) decorate(pod *corev1.PodTemplateSpec) error {
+	pc, ok := d.getProxyConfig()
 	if !ok {
 		return nil
-	}
-
-	pc, ok := proxyConfig.(addonapiv1alpha1.ProxyConfig)
-	if !ok {
-		return fmt.Errorf("proxy config value is invalid")
 	}
 
 	keyValues := []keyValuePair{}
@@ -376,8 +390,114 @@ func (d *proxyDecorator) decorate(pod *corev1.PodTemplateSpec) error {
 		return nil
 	}
 
-	return newEnvironmentDecorator(keyValues).decorate(pod)
-	// TODO: consider to create a configmap to store the proxyConfig.CABundle and mount it to the Deployment/DaemonSet
+	err := newEnvironmentDecorator(keyValues).decorate(pod)
+	if err != nil {
+		return err
+	}
+
+	if len(pc.CABundle) == 0 {
+		return nil
+	}
+
+	return newCABundleDecorator(d.addonName, pc.CABundle).decorate(pod)
+}
+
+func (d *proxyHandler) getProxyConfig() (addonapiv1alpha1.ProxyConfig, bool) {
+	proxyConfig, ok := d.privateValues[ProxyPrivateValueKey]
+	if !ok {
+		return addonapiv1alpha1.ProxyConfig{}, false
+	}
+
+	pc, ok := proxyConfig.(addonapiv1alpha1.ProxyConfig)
+	if !ok {
+		klog.Warningf("proxy config value is invalid: %v", proxyConfig)
+		return addonapiv1alpha1.ProxyConfig{}, false
+	}
+
+	return pc, true
+}
+
+func (d *proxyHandler) inject() ([]runtime.Object, error) {
+	pc, ok := d.getProxyConfig()
+	if !ok {
+		return nil, nil
+	}
+
+	if len(pc.CABundle) == 0 {
+		return nil, nil
+	}
+
+	return []runtime.Object{
+		&corev1.ConfigMap{
+			// add TypeMeta to prevent error:
+			//   "failed to generate required mapper.err got empty kind/version from object"
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: proxyCABundleConfigMapName(d.addonName),
+				// use the default namespace, will be decorated by the namespaceDecorator
+				Namespace: "open-cluster-management-agent-addon",
+			},
+			Data: map[string]string{
+				proxyCABundleConfigMapDataKey(): string(pc.CABundle),
+			},
+		},
+	}, nil
+}
+
+type caBundleDecorator struct {
+	addonName    string
+	caBundle     []byte
+	envDecorator podTemplateSpecDecorator
+}
+
+func newCABundleDecorator(addonName string, caBundle []byte) podTemplateSpecDecorator {
+	keyValues := []keyValuePair{}
+	keyValues = append(keyValues,
+		keyValuePair{name: "CA_BUNDLE_FILE_PATH", value: proxyCABundleFilePath()},
+	)
+
+	return &caBundleDecorator{
+		addonName:    addonName,
+		caBundle:     caBundle,
+		envDecorator: newEnvironmentDecorator(keyValues),
+	}
+}
+
+func (d *caBundleDecorator) decorate(pod *corev1.PodTemplateSpec) error {
+	err := d.envDecorator.decorate(pod)
+	if err != nil {
+		return err
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "proxy-ca-bundle",
+			MountPath: proxyCABundleConfigMapMountPath(),
+		},
+	}
+	volumes := []corev1.Volume{
+		{
+			Name: "proxy-ca-bundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: proxyCABundleConfigMapName(d.addonName),
+					},
+				},
+			},
+		},
+	}
+
+	for j := range pod.Spec.Containers {
+		pod.Spec.Containers[j].VolumeMounts = append(
+			pod.Spec.Containers[j].VolumeMounts, volumeMounts...)
+	}
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes, volumes...)
+	return nil
 }
 
 func hubKubeconfigSecretMountPath() string {
@@ -394,4 +514,20 @@ func CustomSignedSecretName(addonName, signerName string) string {
 
 func customSignedSecretMountPath(signerName string) string {
 	return fmt.Sprintf("/managed/%s", strings.ReplaceAll(signerName, "/", "-"))
+}
+
+func proxyCABundleConfigMapMountPath() string {
+	return "/managed/proxy-ca"
+}
+
+func proxyCABundleConfigMapName(addonName string) string {
+	return fmt.Sprintf("%s-proxy-ca", addonName)
+}
+
+func proxyCABundleConfigMapDataKey() string {
+	return "ca-bundle.crt"
+}
+
+func proxyCABundleFilePath() string {
+	return path.Join(proxyCABundleConfigMapMountPath(), proxyCABundleConfigMapDataKey())
 }

--- a/pkg/addon/templateagent/decorator_test.go
+++ b/pkg/addon/templateagent/decorator_test.go
@@ -1,6 +1,7 @@
 package templateagent
 
 import (
+	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -8,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
@@ -244,7 +246,9 @@ func TestProxyDecorator(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			d := newProxyHandler("addon1", values)
+			ctx := context.TODO()
+			logger := klog.FromContext(ctx)
+			d := newProxyHandler(logger, "addon1", values)
 			err = d.decorate(tc.pod)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/addon/templateagent/decorator_test.go
+++ b/pkg/addon/templateagent/decorator_test.go
@@ -244,7 +244,7 @@ func TestProxyDecorator(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			d := newProxyDecorator(values)
+			d := newProxyHandler("addon1", values)
 			err = d.decorate(tc.pod)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/addon/templateagent/template_agent.go
+++ b/pkg/addon/templateagent/template_agent.go
@@ -202,8 +202,8 @@ func (a *CRDTemplateAgentAddon) decorateObject(
 	orderedValues orderedValues,
 	privateValues addonfactory.Values) (*unstructured.Unstructured, error) {
 	decorators := []decorator{
-		newDeploymentDecorator(a.addonName, template, orderedValues, privateValues),
-		newDaemonSetDecorator(a.addonName, template, orderedValues, privateValues),
+		newDeploymentDecorator(a.logger, a.addonName, template, orderedValues, privateValues),
+		newDaemonSetDecorator(a.logger, a.addonName, template, orderedValues, privateValues),
 		newNamespaceDecorator(privateValues),
 	}
 
@@ -223,7 +223,7 @@ func (a *CRDTemplateAgentAddon) injectAdditionalObjects(
 	orderedValues orderedValues,
 	privateValues addonfactory.Values) ([]runtime.Object, error) {
 	injectors := []objectsInjector{
-		newProxyHandler(a.addonName, privateValues),
+		newProxyHandler(a.logger, a.addonName, privateValues),
 	}
 
 	decorators := []decorator{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is a follow-up of PR https://github.com/open-cluster-management-io/ocm/pull/760, in this PR, it will handle the ca bundle for proxy config, a configmap containing the ca bundle will be created and mounted to the agent deployments/daemonsets. and the mounted ca bundle file path will be injected as the environment `CA_BUNDLE_FILE_PATH` to the deployments/daemonsets. Addon developers can use the environment to get the ca bundle data.

## Related issue(s)

https://github.com/open-cluster-management-io/ocm/issues/761

Fixes #