### PR TITLE
:bug: ARN pattern should be comma separated string instead of a string enclosed in square brackets

### DIFF
--- a/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
@@ -59,7 +59,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/open-cluster-management/registration-operator:latest
-    createdAt: "2025-01-16T23:45:52Z"
+    createdAt: "2025-03-05T16:39:23Z"
     description: Manages the installation and upgrade of the ClusterManager.
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/deploy/cluster-manager/olm-catalog/latest/manifests/operator.open-cluster-management.io_clustermanagers.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/operator.open-cluster-management.io_clustermanagers.yaml
@@ -269,6 +269,13 @@ spec:
                           - csr
                           - awsirsa
                           type: string
+                        autoApprovedIdentities:
+                          description: |-
+                            For csr authentication type, AutoApprovedIdentities represent a list of approved users
+                            For awsirsa authentication type, AutoApprovedIdentities represent a list of approved arn patterns
+                          items:
+                            type: string
+                          type: array
                         hubClusterArn:
                           description: |-
                             This represents the hub cluster ARN

--- a/deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/open-cluster-management/registration-operator:latest
-    createdAt: "2025-01-20T02:57:55Z"
+    createdAt: "2025-03-05T16:39:23Z"
     description: Manages the installation and upgrade of the Klusterlet.
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -36,7 +36,7 @@ type HubConfig struct {
 	HubClusterArn                     string
 	EnabledRegistrationDrivers        string
 	AutoApprovedCSRUsers              []string
-	AutoApprovedARNPatterns           []string
+	AutoApprovedARNPatterns           string
 }
 
 type Webhook struct {

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_runtime_reconcile.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_runtime_reconcile.go
@@ -79,7 +79,10 @@ func (c *runtimeReconcile) reconcile(ctx context.Context, cm *operatorapiv1.Clus
 			enabledRegistrationDrivers = append(enabledRegistrationDrivers, registrationDriver.AuthType)
 			if registrationDriver.AuthType == "awsirsa" {
 				config.HubClusterArn = registrationDriver.HubClusterArn
-				config.AutoApprovedARNPatterns = registrationDriver.AutoApprovedIdentities
+				var AutoApprovedIdentities = registrationDriver.AutoApprovedIdentities
+				if AutoApprovedIdentities != nil {
+					config.AutoApprovedARNPatterns = strings.Join(AutoApprovedIdentities, ",")
+				}
 			} else if registrationDriver.AuthType == "csr" {
 				config.AutoApprovedCSRUsers = registrationDriver.AutoApprovedIdentities
 			}

--- a/test/integration/operator/clustermanager_aws_test.go
+++ b/test/integration/operator/clustermanager_aws_test.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -42,8 +44,9 @@ var _ = ginkgo.Describe("ClusterManager Default Mode with aws registration", fun
 					clusterManager.Spec.RegistrationConfiguration = &operatorapiv1.RegistrationHubConfiguration{}
 					clusterManager.Spec.RegistrationConfiguration.RegistrationDrivers = []operatorapiv1.RegistrationDriverHub{
 						{
-							AuthType:      "awsirsa",
-							HubClusterArn: "arn:aws:eks:us-west-2:123456789012:cluster/hub-cluster",
+							AuthType:               "awsirsa",
+							HubClusterArn:          "arn:aws:eks:us-west-2:123456789012:cluster/hub-cluster",
+							AutoApprovedIdentities: []string{"arn:aws:eks:us-west-2:123456789013:cluster/.*", "arn:aws:eks:us-west-2:123456789012:cluster/.*"},
 						},
 					}
 				}
@@ -77,5 +80,27 @@ var _ = ginkgo.Describe("ClusterManager Default Mode with aws registration", fun
 				return annotation == "arn:aws:iam::123456789012:role/hub-cluster_managed-cluster-identity-creator"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 		})
+		ginkgo.It("should have auto approved arn patterns separated by comma with awsirsa", func() {
+			gomega.Eventually(func() bool {
+				registrationControllerDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).
+					Get(context.Background(), fmt.Sprintf("%s-registration-controller", clusterManagerName), metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				commandLineArgs := registrationControllerDeployment.Spec.Template.Spec.Containers[0].Args
+				autoApprovedArnPatterns, present := findMatchingArg(commandLineArgs, "--auto-approved-arn-patterns")
+				return present && strings.SplitN(autoApprovedArnPatterns, "=", 2)[1] ==
+					"arn:aws:eks:us-west-2:123456789013:cluster/.*,arn:aws:eks:us-west-2:123456789012:cluster/.*"
+			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+		})
 	})
 })
+
+func findMatchingArg(args []string, pattern string) (string, bool) {
+	for _, commandLineArg := range args {
+		if strings.Contains(commandLineArg, pattern) {
+			return commandLineArg, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
We are using StringSliceVar type to store AutoApprovedARNPatterns [here](https://github.com/open-cluster-management-io/ocm/blob/main/pkg/registration/hub/manager.go#L87).

Hence, cluster-manager-operator should convert the [array](https://github.com/open-cluster-management-io/ocm/blob/main/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_runtime_reconcile.go#L82) into comma separated list of ARN patterns, as that is what registration-controller binary will accept. 

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/ocm/issues/514