### PR TITLE
⚠️ use managedclustraddon install namespace when addondeploymentconfig not set

### DIFF
--- a/pkg/addon/templateagent/decorator.go
+++ b/pkg/addon/templateagent/decorator.go
@@ -29,7 +29,7 @@ type namespaceDecorator struct {
 	paths map[string][]string
 }
 
-func newNamespaceDecorator(privateValues addonfactory.Values) *namespaceDecorator {
+func newNamespaceDecorator(defaultNs string, privateValues addonfactory.Values) *namespaceDecorator {
 	decorator := &namespaceDecorator{
 		paths: map[string][]string{
 			"ClusterRoleBinding": {"subjects", "namespace"},
@@ -40,6 +40,8 @@ func newNamespaceDecorator(privateValues addonfactory.Values) *namespaceDecorato
 	namespace, ok := privateValues[InstallNamespacePrivateValueKey]
 	if ok {
 		decorator.installNamespace = namespace.(string)
+	} else if len(defaultNs) != 0 {
+		decorator.installNamespace = defaultNs
 	}
 
 	return decorator

--- a/pkg/addon/templateagent/decorator_test.go
+++ b/pkg/addon/templateagent/decorator_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestNamespaceDecorator(t *testing.T) {
+	defaultNs := "ocm-addon"
 	tests := []struct {
 		name           string
 		namespace      string
@@ -29,7 +30,7 @@ func TestNamespaceDecorator(t *testing.T) {
 			name:   "no namespace set",
 			object: testingcommon.NewUnstructured("v1", "Pod", "default", "test"),
 			validateObject: func(t *testing.T, obj *unstructured.Unstructured) {
-				testingcommon.AssertEqualNameNamespace(t, obj.GetName(), obj.GetNamespace(), "test", "default")
+				testingcommon.AssertEqualNameNamespace(t, obj.GetName(), obj.GetNamespace(), "test", defaultNs)
 			},
 		},
 		{
@@ -153,7 +154,7 @@ func TestNamespaceDecorator(t *testing.T) {
 				values[InstallNamespacePrivateValueKey] = tc.namespace
 			}
 
-			d := newNamespaceDecorator(values)
+			d := newNamespaceDecorator(defaultNs, values)
 			result, err := d.decorate(tc.object)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Currently, when deploying an addonTemplate type addon, if the addondeploymentconfig is not set, we will deploy the resources into the namespace of the first deployment/daemonset defined in the addonTemplate. This PR changes to deploy the resources into the namespace of managedclusteraddon.spec.installnamespace.

## Related issue(s)

Fixes #