### PR TITLE
:bug: fix empty type of ResourceRequirement if ResourceRequirement is empty

### DIFF
--- a/pkg/operator/helpers/chart/config.go
+++ b/pkg/operator/helpers/chart/config.go
@@ -168,5 +168,5 @@ type KlusterletConfig struct {
 	// ResourceRequirement specify QoS classes of deployments managed by clustermanager.
 	// It applies to all the containers in the deployments.
 	// +optional
-	ResourceRequirement operatorv1.ResourceRequirement `json:"resourceRequirement,omitempty"`
+	ResourceRequirement *operatorv1.ResourceRequirement `json:"resourceRequirement,omitempty"`
 }

--- a/pkg/operator/helpers/chart/render_test.go
+++ b/pkg/operator/helpers/chart/render_test.go
@@ -471,6 +471,9 @@ func TestKlusterletConfig(t *testing.T) {
 					if object.Spec.PriorityClassName != config.PriorityClassName {
 						t.Errorf(" expected %s, got %s", config.PriorityClassName, object.Spec.PriorityClassName)
 					}
+					if object.Spec.ResourceRequirement != nil && object.Spec.ResourceRequirement.Type == "" {
+						t.Errorf(" expected resource requirement type, got invalid type")
+					}
 					switch config.Klusterlet.Mode {
 					case "", operatorv1.InstallModeSingleton, operatorv1.InstallModeDefault:
 						if config.Klusterlet.Mode == "" && object.Spec.DeployOption.Mode != operatorv1.InstallModeSingleton {

--- a/pkg/registration/hub/importer/importer.go
+++ b/pkg/registration/hub/importer/importer.go
@@ -180,7 +180,7 @@ func (i *Importer) reconcile(
 		Klusterlet: chart.KlusterletConfig{
 			Create:      true,
 			ClusterName: cluster.Name,
-			ResourceRequirement: operatorv1.ResourceRequirement{
+			ResourceRequirement: &operatorv1.ResourceRequirement{
 				Type: operatorv1.ResourceQosClassDefault,
 			},
 		},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The type of ResourceRequirement in klusterlet spec is Enum=Default;BestEffort;ResourceRequirement, will be empty if not set in KlusterletChartConfig to render helm chart, and will be failed to apply the klusterlet with empty type.

## Related issue(s)

Fixes #