### PR TITLE
:bug: fix incorrect agent namespace in klusterlet helm chart

### DIFF
--- a/deploy/klusterlet/chart/klusterlet/README.md
+++ b/deploy/klusterlet/chart/klusterlet/README.md
@@ -45,23 +45,24 @@ helm install klusterlet --version <version> ocm/klusterlet \
 
 ### Run klusterlet on Hosted mode
 
-Install the Chart on the hosting cluster without installing operator:
+Install the Chart on the hosting cluster:
 
 ```bash
-helm install <klusterlet name> --version <version> ocm/klusterlet \
-    --set klusterlet.clusterName=<cluster name>,klusterlet.mode=Hosted,noOperator=true \
+helm install <klusterlet release name> --version <version> ocm/klusterlet \
+    --set klusterlet.name=<klusterlet name>,klusterlet.clusterName=<cluster name>,klusterlet.mode=Hosted \
     --set-file bootstrapHubKubeConfig=<the bootstrap kubeconfig file of hub cluster>,\
       externalManagedKubeConfig=<the kubeconfig file of the managed cluster>
 ```
 
-Install the Chart on the hosting cluster with installing operator:
+### Run klusterlet without operator
+In this case, the klusterlet operator has been installed on the cluster.
 
 ```bash
-helm install <klusterlet name> --version <version> ocm/klusterlet \
-    --set klusterlet.clusterName=<cluster name>,klusterlet.mode=Hosted \
-    --set-file bootstrapHubKubeConfig=<the bootstrap kubeconfig file of hub cluster>,\
-      externalManagedKubeConfig=<the kubeconfig file of the managed cluster>
+    helm install <klusterlet release name> --version <version> ocm/klusterlet \
+    --set klusterlet.name=<klusterlet name>,klusterlet.clusterName=<cluster name>,klusterlet.namespace=<klusterlet namespace>,noOperator=true \
+    --set-file bootstrapHubKubeConfig=<the bootstrap kubeconfig file of hub cluster>
 ```
+
 
 > Note:
 > If the cluster is KinD cluster, the kubeconfig should be internal:: `kind get kubeconfig --name managed --internal`.

--- a/deploy/klusterlet/chart/klusterlet/templates/_helpers.tpl
+++ b/deploy/klusterlet/chart/klusterlet/templates/_helpers.tpl
@@ -44,11 +44,16 @@ Create secret to access docker registry
 {{- end }}
 {{- end }}
 
+{{/*
+ agentNamespace is the klusterlet name in hosted mode.
+ agentNamespace is the klusterlet.namespace in default mode.
+ agentNamespace is open-cluster-management-agent if klusterlet.namespace is empty in default mode.
+*/}}
 {{- define "agentNamespace" }}
-{{- if .Values.klusterlet.namespace }}
+{{- if or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "SingletonHosted") }}
+{{- printf "%s" .Values.klusterlet.name }}
+{{- else if .Values.klusterlet.namespace }}
 {{- printf "%s" .Values.klusterlet.namespace }}
-{{- else if  or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "SingletonHosted") }}
-{{- printf "open-cluster-management-%s" .Values.klusterlet.clusterName }}
 {{- else }}
 {{- printf "open-cluster-management-agent" }}
 {{- end }}
@@ -62,5 +67,15 @@ Create secret to access docker registry
 {{- printf "klusterlet-%s" .Values.klusterlet.clusterName }}
 {{- else }}
 {{- printf "klusterlet" }}
+{{- end }}
+{{- end }}
+
+{{- define "klusterletNamespace" }}
+{{- if .Values.klusterlet.namespace }}
+{{- printf "%s" .Values.klusterlet.namespace }}
+{{- else if  or ( eq .Values.klusterlet.mode "Hosted") (eq .Values.klusterlet.mode "SingletonHosted") }}
+{{- printf "open-cluster-management-%s" .Values.klusterlet.clusterName }}
+{{- else }}
+{{- printf "open-cluster-management-agent" }}
 {{- end }}
 {{- end }}

--- a/deploy/klusterlet/chart/klusterlet/templates/cluster_role.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/cluster_role.yaml
@@ -1,3 +1,4 @@
+{{- if or ( eq .Values.klusterlet.mode "Singleton") (eq .Values.klusterlet.mode "Default") }}
 {{- if not .Values.noOperator }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -68,4 +69,5 @@ rules:
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["appliedmanifestworks"]
   verbs: ["list", "update", "patch"]
+{{- end }}
 {{- end }}

--- a/deploy/klusterlet/chart/klusterlet/templates/cluster_role_binding.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/cluster_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- if or ( eq .Values.klusterlet.mode "Singleton") (eq .Values.klusterlet.mode "Default") }}
 {{- if not .Values.noOperator }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -11,4 +12,5 @@ subjects:
 - kind: ServiceAccount
   name: klusterlet
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/deploy/klusterlet/chart/klusterlet/templates/klusterlet.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/klusterlet.yaml
@@ -9,8 +9,8 @@ spec:
   registrationImagePullSpec: "{{ template "registrationImage" . }}"
   workImagePullSpec: "{{ template "workImage" . }}"
   imagePullSpec: "{{ template "operatorImage" . }}"
-  clusterName: {{ .Values.klusterlet.clusterName }}
-  namespace: "{{ template "agentNamespace" . }}"
+  clusterName: "{{ .Values.klusterlet.clusterName }}"
+  namespace: "{{ template "klusterletNamespace" . }}"
   {{- with .Values.klusterlet.externalServerURLs }}
   externalServerURLs:
     {{- toYaml . | nindent 4 }}

--- a/deploy/klusterlet/chart/klusterlet/templates/operator.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/operator.yaml
@@ -1,3 +1,4 @@
+{{- if or ( eq .Values.klusterlet.mode "Singleton") (eq .Values.klusterlet.mode "Default") }}
 {{- if not .Values.noOperator }}
 kind: Deployment
 apiVersion: apps/v1
@@ -74,4 +75,5 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/klusterlet/chart/klusterlet/templates/priority_class.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/priority_class.yaml
@@ -1,3 +1,4 @@
+{{- if or ( eq .Values.klusterlet.mode "Singleton") (eq .Values.klusterlet.mode "Default") }}
 {{- if not .Values.noOperator }}
 {{- if .Values.priorityClassName }}
 apiVersion: scheduling.k8s.io/v1
@@ -8,5 +9,6 @@ value: 1000000
 globalDefault: false
 description: "This priority class should be used for klusterlet agents only."
 preemptionPolicy: PreemptLowerPriority
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/klusterlet/chart/klusterlet/templates/service_account.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/service_account.yaml
@@ -1,3 +1,4 @@
+{{- if or ( eq .Values.klusterlet.mode "Singleton") (eq .Values.klusterlet.mode "Default") }}
 {{- if not .Values.noOperator }}
 apiVersion: v1
 kind: ServiceAccount
@@ -6,4 +7,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 imagePullSecrets:
   - name: open-cluster-management-image-pull-credentials
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. correct the definition of  agentNamespace and differentiate between agentNamespace and klusterletNamespace:
agentNamespace is the klusterlet name in hosted mode.
agentNamespace is the klusterlet.namespace in default mode.
agentNamespace is open-cluster-management-agent if klusterlet.namespace is empty in default mode.

2. separate hosted mode from `noOperator = true` because noOperator = true is a special case,  could be hosted mode or default mode.

## Related issue(s)

Fixes #