### PR TITLE
 🌱 Requeue importer when secret is not found

### DIFF
--- a/pkg/registration/hub/importer/providers/capi/provider.go
+++ b/pkg/registration/hub/importer/providers/capi/provider.go
@@ -24,6 +24,7 @@ import (
 	clusterinformerv1 "open-cluster-management.io/api/client/cluster/informers/externalversions/cluster/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
+	"open-cluster-management.io/ocm/pkg/common/helpers"
 	"open-cluster-management.io/ocm/pkg/registration/hub/importer/providers"
 )
 
@@ -100,7 +101,7 @@ func (c *CAPIProvider) Clients(ctx context.Context, cluster *clusterv1.ManagedCl
 	case apierrors.IsNotFound(err):
 		logger.V(4).Info(
 			"kubeconfig secret is not found", "name", name+"-kubeconfig", "namespace", namespace)
-		return nil, nil
+		return nil, helpers.NewRequeueError("kubeconfig secret is not found", 1*time.Minute)
 	case err != nil:
 		return nil, err
 	}

--- a/pkg/registration/hub/importer/providers/capi/provider_test.go
+++ b/pkg/registration/hub/importer/providers/capi/provider_test.go
@@ -98,7 +98,7 @@ func TestClients(t *testing.T) {
 			cluster: &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster1"}},
 		},
 		{
-			name:    "capi cluster not provisionde",
+			name:    "capi cluster not provisioned",
 			cluster: &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster1"}},
 			capiObjects: []runtime.Object{
 				testingcommon.NewUnstructuredWithContent("cluster.x-k8s.io/v1beta1", "Cluster", "cluster1", "cluster1",
@@ -114,8 +114,15 @@ func TestClients(t *testing.T) {
 			name:    "secret not found",
 			cluster: &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster1"}},
 			capiObjects: []runtime.Object{
-				testingcommon.NewUnstructured(
-					"cluster.x-k8s.io/v1beta1", "Cluster", "cluster1", "cluster1")},
+				testingcommon.NewUnstructuredWithContent("cluster.x-k8s.io/v1beta1", "Cluster", "cluster1", "cluster1",
+					map[string]interface{}{
+						"status": map[string]interface{}{
+							"phase": "Provisioned",
+						},
+					},
+				),
+			},
+			expectErr: true,
 		},
 		{
 			name:    "secret found with invalid key",


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

requeue when the kubeconfig secret is not found. We cannot ensure that we always can get secret when capi cluster is in provisioned state.

## Related issue(s)

Fixes #