### PR TITLE
🐛 Only enable auth driver when type is irsa

### DIFF
--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -108,14 +108,12 @@ spec:
           {{if .AppliedManifestWorkEvictionGracePeriod}}
           - "--appliedmanifestwork-eviction-grace-period={{ .AppliedManifestWorkEvictionGracePeriod }}"
           {{end}}
-          {{if and .RegistrationDriver .RegistrationDriver.AuthType}}
-          - "--registration-auth={{ .RegistrationDriver.AuthType }}"
           {{if eq .RegistrationDriver.AuthType "awsirsa"}}
+          - "--registration-auth={{ .RegistrationDriver.AuthType }}"
           - "--hub-cluster-arn={{ .RegistrationDriver.AwsIrsa.HubClusterArn }}"
           - "--managed-cluster-arn={{ .RegistrationDriver.AwsIrsa.ManagedClusterArn }}"
           {{if .ManagedClusterRoleSuffix}}
           - "--managed-cluster-role-suffix={{ .ManagedClusterRoleSuffix }}"
-          {{end}}
           {{end}}
           {{end}}
         env:

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -94,14 +94,12 @@ spec:
           {{if gt .RegistrationKubeAPIBurst 0}}
           - "--kube-api-burst={{ .RegistrationKubeAPIBurst }}"
           {{end}}
-          {{if and .RegistrationDriver .RegistrationDriver.AuthType}}
-          - "--registration-auth={{ .RegistrationDriver.AuthType }}"
           {{if eq .RegistrationDriver.AuthType "awsirsa"}}
+          - "--registration-auth={{ .RegistrationDriver.AuthType }}"
           - "--hub-cluster-arn={{ .RegistrationDriver.AwsIrsa.HubClusterArn }}"
           - "--managed-cluster-arn={{ .RegistrationDriver.AwsIrsa.ManagedClusterArn }}"
           {{if .ManagedClusterRoleSuffix}}
           - "--managed-cluster-role-suffix={{ .ManagedClusterRoleSuffix }}"
-          {{end}}
           {{end}}
           {{end}}
         env:


### PR DESCRIPTION
This is to ensure during upgrade scenario, the new operator can still start the old version of the agent.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #