### PR TITLE
:bug: fix the ut failure in pod

### DIFF
--- a/pkg/registration/register/common.go
+++ b/pkg/registration/register/common.go
@@ -267,6 +267,10 @@ func KubeConfigFromSecretOption(s SecretOption, bootstrap bool) (*rest.Config, e
 			return nil, fmt.Errorf("unable to load bootstrap kubeconfig: %w", err)
 		}
 	} else {
+		if s.HubKubeconfigFile == "" {
+			return nil, fmt.Errorf("no hub kubeconfig found")
+		}
+
 		kubeConfig, err = clientcmd.BuildConfigFromFlags("", s.HubKubeconfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load hub kubeconfig from file %q: %w", s.HubKubeconfigFile, err)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the ut can pass when run locally, but fail when run in pod.
because if HubKubeconfigFile is empty clientcmd.BuildConfigFromFlags will use the restclient.InClusterConfig() to get kubeConfig in pod. 

The failed ut 
https://github.com/open-cluster-management-io/ocm/blob/215cfed77e52b13e1b409d6d03866669ef77bc57/pkg/registration/register/common_test.go#L315-L321

## Related issue(s)

Fixes #