### PR TITLE
🐛 add hub QPS/Burst to hub work client,for talking with hub cluster api…

### DIFF
--- a/pkg/common/options/agent.go
+++ b/pkg/common/options/agent.go
@@ -32,6 +32,8 @@ type AgentOptions struct {
 	HubKubeconfigDir    string
 	HubKubeconfigFile   string
 	AgentID             string
+	HubBurst            int
+	HubQPS              float32
 }
 
 // NewAgentOptions returns the flags with default value set
@@ -61,6 +63,8 @@ func (o *AgentOptions) AddFlags(flags *pflag.FlagSet) {
 		"The mount path of hub-kubeconfig-secret in the container.")
 	flags.StringVar(&o.HubKubeconfigFile, "hub-kubeconfig", o.HubKubeconfigFile, "Location of kubeconfig file to connect to hub cluster.")
 	flags.StringVar(&o.AgentID, "agent-id", o.AgentID, "ID of the agent")
+	flags.Float32Var(&o.HubQPS, "hub-kube-api-qps", 50.0, "QPS to use while talking with apiserver on hub cluster.")
+	flags.IntVar(&o.HubBurst, "hub-kube-api-burst", 100, "Burst to use while talking with apiserver on hub cluster.")
 }
 
 // SpokeKubeConfig builds kubeconfig for the spoke/managed cluster

--- a/pkg/work/spoke/spokeagent.go
+++ b/pkg/work/spoke/spokeagent.go
@@ -207,6 +207,8 @@ func (o *WorkAgentConfig) newWorkClientAndInformer(
 		if err != nil {
 			return "", nil, nil, err
 		}
+		config.QPS = o.agentOptions.HubQPS
+		config.Burst = o.agentOptions.HubBurst
 
 		workClient, err = workclientset.NewForConfig(config)
 		if err != nil {


### PR DESCRIPTION
# Summary
if you have a large number of manifestworks for one managed cluster，the work-agent may experience client throttling. (manifestwork controller and status controller). Seriously affects the update speed of manifestworks status, and the deletion of manifestworks.
In this case, we need to set the QPS/Burst of hubworkclient to hub cluster apiserver.

# Related issue(s)
Fixes #1011 