### PR TITLE
✨ Mount the awscli volume when using AWS IRSA-based authentication.

### DIFF
--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -121,6 +121,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+          - name: PATH
+            value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/awscli/dist
+          {{end}}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -148,6 +152,8 @@ spec:
         {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
         - name: dot-aws
           mountPath: /.aws
+        - name: awscli
+          mountPath: "/awscli"
         {{end}}
         {{if eq .InstallMode "SingletonHosted"}}
         - name: spoke-kubeconfig-secret
@@ -180,6 +186,19 @@ spec:
         resources:
           {{ .ResourceRequirements | indent 10 }}
         {{- end }}
+      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      initContainers:
+      - command:
+          - cp
+          - -vr
+          - /usr/local/aws-cli/v2/current/dist
+          - /awscli
+        image: amazon/aws-cli:latest
+        name: load-awscli
+        volumeMounts:
+          - mountPath: /awscli
+            name: awscli
+      {{end}}
       {{- if .PriorityClassName }}
       priorityClassName: "{{ .PriorityClassName }}"
       {{- end }}
@@ -202,6 +221,8 @@ spec:
         emptyDir: { }
       {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
       - name: dot-aws
+        emptyDir: { }
+      - name: awscli
         emptyDir: { }
       {{end}}
       {{if eq .InstallMode "SingletonHosted"}}

--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -121,7 +121,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+          {{if eq .RegistrationDriver.AuthType "awsirsa"}}
           - name: PATH
             value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/awscli/dist
           {{end}}
@@ -149,7 +149,7 @@ spec:
           mountPath: "/spoke/hub-kubeconfig"
         - name: tmpdir
           mountPath: /tmp
-        {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+        {{if eq .RegistrationDriver.AuthType "awsirsa"}}
         - name: dot-aws
           mountPath: /.aws
         - name: awscli
@@ -186,7 +186,7 @@ spec:
         resources:
           {{ .ResourceRequirements | indent 10 }}
         {{- end }}
-      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      {{if eq .RegistrationDriver.AuthType "awsirsa"}}
       initContainers:
       - command:
           - cp
@@ -219,7 +219,7 @@ spec:
           medium: Memory
       - name: tmpdir
         emptyDir: { }
-      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      {{if eq .RegistrationDriver.AuthType "awsirsa"}}
       - name: dot-aws
         emptyDir: { }
       - name: awscli

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -107,6 +107,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+          - name: PATH
+            value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/awscli/dist
+          {{end}}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -134,6 +138,8 @@ spec:
         {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
         - name: dot-aws
           mountPath: /.aws
+        - name: awscli
+          mountPath: "/awscli"
         {{end}}
         {{if eq .InstallMode "Hosted"}}
         - name: spoke-kubeconfig-secret
@@ -166,6 +172,19 @@ spec:
         resources:
           {{ .ResourceRequirements | indent 10 }}
         {{- end }}
+      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      initContainers:
+        - command:
+            - cp
+            - -vr
+            - /usr/local/aws-cli/v2/current/dist
+            - /awscli
+          image: amazon/aws-cli:latest
+          name: load-awscli
+          volumeMounts:
+            - mountPath: /awscli
+              name: awscli
+      {{end}}
       {{- if .PriorityClassName }}
       priorityClassName: "{{ .PriorityClassName }}"
       {{- end }}
@@ -188,6 +207,8 @@ spec:
         emptyDir: { }
       {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
       - name: dot-aws
+        emptyDir: { }
+      - name: awscli
         emptyDir: { }
       {{end}}
       {{if eq .InstallMode "Hosted"}}

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -107,7 +107,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+          {{if eq .RegistrationDriver.AuthType "awsirsa"}}
           - name: PATH
             value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/awscli/dist
           {{end}}
@@ -135,7 +135,7 @@ spec:
           mountPath: "/spoke/hub-kubeconfig"
         - name: tmpdir
           mountPath: /tmp
-        {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+        {{if eq .RegistrationDriver.AuthType "awsirsa"}}
         - name: dot-aws
           mountPath: /.aws
         - name: awscli
@@ -172,7 +172,7 @@ spec:
         resources:
           {{ .ResourceRequirements | indent 10 }}
         {{- end }}
-      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      {{if eq .RegistrationDriver.AuthType "awsirsa"}}
       initContainers:
         - command:
             - cp
@@ -205,7 +205,7 @@ spec:
           medium: Memory
       - name: tmpdir
         emptyDir: { }
-      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      {{if eq .RegistrationDriver.AuthType "awsirsa"}}
       - name: dot-aws
         emptyDir: { }
       - name: awscli

--- a/manifests/klusterlet/management/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-deployment.yaml
@@ -92,7 +92,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+          {{if eq .RegistrationDriver.AuthType "awsirsa"}}
           - name: PATH
             value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/awscli/dist
           {{end}}
@@ -110,7 +110,7 @@ spec:
           readOnly: true
         - name: tmpdir
           mountPath: /tmp
-        {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+        {{if eq .RegistrationDriver.AuthType "awsirsa"}}
         - name: dot-aws
           mountPath: /.aws
         - name: awscli
@@ -147,7 +147,7 @@ spec:
         resources:
           {{ .ResourceRequirements | indent 10 }}
         {{- end }}
-      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      {{if eq .RegistrationDriver.AuthType "awsirsa"}}
       initContainers:
         - command:
             - cp
@@ -169,7 +169,7 @@ spec:
           secretName: {{ .HubKubeConfigSecret }}
       - name: tmpdir
         emptyDir: { }
-      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      {{if eq .RegistrationDriver.AuthType "awsirsa"}}
       - name: dot-aws
         emptyDir: { }
       - name: awscli

--- a/manifests/klusterlet/management/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-deployment.yaml
@@ -92,6 +92,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+          - name: PATH
+            value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/awscli/dist
+          {{end}}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -109,6 +113,8 @@ spec:
         {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
         - name: dot-aws
           mountPath: /.aws
+        - name: awscli
+          mountPath: "/awscli"
         {{end}}
         {{if eq .InstallMode "Hosted"}}
         - name: spoke-kubeconfig-secret
@@ -141,6 +147,19 @@ spec:
         resources:
           {{ .ResourceRequirements | indent 10 }}
         {{- end }}
+      {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
+      initContainers:
+        - command:
+            - cp
+            - -vr
+            - /usr/local/aws-cli/v2/current/dist
+            - /awscli
+          image: amazon/aws-cli:latest
+          name: load-awscli
+          volumeMounts:
+            - mountPath: /awscli
+              name: awscli
+      {{end}}
       {{- if .PriorityClassName }}
       priorityClassName: "{{ .PriorityClassName }}"
       {{- end }}
@@ -152,6 +171,8 @@ spec:
         emptyDir: { }
       {{if and .RegistrationDriver .RegistrationDriver.AuthType (eq .RegistrationDriver.AuthType "awsirsa")}}
       - name: dot-aws
+        emptyDir: { }
+      - name: awscli
         emptyDir: { }
       {{end}}
       {{if eq .InstallMode "Hosted"}}

--- a/test/integration/util/aws.go
+++ b/test/integration/util/aws.go
@@ -16,12 +16,15 @@ const (
 
 func AwsCliSpecificVolumesMounted(deployment v1.Deployment) bool {
 	isDotAwsMounted := false
+	isAwsCliMounted := false
 	for _, volumeMount := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
 		if volumeMount.Name == "dot-aws" && volumeMount.MountPath == "/.aws" {
 			isDotAwsMounted = true
+		} else if volumeMount.Name == "awscli" && volumeMount.MountPath == "/awscli" {
+			isAwsCliMounted = true
 		}
 	}
-	return isDotAwsMounted
+	return isDotAwsMounted && isAwsCliMounted
 }
 
 func AllCommandLineOptionsPresent(deployment v1.Deployment) bool {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Add an initContainer to the Klusterlet deployment manifests and mount the awscli volume when using AWS IRSA-based authentication.
Update the test util function to check for both .aws and /awscli volume mounts.

## Related issue(s)

Fixes # https://github.com/open-cluster-management-io/ocm/issues/514