### PR TITLE
🐛 Switch the order of deletion of access entry and iamrole when managedcluster gets deleted.

### DIFF
--- a/pkg/registration/register/aws_irsa/hub_driver.go
+++ b/pkg/registration/register/aws_irsa/hub_driver.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	resourceNotFound 		= "ResourceNotFoundException"
+	resourceNotFound        = "ResourceNotFoundException"
 	errNoSuchEntity         = "NoSuchEntity"
 	errEntityAlreadyExists  = "EntityAlreadyExists"
 	trustPolicyTemplatePath = "managed-cluster-policy/TrustPolicy.tmpl"

--- a/pkg/registration/register/aws_irsa/hub_driver.go
+++ b/pkg/registration/register/aws_irsa/hub_driver.go
@@ -28,6 +28,7 @@ import (
 )
 
 const (
+	resourceNotFound 		= "ResourceNotFoundException"
 	errNoSuchEntity         = "NoSuchEntity"
 	errEntityAlreadyExists  = "EntityAlreadyExists"
 	trustPolicyTemplatePath = "managed-cluster-policy/TrustPolicy.tmpl"
@@ -77,14 +78,14 @@ func (c *AWSIRSAHubDriver) Cleanup(ctx context.Context, managedCluster *clusterv
 		return err
 	}
 
-	err = deleteIAMRole(ctx, c.cfg, roleName)
+	eksClient := eks.NewFromConfig(c.cfg)
+	_, hubClusterName := commonhelpers.GetAwsAccountIdAndClusterName(c.hubClusterArn)
+	err = deleteAccessEntry(ctx, eksClient, roleArn, hubClusterName)
 	if err != nil {
 		return err
 	}
 
-	eksClient := eks.NewFromConfig(c.cfg)
-	_, hubClusterName := commonhelpers.GetAwsAccountIdAndClusterName(c.hubClusterArn)
-	err = deleteAccessEntry(ctx, eksClient, roleArn, hubClusterName)
+	err = deleteIAMRole(ctx, c.cfg, roleName)
 	if err != nil {
 		return err
 	}
@@ -312,7 +313,10 @@ func deleteAccessEntry(ctx context.Context, eksClient *eks.Client, roleArn strin
 	}
 
 	_, err := eksClient.DeleteAccessEntry(ctx, params)
-	if err != nil {
+	if strings.Contains(err.Error(), resourceNotFound) {
+		logger.V(4).Error(err, "Access Entry already deleted for HubClusterName", "HubClusterName", hubClusterName)
+		return nil
+	} else if err != nil {
 		logger.V(4).Error(err, "Failed to delete Access Entry for HubClusterName", "HubClusterName", hubClusterName)
 		return err
 	} else {

--- a/pkg/registration/register/aws_irsa/hub_driver.go
+++ b/pkg/registration/register/aws_irsa/hub_driver.go
@@ -313,10 +313,11 @@ func deleteAccessEntry(ctx context.Context, eksClient *eks.Client, roleArn strin
 	}
 
 	_, err := eksClient.DeleteAccessEntry(ctx, params)
-	if strings.Contains(err.Error(), resourceNotFound) {
-		logger.V(4).Error(err, "Access Entry already deleted for HubClusterName", "HubClusterName", hubClusterName)
-		return nil
-	} else if err != nil {
+	if err != nil {
+		if strings.Contains(err.Error(), resourceNotFound) {
+			logger.V(4).Error(err, "Access Entry already deleted for HubClusterName", "HubClusterName", hubClusterName)
+			return nil
+		}
 		logger.V(4).Error(err, "Failed to delete Access Entry for HubClusterName", "HubClusterName", hubClusterName)
 		return err
 	} else {


### PR DESCRIPTION
## Summary

Delete the access entry first and then delete the IAM role created by registration controller since deleting the IAM role first also seems to remove the access entry and the access entry deletion fails. Also add a check after deletion of access entry and ignore the error if it returns "resourceNotFound".

## Related issue(s)

Fixes #1010 