### PR TITLE
:sparkles: Removing manual step to generate the hub kube config secret

### DIFF
--- a/solutions/joining-hub-and-spoke-with-aws-auth-manually/README.md
+++ b/solutions/joining-hub-and-spoke-with-aws-auth-manually/README.md
@@ -152,34 +152,4 @@ While the implementation of this feature is in progress, in the hub and spoke si
    aws eks create-access-entry --cluster-name $HUB_CLUSTER_NAME --region=$HUB_REGION --principal-arn arn:aws:iam::"$HUB_ACCOUNT_ID":role/$HUB_ROLE_NAME --username $SPOKE_CLUSTER_NAME --kubernetes-groups open-cluster-management:$SPOKE_CLUSTER_NAME
    aws eks list-access-entries --cluster $HUB_CLUSTER_NAME --region=$HUB_REGION | grep -i $HUB_ROLE_NAME
    ```
-
-9. Generate the secret called `hub-kubeconfig-secret` in `open-cluster-management-agent` namespace using above kubeconfig:
-   ```shell
-   aws eks update-kubeconfig --name $HUB_CLUSTER_NAME --kubeconfig /awscli/kubeconfig.kubeconfig --role-arn arn:aws:iam::"$HUB_ACCOUNT_ID":role/$HUB_ROLE_NAME --dry-run > hub-kubeconfig
-   
-    # Updating the clusterName to "hub" to make it same as bootstrap-kubeconfig
-   # to pass a validation in ocm. Install yq, if missing.
-   # Note - The yq command works only on a Linux machine. Please use a text editor to manually replace the values otherwise.
-   NEW_CLUSTER_NAME="hub"
-   yq eval "
-   (.clusters[].name = \"${NEW_CLUSTER_NAME}\") |
-   (.contexts[].context.cluster = \"${NEW_CLUSTER_NAME}\") |
-   del(.users[].user.exec.env)
-   " -i "hub-kubeconfig"
-
-   HUB_KUBECONFIG=$(cat hub-kubeconfig)
-
-   AGENT_NAME_ENCODED=$(kubectl get klusterlet klusterlet -o jsonpath='{.metadata.uid}' | tr -d '\n' | base64 | tr -d '\n')
-   SPOKE_CLUSTER_NAME_ENCODED=$(echo -n "$SPOKE_CLUSTER_NAME" | base64 | tr -d '\n')
-   HUB_KUBECONFIG_ENCODED=$(echo -n "$HUB_KUBECONFIG" | base64 | tr -d '\n')
-   HUB_KUBECONFIG_ENCODED_ESCAPED=$(printf '%s' "$HUB_KUBECONFIG_ENCODED" | sed 's/[&/\|]/\\&/g')
-   
-   sed -e "s|\${AGENT_NAME_ENCODED}|$AGENT_NAME_ENCODED|g" \
-       -e "s|\${SPOKE_CLUSTER_NAME_ENCODED}|$SPOKE_CLUSTER_NAME_ENCODED|g" \
-       -e "s|\${HUB_KUBECONFIG_ENCODED}|$HUB_KUBECONFIG_ENCODED_ESCAPED|g" \
-       templates/Template-hub-kubeconfig-secret.yaml > hubKubeconfigSecret.yaml
-       
-   kubectl apply -f hubKubeconfigSecret.yaml
-   ```
-
-10. Create a sample manifestwork in hub. Confirm that resources are pushed to spoke.
+9. Create a sample manifestwork in hub. Confirm that resources are pushed to spoke.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Removing manual step to generate the hub kube config secret
## Related issue(s)

Fixes # [GWCP-65928](https://guidewirejira.atlassian.net/browse/GWCP-65928)