### PR TITLE
🐛 Apply ownerref eventhough other field is ignored

### DIFF
--- a/pkg/work/spoke/apply/server_side_apply.go
+++ b/pkg/work/spoke/apply/server_side_apply.go
@@ -103,7 +103,9 @@ func (c *ServerSideApply) Apply(
 			// skip the apply operation when the hash of the existing resource matches the required hash
 			existingHash := existing.GetAnnotations()[workapiv1.ManifestConfigSpecHashAnnotationKey]
 			if requiredHash == existingHash {
-				return existing, nil
+				// still needs to apply ownerref since it might be changed due to deleteoption update.
+				err := helper.ApplyOwnerReferences(ctx, c.client, gvr, existing, owner)
+				return existing, err
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

there is a chance that owner ref apply is skipped when ignoreFields is set, which results in flaky e2e test.

## Related issue(s)

Fixes #