### PR TITLE
:seedling: use images overrides in operator deploy

### DIFF
--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -21,7 +21,7 @@ hub-kubeconfig:
 deploy-hub: deploy-hub-helm hub-kubeconfig cluster-ip
 
 deploy-hub-helm: ensure-helm
-	$(HELM) install cluster-manager deploy/cluster-manager/chart/cluster-manager --namespace=open-cluster-management --create-namespace --set images.registry=$(IMAGE_REGISTRY),images.tag=$(IMAGE_TAG)
+	$(HELM) install cluster-manager deploy/cluster-manager/chart/cluster-manager --namespace=open-cluster-management --create-namespace --set images.overrides.operatorImage=$(OPERATOR_IMAGE_NAME),images.overrides.registrationImage=$(REGISTRATION_IMAGE),images.overrides.workImage=$(WORK_IMAGE),images.overrides.placementImage=$(PLACEMENT_IMAGE),images.overrides.addOnManagerImage=$(ADDON_MANAGER_IMAGE)
 
 deploy-hub-operator: ensure-kustomize
 	cp deploy/cluster-manager/config/kustomization.yaml deploy/cluster-manager/config/kustomization.yaml.tmp
@@ -56,7 +56,7 @@ bootstrap-secret:
 	$(KUSTOMIZE) build deploy/klusterlet/config/samples/bootstrap | $(KUBECTL) apply -f -
 
 deploy-spoke-operator-helm: ensure-helm
-	$(HELM) install klusterlet deploy/klusterlet/chart/klusterlet --namespace=open-cluster-management --set klusterlet.create=false,images.registry=$(IMAGE_REGISTRY),images.tag=$(IMAGE_TAG) --set-file bootstrapHubKubeConfig=$(HUB_KUBECONFIG)
+	$(HELM) install klusterlet deploy/klusterlet/chart/klusterlet --namespace=open-cluster-management --set-file bootstrapHubKubeConfig=$(HUB_KUBECONFIG) --set klusterlet.create=false,images.overrides.operatorImage=$(OPERATOR_IMAGE_NAME),images.overrides.registrationImage=$(REGISTRATION_IMAGE),images.overrides.workImage=$(WORK_IMAGE)
 
 deploy-spoke-operator: ensure-kustomize
 	cp deploy/klusterlet/config/kustomization.yaml deploy/klusterlet/config/kustomization.yaml.tmp


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The two makefile commands are used in e2e tests, but in some case, the image name will be overrode by the temp names. 
So here use the override images directly .

## Related issue(s)

Fixes #