### PR TITLE
:book: Update docs for joining hubspoke awsirsa to not use bundle version latest but default

### DIFF
--- a/solutions/joining-hub-and-spoke-with-aws-auth/README.md
+++ b/solutions/joining-hub-and-spoke-with-aws-auth/README.md
@@ -69,7 +69,7 @@ The hub and spoke can be joined using AWS IAM based authentication by running fo
 
 4. Login to hub EKS clusters and initialize hub:
    ```shell
-   clusteradm init --bundle-version latest --registration-drivers awsirsa \
+   clusteradm init --registration-drivers awsirsa \
    --feature-gates ManagedClusterAutoApproval=true \
    --auto-approved-arn-patterns "arn:aws:eks:us-west-2:123412341234:cluster/.*" --wait
    
@@ -83,7 +83,7 @@ The hub and spoke can be joined using AWS IAM based authentication by running fo
    ```shell
    clusteradm join --hub-token $TOKEN --hub-apiserver $HUB_API_SERVER \
    --wait --cluster-name $SPOKE_CLUSTER_NAME --singleton \
-   --bundle-version latest --registration-auth awsirsa \
+   --registration-auth awsirsa \
    --hub-cluster-arn arn:aws:eks:$HUB_REGION:"$HUB_ACCOUNT_ID":cluster/$HUB_CLUSTER_NAME
    ```
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

We want to update our example docs for joining hub and spoke through AWSIRSA to not pass --bundle-version latest and instead just use default (pass nothing)

## Related issue(s)

Fixes #