### PR TITLE
:bug: set empty nodeselect to nil

### DIFF
--- a/pkg/operator/helpers/chart/config.go
+++ b/pkg/operator/helpers/chart/config.go
@@ -20,7 +20,7 @@ type ClusterManagerChartConfig struct {
 	// Resources is the resource requirements of the operator deployment
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// NodeSelector is the nodeSelector of the operator deployment
-	NodeSelector corev1.NodeSelector `json:"nodeSelector,omitempty"`
+	NodeSelector *corev1.NodeSelector `json:"nodeSelector,omitempty"`
 	// Tolerations is the tolerations of the operator deployment
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// Affinity is the affinity of the operator deployment
@@ -47,7 +47,7 @@ type KlusterletChartConfig struct {
 	// Resources is the resource requirements of the operator deployment
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// NodeSelector is the nodeSelector of the operator deployment
-	NodeSelector corev1.NodeSelector `json:"nodeSelector,omitempty"`
+	NodeSelector *corev1.NodeSelector `json:"nodeSelector,omitempty"`
 	// Tolerations is the tolerations of the operator deployment
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// Affinity is the affinity of the operator deployment


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the operator pod is pending because these fields are append to the deployment when nodeSelector is empty.
```
     nodeSelector:
        nodeSelectorTerms: ""
```

set nodeSelector to pointer, the fields will not be initialised if empty. 
## Related issue(s)

Fixes #