### PR TITLE
:book: docs: Argo CD push solution doc clusteradm init command should use the --wait param

### DIFF
--- a/solutions/deploy-argocd-apps/setup-ocm.sh
+++ b/solutions/deploy-argocd-apps/setup-ocm.sh
@@ -15,7 +15,7 @@ kind create cluster --name "${c2}" --config cluster2-config.yaml
 
 kubectl config use ${hubctx}
 echo "Initialize the ocm hub cluster"
-joincmd=$(clusteradm init --use-bootstrap-token | grep clusteradm)
+joincmd=$(clusteradm init --use-bootstrap-token --wait | grep clusteradm)
 
 kubectl config use ${c1ctx}
 echo "Join cluster1 to hub"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Argo CD push solution doc clusteradm init command should use the --wait param.

## Related issue(s)

Fixes #