### PR TITLE
:book: docs: Remove the username and password requirement from Argo CD Agent solution

### DIFF
--- a/solutions/argocd-agent/README.md
+++ b/solutions/argocd-agent/README.md
@@ -150,6 +150,7 @@ Run the following `helm` command:
 ```shell
 helm -n argocd install argocd-agent-addon charts/argocd-agent-addon \
   --set-file agent.secrets.cacrt=/tmp/ca.crt \
+  --set-file agent.secrets.cakey=/tmp/ca.key \
   --set-file agent.secrets.tlscrt=/tmp/tls.crt \
   --set-file agent.secrets.tlskey=/tmp/tls.key \
   --set-file agent.secrets.jwtkey=/tmp/jwt.key \
@@ -196,28 +197,6 @@ argocd-agent-principal   LoadBalancer   10.96.149.226   172.18.255.201   443:321
 
 3. For details on operational modes and guidance on selecting the appropriate `agent.mode` (e.g., `managed` or `autonomous`),
 refer to the [Argo CD Agent website](https://argocd-agent.readthedocs.io/latest/concepts/agent-modes/).
-
-**Important:** 
-The default Argo CD Agent authentication scheme requires a principal user credentials store on the hub cluster
-and corresponding agent authentication credentials (username and password) on the spoke/managed/workload clusters.
-
-By default, the user store includes credentials for users `cluster1` through `cluster10`.
-If your OCM managed cluster name is not in this range or if you want to customize your password,
-you need to modify the following secrets:
-
-```shell
-# kubectl config use-context <hub-cluster>
-kubectl -n open-cluster-management-hub edit secret argocd-agent-principal-userpass 
-```
-
-```shell
-# kubectl config use-context <managed-cluster>
-kubectl -n argocd edit secret argocd-agent-agent-userpass
-```
-
-See [gen-creds.sh](https://github.com/argoproj-labs/argocd-agent/blob/main/hack/demo-env/gen-creds.sh)
-for an example of how to create user credentials.
-
 
 ## Deploying Applications
 


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
docs: Remove the username and password requirement from Argo CD Agent solution

I have a working POC mTLS Argo CD Agent authentication working. Removing the username and password requirement from the Argo CD Agent solution will make it more secure and easier to use.

https://github.com/open-cluster-management-io/addon-contrib/pull/26 will need to be merged first.

/hold

## Related issue(s)

