### PR TITLE
:seedling: chore: e2e hosted and singleton should not be run on DOC-ONLY changes

### DIFF
--- a/.github/workflows/doc-only.yml
+++ b/.github/workflows/doc-only.yml
@@ -45,3 +45,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Not required"'
+  e2e-hosted:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required"'
+  e2e-singleton:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required"'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
e2e hosted and singleton GitHub workflow should not be run on DOC-ONLY changes


## Related issue(s)

Fixes NA