### PR TITLE
:sparkles: Adding Guidewire team members to registration owners

### DIFF
--- a/pkg/registration/OWNERS
+++ b/pkg/registration/OWNERS
@@ -2,9 +2,19 @@ approvers:
 - elgnay
 - skeeey
 - xuezhaojun
+- jaswalkiranavtar
+- suvaanshkumar
+- ramekris3163
+- amrcoder
+- jeffw17
 
 reviewers:
 - elgnay
 - skeeey
 - ldpliu
 - xuezhaojun
+- jaswalkiranavtar
+- suvaanshkumar
+- ramekris3163
+- amrcoder
+- jeffw17

--- a/pkg/registration/OWNERS
+++ b/pkg/registration/OWNERS
@@ -4,9 +4,7 @@ approvers:
 - xuezhaojun
 - jaswalkiranavtar
 - suvaanshkumar
-- ramekris3163
 - amrcoder
-- jeffw17
 
 reviewers:
 - elgnay
@@ -15,6 +13,4 @@ reviewers:
 - xuezhaojun
 - jaswalkiranavtar
 - suvaanshkumar
-- ramekris3163
 - amrcoder
-- jeffw17


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Making guidewire members owner of aws registration

## Related issue(s)
https://github.com/open-cluster-management-io/ocm/issues/514

Fixes #