### PR TITLE
:seedling: support configure multiple hub kubeconfigs in klusterlet chart

### DIFF
--- a/deploy/klusterlet/chart/klusterlet/templates/_helpers.tpl
+++ b/deploy/klusterlet/chart/klusterlet/templates/_helpers.tpl
@@ -43,3 +43,24 @@ Create secret to access docker registry
 {{- printf "%s/registration-operator:%s" .Values.images.registry .Chart.AppVersion }}
 {{- end }}
 {{- end }}
+
+{{- define "agentNamespace" }}
+{{- if .Values.klusterlet.namespace }}
+{{- printf "%s" .Values.klusterlet.namespace }}
+{{- else if  or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "SingletonHosted") }}
+{{- printf "open-cluster-management-%s" .Values.klusterlet.clusterName }}
+{{- else }}
+{{- printf "open-cluster-management-agent" }}
+{{- end }}
+{{- end }}
+
+
+{{- define "klusterletName" }}
+{{- if .Values.klusterlet.name }}
+{{- printf "%s" .Values.klusterlet.name }}
+{{- else if  or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "SingletonHosted") }}
+{{- printf "klusterlet-%s" .Values.klusterlet.clusterName }}
+{{- else }}
+{{- printf "klusterlet" }}
+{{- end }}
+{{- end }}

--- a/deploy/klusterlet/chart/klusterlet/templates/agent-namespace.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/agent-namespace.yaml
@@ -1,12 +1,8 @@
-{{- if or .Values.bootstrapHubKubeConfig .Values.externalManagedKubeConfig }}
+{{- if or .Values.bootstrapHubKubeConfig .Values.externalManagedKubeConfig .Values.multiHubBootstrapHubKubeConfigs }}
 apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
     workload.openshift.io/allowed: "management"
-{{- if or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "HostedSingleton") }}
-  name: "klusterlet-{{ .Values.klusterlet.clusterName }}"
-{{- else }}
-  name: {{ .Values.klusterlet.namespace | default "open-cluster-management-agent" }}
-{{- end }}
+  name: "{{ template "agentNamespace" . }}"
 {{- end }}

--- a/deploy/klusterlet/chart/klusterlet/templates/bootstrap_kubeconfig_secret.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/bootstrap_kubeconfig_secret.yaml
@@ -1,13 +1,24 @@
-{{- if .Values.bootstrapHubKubeConfig }}
+{{- if .Values.multiHubBootstrapHubKubeConfigs }}
+{{- range .Values.multiHubBootstrapHubKubeConfigs }}
+{{- $global := . }}
+{{- $global = merge $global (dict "Release" $.Release) }}
+{{- $global = merge $global (dict "Values" $.Values) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: "{{ template "agentNamespace" $global }}"
+type: Opaque
+data:
+  kubeconfig: "{{ .kubeConfig | b64enc }}"
+{{- end }}
+{{- else if .Values.bootstrapHubKubeConfig }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: bootstrap-hub-kubeconfig
-  {{- if or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "HostedSingleton") }}
-  namespace: "klusterlet-{{ .Values.klusterlet.clusterName }}"
-  {{- else }}
-  namespace: {{ .Values.klusterlet.namespace | default "open-cluster-management-agent" }}
-  {{- end }}
+  namespace: "{{ template "agentNamespace" . }}"
 type: Opaque
 data:
   kubeconfig: "{{ .Values.bootstrapHubKubeConfig | b64enc }}"

--- a/deploy/klusterlet/chart/klusterlet/templates/external_managedcluster-kubeconfig_secret.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/external_managedcluster-kubeconfig_secret.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: external-managed-kubeconfig
-  {{- if or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "HostedSingleton") }}
-  namespace: "klusterlet-{{ .Values.klusterlet.clusterName }}"
-  {{- else }}
-  namespace: {{ .Values.klusterlet.namespace | default "open-cluster-management-agent" }}
-  {{- end }}
+  namespace: "{{ template "agentNamespace" . }}"
 type: Opaque
 data:
   kubeconfig: {{ .Values.externalManagedKubeConfig | b64enc }}

--- a/deploy/klusterlet/chart/klusterlet/templates/klusterlet.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/klusterlet.yaml
@@ -2,11 +2,7 @@
 apiVersion: operator.open-cluster-management.io/v1
 kind: Klusterlet
 metadata:
-  {{- if or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "SingletonHosted") }}
-  name: "klusterlet-{{ .Values.klusterlet.clusterName }}"
-  {{- else }}
-  name: {{ .Values.klusterlet.name | default "klusterlet" }}
-  {{- end }}
+  name: "{{ template "klusterletName" . }}"
 spec:
   deployOption:
     mode: {{ .Values.klusterlet.mode | default "Singleton" }}
