### PR TITLE
:bug: fix gc controller not handle empty cluster

### DIFF
--- a/pkg/registration/hub/gc/controller_test.go
+++ b/pkg/registration/hub/gc/controller_test.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeinformers "k8s.io/client-go/informers"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	fakemetadataclient "k8s.io/client-go/metadata/fake"
+	clienttesting "k8s.io/client-go/testing"
 
 	fakeclusterclient "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
 	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
@@ -27,29 +29,45 @@ import (
 
 func TestGController(t *testing.T) {
 	cases := []struct {
-		name        string
-		key         string
-		cluster     *clusterv1.ManagedCluster
-		expectedErr string
+		name            string
+		key             string
+		cluster         *clusterv1.ManagedCluster
+		namespace       *corev1.Namespace
+		expectedErr     string
+		validateActions func(t *testing.T, clusterActions []clienttesting.Action)
 	}{
 		{
 			name:        "invalid key",
 			key:         factory.DefaultQueueKey,
 			cluster:     testinghelpers.NewDeletingManagedCluster(),
 			expectedErr: "",
+			validateActions: func(t *testing.T, clusterActions []clienttesting.Action) {
+				testingcommon.AssertNoActions(t, clusterActions)
+			},
 		},
 		{
-			name:        "valid key",
+			name:        "valid key with cluster",
 			key:         testinghelpers.TestManagedClusterName,
 			cluster:     testinghelpers.NewDeletingManagedCluster(),
 			expectedErr: "",
+			validateActions: func(t *testing.T, clusterActions []clienttesting.Action) {
+				testingcommon.AssertActions(t, clusterActions, "patch", "patch")
+			},
+		},
+		{
+			name:        "valid key with no cluster ",
+			key:         "cluster1",
+			cluster:     testinghelpers.NewDeletingManagedCluster(),
+			expectedErr: "",
+			validateActions: func(t *testing.T, clusterActions []clienttesting.Action) {
+				testingcommon.AssertNoActions(t, clusterActions)
+			},
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			kubeClient := fakeclient.NewSimpleClientset()
 			kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Minute*10)
-
 			metadataClient := fakemetadataclient.NewSimpleMetadataClient(scheme.Scheme)
 
 			clusterClient := fakeclusterclient.NewSimpleClientset(c.cluster)
@@ -66,7 +84,6 @@ func TestGController(t *testing.T) {
 
 			_ = NewGCController(
 				kubeInformerFactory.Rbac().V1().ClusterRoles().Lister(),
-				kubeInformerFactory.Rbac().V1().ClusterRoleBindings().Lister(),
 				kubeInformerFactory.Rbac().V1().RoleBindings().Lister(),
 				clusterInformerFactory.Cluster().V1().ManagedClusters(),
 				workInformerFactory.Work().V1().ManifestWorks().Lister(),
@@ -79,7 +96,12 @@ func TestGController(t *testing.T) {
 					"work.open-cluster-management.io/v1/manifestworks"},
 				true,
 			)
-
+			namespaceStore := kubeInformerFactory.Core().V1().Namespaces().Informer().GetStore()
+			if c.namespace != nil {
+				if err := namespaceStore.Add(c.namespace); err != nil {
+					t.Fatal(err)
+				}
+			}
 			clusterPatcher := patcher.NewPatcher[
 				*clusterv1.ManagedCluster, clusterv1.ManagedClusterSpec, clusterv1.ManagedClusterStatus](
 				clusterClient.ClusterV1().ManagedClusters())
@@ -91,9 +113,7 @@ func TestGController(t *testing.T) {
 					newGCResourcesController(metadataClient, []schema.GroupVersionResource{addonGvr, workGvr},
 						events.NewInMemoryRecorder("")),
 					newGCClusterRbacController(kubeClient, clusterPatcher,
-						clusterInformerFactory.Cluster().V1().ManagedClusters(),
 						kubeInformerFactory.Rbac().V1().ClusterRoles().Lister(),
-						kubeInformerFactory.Rbac().V1().ClusterRoleBindings().Lister(),
 						kubeInformerFactory.Rbac().V1().RoleBindings().Lister(),
 						workInformerFactory.Work().V1().ManifestWorks().Lister(),
 						register.NewNoopApprover(),
@@ -105,6 +125,7 @@ func TestGController(t *testing.T) {
 			controllerContext := testingcommon.NewFakeSyncContext(t, c.key)
 			err := ctrl.sync(context.TODO(), controllerContext)
 			testingcommon.AssertError(t, err, c.expectedErr)
+			c.validateActions(t, clusterClient.Actions())
 		})
 	}
 }

--- a/pkg/registration/hub/manager.go
+++ b/pkg/registration/hub/manager.go
@@ -272,7 +272,6 @@ func (m *HubManagerOptions) RunControllerManagerWithInformers(
 
 	gcController := gc.NewGCController(
 		kubeInformers.Rbac().V1().ClusterRoles().Lister(),
-		kubeInformers.Rbac().V1().ClusterRoleBindings().Lister(),
 		kubeInformers.Rbac().V1().RoleBindings().Lister(),
 		clusterInformers.Cluster().V1().ManagedClusters(),
 		workInformers.Work().V1().ManifestWorks().Lister(),


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the gc controller returned when cluster is empty, and the work rolebinding is left over.
this PR will handle the case that cluster is empty in gc controller.

## Related issue(s)

Fixes #