### PR TITLE
:seedling: do not install PriorityClass if noOperator is true

### DIFF
--- a/deploy/klusterlet/chart/klusterlet/templates/priority_class.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/priority_class.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.noOperator }}
 {{- if .Values.priorityClassName }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -7,4 +8,5 @@ value: 1000000
 globalDefault: false
 description: "This priority class should be used for klusterlet agents only."
 preemptionPolicy: PreemptLowerPriority
+{{- end }}
 {{- end }}

--- a/pkg/operator/helpers/chart/render_test.go
+++ b/pkg/operator/helpers/chart/render_test.go
@@ -327,6 +327,20 @@ func TestKlusterletConfig(t *testing.T) {
 			expectedObjCnt: 1,
 		},
 		{
+			name:      "noOperator with priority cluster",
+			namespace: "ocm",
+			chartConfig: func() *KlusterletChartConfig {
+				config := NewDefaultKlusterletChartConfig()
+				config.NoOperator = true
+				config.Klusterlet.Name = "klusterlet2"
+				config.Klusterlet.Namespace = "open-cluster-management-test"
+				config.Klusterlet.ClusterName = "testCluster"
+				config.PriorityClassName = "klusterlet-critical"
+				return config
+			},
+			expectedObjCnt: 1,
+		},
+		{
 			name:      "noOperator with image pull secret",
 			namespace: "ocm",
 			chartConfig: func() *KlusterletChartConfig {
@@ -335,6 +349,7 @@ func TestKlusterletConfig(t *testing.T) {
 				config.Klusterlet.Name = "klusterlet2"
 				config.Klusterlet.Namespace = "open-cluster-management-test"
 				config.Klusterlet.ClusterName = "testCluster"
+				config.PriorityClassName = "klusterlet-critical"
 				config.Images = ImagesConfig{
 					ImageCredentials: ImageCredentials{
 						CreateImageCredentials: true,
@@ -452,6 +467,9 @@ func TestKlusterletConfig(t *testing.T) {
 
 					if object.Spec.ClusterName != config.Klusterlet.ClusterName {
 						t.Errorf(" expected %s, got %s", config.Klusterlet.ClusterName, object.Spec.ClusterName)
+					}
+					if object.Spec.PriorityClassName != config.PriorityClassName {
+						t.Errorf(" expected %s, got %s", config.PriorityClassName, object.Spec.PriorityClassName)
 					}
 					switch config.Klusterlet.Mode {
 					case "", operatorv1.InstallModeSingleton, operatorv1.InstallModeDefault:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
when noOperator is true , that means the PriorityClass has been applied on the cluster, so there is no need to redeploy PriorityClass in this case.

## Related issue(s)

Fixes #