@@ -14,11 +10,7 @@ spec:
   workImagePullSpec: "{{ template "workImage" . }}"
   imagePullSpec: "{{ template "operatorImage" . }}"
   clusterName: {{ .Values.klusterlet.clusterName }}
-  {{- if or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "SingletonHosted") }}
-  namespace: "open-cluster-management-{{ .Values.klusterlet.clusterName }}"
-  {{- else }}
-  namespace: {{ .Values.klusterlet.namespace | default "open-cluster-management-agent" }}
-  {{- end }}
+  namespace: "{{ template "agentNamespace" . }}"
   {{- with .Values.klusterlet.externalServerURLs }}
   externalServerURLs:
     {{- toYaml . | nindent 4 }}

--- a/deploy/klusterlet/chart/klusterlet/values.yaml
+++ b/deploy/klusterlet/chart/klusterlet/values.yaml
@@ -78,6 +78,14 @@ enableSyncLabels: false
 # should be the kubeConfig file of the hub cluster via setting --set-file=<the kubeConfig file of hub cluster> optional
 bootstrapHubKubeConfig: ""
 
+# when MultipleHubs feature gate in klusterlet.registrationConfiguration is enabled, could set multiple bootstrap hub kubeConfigs here.
+# otherwise can create these kubeConfig secret in the klusterlet.namespace manually on the managed cluster.
+multiHubBootstrapHubKubeConfigs:
+#  - name: xxx
+#    kubeConfig: xxx
+#  - name: xxx
+#    kubeConfig: xxx
+
 # should be the kubeConfig file of the managed cluster via setting --set-file=<the kubeConfig file of managed cluster>
 # only need to set in the hosted mode. optional
 externalManagedKubeConfig: ""
@@ -93,8 +101,12 @@ klusterlet:
   create: true
   # mode can be Default, Hosted, Singleton or SingletonHosted.
   mode: Singleton
+  # when Default or Singleton mode, the name is klusterlet by default.
+  # when in Hosted or SingletonHosted mode, the name will be klusterlet-<cluster name> if name is empty.
   name: "klusterlet"
   clusterName: cluster1
+  # when Default or Singleton mode, the namespace is open-cluster-management-agent by default.
+  # when in Hosted or SingletonHosted mode, the namespace is open-cluster-management-<cluster name> if namespace is empty.
   namespace: ""
   externalServerURLs: []
 #   - url: ""

--- a/pkg/operator/helpers/chart/config.go
+++ b/pkg/operator/helpers/chart/config.go
@@ -63,12 +63,22 @@ type KlusterletChartConfig struct {
 	// BootstrapHubKubeConfig should be the kubeConfig file of the hub cluster via setting --set-file=<the kubeConfig file of hub cluster> optional
 	BootstrapHubKubeConfig string `json:"bootstrapHubKubeConfig,omitempty"`
 
+	// when MultipleHubs feature gate in klusterlet.registrationConfiguration is enabled, need to set multiple bootstrap hub kubeConfigs here.
+	MultiHubBootstrapHubKubeConfigs []BootStrapKubeConfig `json:"multiHubBootstrapHubKubeConfigs,omitempty"`
+
 	// ExternalManagedKubeConfig should be the kubeConfig file of the managed cluster via setting --set-file=<the kubeConfig file of managed cluster>
 	// only need to set in the hosted mode. optional
 	ExternalManagedKubeConfig string `json:"externalManagedKubeConfig,omitempty"`
 
 	// NoOperator is to only deploy the klusterlet CR if set true.
 	NoOperator bool `json:"noOperator,omitempty"`
+}
+
+type BootStrapKubeConfig struct {
+	// the boostStrap secret name
+	Name string `json:"name,omitempty"`
+	// the kubeConfig file of the hub cluster
+	KubeConfig string `json:"kubeConfig,omitempty"`
 }
 
 type ImagesConfig struct {

--- a/pkg/operator/helpers/chart/render_test.go
+++ b/pkg/operator/helpers/chart/render_test.go
@@ -262,6 +262,22 @@ func TestKlusterletConfig(t *testing.T) {
 			},
 			expectedObjCnt: 7,
 		},
