### PR TITLE
:sparkles: Adding Guidewire team members to registration owners

### DIFF
--- a/pkg/registration/OWNERS
+++ b/pkg/registration/OWNERS
@@ -3,8 +3,6 @@ approvers:
 - skeeey
 - xuezhaojun
 - jaswalkiranavtar
-- suvaanshkumar
-- amrcoder
 
 reviewers:
 - elgnay
@@ -12,5 +10,3 @@ reviewers:
 - ldpliu
 - xuezhaojun
 - jaswalkiranavtar
-- suvaanshkumar
-- amrcoder

--- a/pkg/registration/register/aws_irsa/OWNERS
+++ b/pkg/registration/register/aws_irsa/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- amrcoder
+- jeffw17
+- ramekris3163
+- suvaanshkumar
+
+reviewers:
+- amrcoder
+- jeffw17
+- ramekris3163
+- suvaanshkumar


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Making guidewire members owner of aws registration

## Related issue(s)

Ref # https://github.com/open-cluster-management-io/ocm/issues/514