### PR TITLE
🐛 Change the component name to klusterlet-agent

### DIFF
--- a/pkg/cmd/spoke/operator.go
+++ b/pkg/cmd/spoke/operator.go
@@ -62,7 +62,7 @@ func NewKlusterletAgentCmd() *cobra.Command {
 
 	agentConfig := singletonspoke.NewAgentConfig(commonOptions, registrationOption, workOptions, cancel)
 	cmdConfig := commonOptions.CommonOpts.
-		NewControllerCommandConfig("klusterlet", version.Get(), agentConfig.RunSpokeAgent).
+		NewControllerCommandConfig("klusterlet-agent", version.Get(), agentConfig.RunSpokeAgent).
 		WithHealthChecks(agentConfig.HealthCheckers()...)
 	cmd := cmdConfig.NewCommandWithContext(ctx)
 	cmd.Use = agentCmdName

--- a/pkg/registration/hub/importer/renderers.go
+++ b/pkg/registration/hub/importer/renderers.go
@@ -33,8 +33,8 @@ func RenderBootstrapHubKubeConfig(
 			ServiceAccounts(bootstrapSANamespace).
 			CreateToken(ctx, bootstrapSAName, &authv1.TokenRequest{
 				Spec: authv1.TokenRequestSpec{
-					// token expired in 1 hour
-					ExpirationSeconds: ptr.To[int64](3600),
+					// token expired in 24 hours
+					ExpirationSeconds: ptr.To[int64](24 * 3600),
 				},
 			}, metav1.CreateOptions{})
 		if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

when operator and agent run in the same namespace, they should use the different lease name.
## Related issue(s)

Fixes #