+		{
+			name:      "use multiHubBootstrapHubKubeConfigs",
+			namespace: "open-cluster-management",
+			chartConfig: func() *KlusterletChartConfig {
+				config := NewDefaultKlusterletChartConfig()
+				config.Klusterlet.ClusterName = "testCluster"
+				config.Klusterlet.Mode = operatorv1.InstallModeSingleton
+				config.Klusterlet.ClusterName = "multiHubCluster-agent"
+				config.MultiHubBootstrapHubKubeConfigs = []BootStrapKubeConfig{
+					{Name: "bootStrap1", KubeConfig: "kubeconfig1"},
+					{Name: "bootStrap2", KubeConfig: "kubeconfig2"},
+				}
+				return config
+			},
+			expectedObjCnt: 8,
+		},
 
 		{
 			name:      "change images config",
@@ -397,37 +413,38 @@ func TestKlusterletConfig(t *testing.T) {
 						if config.Klusterlet.Mode != "" && object.Spec.DeployOption.Mode != config.Klusterlet.Mode {
 							t.Errorf(" expected %s, got %s", config.Klusterlet.Mode, object.Spec.DeployOption.Mode)
 						}
-						switch config.Klusterlet.Name {
-						case "":
-							if object.Name != "klusterlet" {
-								t.Errorf(" expected klusterlet, got %s", object.Name)
-							}
-						default:
-							if object.Name != config.Klusterlet.Name {
-								t.Errorf(" expected %s, got %s", config.Klusterlet.Name, object.Name)
-							}
+						if config.Klusterlet.Name == "" && object.Name != "klusterlet" {
+							t.Errorf(" expected klusterlet, got %s", object.Name)
 						}
-						switch config.Klusterlet.Namespace {
-						case "":
-							if object.Spec.Namespace != "open-cluster-management-agent" {
-								t.Errorf(" expected open-cluster-management-agent, got %s", object.Spec.Namespace)
-							}
-						default:
-							if object.Spec.Namespace != config.Klusterlet.Namespace {
-								t.Errorf(" expected %s, got %s", config.Klusterlet.Namespace, object.Spec.Namespace)
-							}
+						if config.Klusterlet.Name != "" && object.Name != config.Klusterlet.Name {
+							t.Errorf(" expected %s, got %s", config.Klusterlet.Name, object.Name)
 						}
+						if config.Klusterlet.Namespace == "" && object.Spec.Namespace != "open-cluster-management-agent" {
+							t.Errorf(" expected open-cluster-management-agent, got %s", object.Spec.Namespace)
+						}
+						if config.Klusterlet.Namespace != "" && object.Spec.Namespace != config.Klusterlet.Namespace {
+							t.Errorf(" expected %s, got %s", config.Klusterlet.Namespace, object.Spec.Namespace)
+						}
+
 					case operatorv1.InstallModeSingletonHosted, operatorv1.InstallModeHosted:
 						if object.Spec.DeployOption.Mode != config.Klusterlet.Mode {
 							t.Errorf(" expected %s, got %s", config.Klusterlet.Mode, object.Spec.DeployOption.Mode)
 						}
-						if object.Name != fmt.Sprintf("klusterlet-%s", object.Spec.ClusterName) {
+						if config.Klusterlet.Name == "" &&
+							object.Name != fmt.Sprintf("klusterlet-%s", object.Spec.ClusterName) {
 							t.Errorf(" expected %s, got %s",
 								fmt.Sprintf("klusterlet-%s", object.Spec.ClusterName), object.Name)
 						}
-						if object.Spec.Namespace != fmt.Sprintf("open-cluster-management-%s", object.Spec.ClusterName) {
+						if config.Klusterlet.Name != "" && object.Name != config.Klusterlet.Name {
+							t.Errorf(" expected %s, got %s", config.Klusterlet.Name, object.Name)
+						}
+						if config.Klusterlet.Namespace == "" &&
+							object.Spec.Namespace != fmt.Sprintf("open-cluster-management-%s", object.Spec.ClusterName) {
 							t.Errorf(" expected %s, got %s",
 								fmt.Sprintf("open-cluster-management-%s", object.Spec.ClusterName), object.Spec.Namespace)
+						}
+						if config.Klusterlet.Namespace != "" && object.Spec.Namespace != config.Klusterlet.Namespace {
+							t.Errorf(" expected %s, got %s", config.Klusterlet.Namespace, object.Spec.Namespace)
 						}
 					}
 				case *corev1.Secret:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. support configure configure multiple hub kubeconfigs in klusterlet chart
2. fix the name of klusterlet agent namespace in different mode.

## Related issue(s)

Fixes #