### PR TITLE
:bug: fix the labels of hub deployments cannot be updated from the clustermanager

### DIFF
--- a/manifests/cluster-manager/cluster-manager-namespace.yaml
+++ b/manifests/cluster-manager/cluster-manager-namespace.yaml
@@ -2,3 +2,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}

--- a/manifests/cluster-manager/hub/cluster-manager-clusterprofiles-clusterrole.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-clusterprofiles-clusterrole.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-clusterprofile:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 rules:
 # Allow hub to manage clusterprofile
 - apiGroups: ["multicluster.x-k8s.io"]

--- a/manifests/cluster-manager/hub/cluster-manager-clusterprofiles-clusterrolebinding.yaml
+++ b/manifests/cluster-manager/hub/cluster-manager-clusterprofiles-clusterrolebinding.yaml
@@ -2,6 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:{{ .ClusterManagerName }}-clusterprofile:controller
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .ClusterManagerName }}-addon-manager-controller
   namespace: {{ .ClusterManagerNamespace }}
   labels:
-    app: clustermanager-controller
+    app: {{ .ClusterManagerName }}-addon-manager-controller
     createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
@@ -15,16 +15,11 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: clustermanager-addon-manager-controller
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
+      app: {{ .ClusterManagerName }}-addon-manager-controller
   template:
     metadata:
       labels:
-        app: clustermanager-addon-manager-controller
+        app: {{ .ClusterManagerName }}-addon-manager-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-addon-manager-controller
-    createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
     "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-work-controller
-    createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
     "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
@@ -16,11 +16,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .ClusterManagerName }}-work-controller
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
   template:
     metadata:
       labels:

--- a/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-placement-controller
-    createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
     "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .ClusterManagerName }}-placement-controller
   namespace: {{ .ClusterManagerNamespace }}
   labels:
-    app: clustermanager-controller
+    app: {{ .ClusterManagerName }}-placement-controller
     createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
@@ -15,16 +15,11 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: clustermanager-placement-controller
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
+      app: {{ .ClusterManagerName }}-placement-controller
   template:
     metadata:
       labels:
-        app: clustermanager-placement-controller
+        app: {{ .ClusterManagerName }}-placement-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .ClusterManagerName }}-registration-controller
   namespace: {{ .ClusterManagerNamespace }}
   labels:
-    app: clustermanager-controller
+    app: {{ .ClusterManagerName }}-registration-controller
     createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
@@ -15,16 +15,11 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: clustermanager-registration-controller
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
+      app: {{ .ClusterManagerName }}-registration-controller
   template:
     metadata:
       labels:
-        app: clustermanager-registration-controller
+        app: {{ .ClusterManagerName }}-registration-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{$key}}": "{{$value}}"

--- a/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-registration-controller
-    createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
     "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-registration-webhook
-    createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
     "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
@@ -16,11 +16,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .ClusterManagerName }}-registration-webhook
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
   template:
     metadata:
       labels:

--- a/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
@@ -16,11 +16,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .ClusterManagerName }}-work-webhook
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
   template:
     metadata:
       labels:

--- a/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .ClusterManagerNamespace }}
   labels:
     app: {{ .ClusterManagerName }}-work-webhook
-    createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
     "{{ $key }}": "{{ $value }}"

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -830,6 +830,9 @@ func GetKlusterletAgentLabels(klusterlet *operatorapiv1.Klusterlet, enableSyncLa
 	labels := map[string]string{}
 	if enableSyncLabels {
 		for k, v := range klusterlet.GetLabels() {
+			if k == "app" {
+				continue
+			}
 			labels[k] = v
 		}
 	}

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	appsinformer "k8s.io/client-go/informers/apps/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -44,6 +45,12 @@ const (
 	defaultWebhookPort       = int32(9443)
 	clusterManagerReSyncTime = 5 * time.Second
 )
+
+var reservedLabelKeySets = sets.Set[string]{
+	"app":                     sets.Empty{},
+	"createdByClusterManager": sets.Empty{},
+	"open-cluster-management.io/cluster-name": sets.Empty{},
+}
 
 type clusterManagerController struct {
 	patcher              patcher.Patcher[*operatorapiv1.ClusterManager, operatorapiv1.ClusterManagerSpec, operatorapiv1.ClusterManagerStatus]
@@ -226,8 +233,9 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	}
 
 	if n.enableSyncLabels {
-		config.LabelsString = helpers.ConvertLabelsMapToString(clusterManager.Labels)
-		config.Labels = clusterManager.Labels
+		labels := filterLabels(clusterManager.Labels)
+		config.LabelsString = helpers.ConvertLabelsMapToString(labels)
+		config.Labels = labels
 	}
 
 	// Update finalizer at first
@@ -443,4 +451,15 @@ func getIdentityCreatorRoleAndTags(cm operatorapiv1.ClusterManager) string {
 		}
 	}
 	return ""
+}
+
+func filterLabels(labels map[string]string) map[string]string {
+	result := map[string]string{}
+	for key, value := range labels {
+		if reservedLabelKeySets.Has(key) {
+			continue
+		}
+		result[key] = value
+	}
+	return result
 }

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
@@ -284,8 +284,9 @@ func ensureObject(t *testing.T, object runtime.Object, hubCore *operatorapiv1.Cl
 	if err != nil {
 		t.Errorf("Unable to access objectmeta: %v", err)
 	}
-	//TODO: add test by enabling sync labels = true
-	if enableSyncLabels && !helpers.MapCompare(hubCore.Labels, access.GetLabels()) {
+	// TODO: add test by enabling sync labels = true
+	labels := filterLabels(hubCore.Labels)
+	if enableSyncLabels && !helpers.MapCompare(access.GetLabels(), labels) {
 		t.Errorf("the labels of the clustermanager are not synced to %v %v %v", access.GetName(), hubCore.GetLabels(), access.GetLabels())
 		return
 	}
@@ -434,7 +435,8 @@ func TestSyncSecret(t *testing.T) {
 
 // TestSyncDeploy tests sync manifests of hub component
 func TestSyncDeploy(t *testing.T) {
-	labels := map[string]string{"test": "test", "createdByClusterManager": "testhub", "abc": "abc"}
+	labels := map[string]string{"app": "test", "createdByClusterManager": "testhub", "abc": "abc",
+		"open-cluster-management.io/cluster-name": "test"}
 	clusterManager := newClusterManager("testhub")
 	clusterManager.SetLabels(labels)
 	tc := newTestController(t, clusterManager)
@@ -462,7 +464,7 @@ func TestSyncDeploy(t *testing.T) {
 	// We expect create the namespace twice respectively in the management cluster and the hub cluster.
 	testingcommon.AssertEqualNumber(t, len(createKubeObjects), 28)
 	for _, object := range createKubeObjects {
-		ensureObject(t, object, clusterManager, false)
+		ensureObject(t, object, clusterManager, true)
 	}
 
 	var createCRDObjects []runtime.Object

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
@@ -284,8 +284,8 @@ func ensureObject(t *testing.T, object runtime.Object, hubCore *operatorapiv1.Cl
 	if err != nil {
 		t.Errorf("Unable to access objectmeta: %v", err)
 	}
-	// TODO: add test by enabling sync labels = true
-	labels := filterLabels(hubCore.Labels)
+
+	labels := helpers.GetClusterManagerHubLabels(hubCore, enableSyncLabels)
 	if enableSyncLabels && !helpers.MapCompare(access.GetLabels(), labels) {
 		t.Errorf("the labels of the clustermanager are not synced to %v %v %v", access.GetName(), hubCore.GetLabels(), access.GetLabels())
 		return
@@ -435,7 +435,7 @@ func TestSyncSecret(t *testing.T) {
 
 // TestSyncDeploy tests sync manifests of hub component
 func TestSyncDeploy(t *testing.T) {
-	labels := map[string]string{"app": "test", "createdByClusterManager": "testhub", "abc": "abc",
+	labels := map[string]string{"app": "test", helpers.HubLabelKey: "testhub", "abc": "abc",
 		"open-cluster-management.io/cluster-name": "test"}
 	clusterManager := newClusterManager("testhub")
 	clusterManager.SetLabels(labels)

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_secret_reconcile.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_secret_reconcile.go
@@ -29,6 +29,7 @@ type secretReconcile struct {
 	operatorNamespace  string
 	cache              resourceapply.ResourceCache
 	recorder           events.Recorder
+	enableSyncLabels   bool
 }
 
 func (c *secretReconcile) reconcile(ctx context.Context, cm *operatorapiv1.ClusterManager,
@@ -53,7 +54,7 @@ func (c *secretReconcile) reconcile(ctx context.Context, cm *operatorapiv1.Clust
 			config.ClusterManagerNamespace,
 			secretName,
 			[]metav1.OwnerReference{},
-			nil,
+			helpers.GetClusterManagerHubLabels(cm, c.enableSyncLabels),
 		); err != nil {
 			syncedErrs = append(syncedErrs, fmt.Errorf("failed to sync secret %s: %v", secretName, err))
 		}

--- a/test/integration/operator/clustermanager_test.go
+++ b/test/integration/operator/clustermanager_test.go
@@ -251,7 +251,7 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
-			//#nosec G101
+			// #nosec G101
 			workWebhookSecret := "work-webhook-serving-cert"
 			gomega.Eventually(func() error {
 				s, err := kubeClient.CoreV1().Secrets(hubNamespace).Get(context.Background(), workWebhookSecret, metav1.GetOptions{})
@@ -1184,6 +1184,8 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 		ginkgo.It("should have labels on resources created by clustermanager", func() {
 
 			labels := map[string]string{"app": "clustermanager", "createdByClusterManager": "hub", "test-label": "test-value", "test-label2": "test-value2"}
+			// app and createdByClusterManager are reserved label keys, and will not be changed to the hub resources.
+			expectedLabels := map[string]string{"test-label": "test-value", "test-label2": "test-value2"}
 			gomega.Eventually(func() error {
 				clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
 				if err != nil {
@@ -1202,8 +1204,8 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected registration-controller labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
+				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
+					return fmt.Errorf("expected registration-controller labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1216,7 +1218,7 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				}
 				commandLineArgs := registrationDeployment.Spec.Template.Spec.Containers[0].Args
 				labelsArg, present := findMatchingArg(commandLineArgs, "--labels")
-				return present && strings.SplitN(labelsArg, "=", 2)[1] == helpers.ConvertLabelsMapToString(labels)
+				return present && strings.SplitN(labelsArg, "=", 2)[1] == helpers.ConvertLabelsMapToString(expectedLabels)
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			// Compare labels on registration-webhook
@@ -1226,8 +1228,8 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected registration-webhook labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
+				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
+					return fmt.Errorf("expected registration-webhook labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1238,8 +1240,8 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected work-webhook labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
+				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
+					return fmt.Errorf("expected work-webhook labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1250,8 +1252,8 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected placement-controller labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
+				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
+					return fmt.Errorf("expected placement-controller labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1262,8 +1264,8 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected labels addon-manager-controller to be %v, but got %v", labels, registrationDeployment.GetLabels())
+				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
+					return fmt.Errorf("expected labels addon-manager-controller to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1274,8 +1276,8 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected work-controller labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
+				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
+					return fmt.Errorf("expected work-controller labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())

--- a/test/integration/operator/clustermanager_test.go
+++ b/test/integration/operator/clustermanager_test.go
@@ -1183,9 +1183,12 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 
 		ginkgo.It("should have labels on resources created by clustermanager", func() {
 
-			labels := map[string]string{"app": "clustermanager", "createdByClusterManager": "hub", "test-label": "test-value", "test-label2": "test-value2"}
+			labels := map[string]string{helpers.AppLabelKey: "clustermanager", helpers.HubLabelKey: "hub",
+				helpers.LabelPrefix + "/cluster-name": "test", "test-label": "test-value", "test-label2": "test-value2"}
 			// app and createdByClusterManager are reserved label keys, and will not be changed to the hub resources.
-			expectedLabels := map[string]string{"test-label": "test-value", "test-label2": "test-value2"}
+			expectedDeploymentLabels := map[string]string{helpers.AppLabelKey: "deployment name", helpers.HubLabelKey: clusterManagerName,
+				"test-label": "test-value", "test-label2": "test-value2"}
+			expectedRegistrationLabels := map[string]string{"test-label": "test-value", "test-label2": "test-value2"}
 			gomega.Eventually(func() error {
 				clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
 				if err != nil {
@@ -1204,8 +1207,10 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
-					return fmt.Errorf("expected registration-controller labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
+
+				expectedDeploymentLabels[helpers.AppLabelKey] = clusterManagerName + "-registration-controller"
+				if !helpers.MapCompare(registrationDeployment.GetLabels(), expectedDeploymentLabels) {
+					return fmt.Errorf("expected registration-controller labels to be %v, but got %v", expectedDeploymentLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1218,7 +1223,7 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				}
 				commandLineArgs := registrationDeployment.Spec.Template.Spec.Containers[0].Args
 				labelsArg, present := findMatchingArg(commandLineArgs, "--labels")
-				return present && strings.SplitN(labelsArg, "=", 2)[1] == helpers.ConvertLabelsMapToString(expectedLabels)
+				return present && strings.SplitN(labelsArg, "=", 2)[1] == helpers.ConvertLabelsMapToString(expectedRegistrationLabels)
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			// Compare labels on registration-webhook
@@ -1228,8 +1233,9 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
-					return fmt.Errorf("expected registration-webhook labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
+				expectedDeploymentLabels[helpers.AppLabelKey] = clusterManagerName + "-registration-webhook"
+				if !helpers.MapCompare(registrationDeployment.GetLabels(), expectedDeploymentLabels) {
+					return fmt.Errorf("expected registration-webhook labels to be %v, but got %v", expectedDeploymentLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1240,8 +1246,9 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
-					return fmt.Errorf("expected work-webhook labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
+				expectedDeploymentLabels[helpers.AppLabelKey] = clusterManagerName + "-work-webhook"
+				if !helpers.MapCompare(registrationDeployment.GetLabels(), expectedDeploymentLabels) {
+					return fmt.Errorf("expected work-webhook labels to be %v, but got %v", expectedDeploymentLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1252,8 +1259,9 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
-					return fmt.Errorf("expected placement-controller labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
+				expectedDeploymentLabels[helpers.AppLabelKey] = clusterManagerName + "-placement-controller"
+				if !helpers.MapCompare(registrationDeployment.GetLabels(), expectedDeploymentLabels) {
+					return fmt.Errorf("expected placement-controller labels to be %v, but got %v", expectedDeploymentLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1264,8 +1272,9 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
-					return fmt.Errorf("expected labels addon-manager-controller to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
+				expectedDeploymentLabels[helpers.AppLabelKey] = clusterManagerName + "-addon-manager-controller"
+				if !helpers.MapCompare(registrationDeployment.GetLabels(), expectedDeploymentLabels) {
+					return fmt.Errorf("expected labels addon-manager-controller to be %v, but got %v", expectedDeploymentLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
@@ -1276,8 +1285,9 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(expectedLabels, registrationDeployment.GetLabels()) {
-					return fmt.Errorf("expected work-controller labels to be %v, but got %v", expectedLabels, registrationDeployment.GetLabels())
+				expectedDeploymentLabels[helpers.AppLabelKey] = clusterManagerName + "-work-controller"
+				if !helpers.MapCompare(registrationDeployment.GetLabels(), expectedDeploymentLabels) {
+					return fmt.Errorf("expected work-controller labels to be %v, but got %v", expectedDeploymentLabels, registrationDeployment.GetLabels())
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
meet failure error when update labels for the cluster manager deployments because the filed is immutable. 

`spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"cluster-manager", "test":"test"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable`

remove the labels from spec.selector for cluster manager deployments 
## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dynamic label support to various Kubernetes resources, allowing user-defined labels to be applied based on input.
  - Introduced filtering to exclude reserved label keys from user-defined labels for consistent resource labeling.
  - Enabled dynamic generation of deployment and secret labels based on cluster manager name.

- **Bug Fixes**
  - Improved label filtering to exclude reserved keys and ensure consistent labeling across managed resources.

- **Tests**
  - Updated and enhanced tests to verify correct label synchronization and filtering for all relevant resources.
  - Refined test label sets and assertions to reflect updated label handling and reserved key usage.

- **Chores**
  - Refined label management for deployments and secrets, including dynamic label generation based on cluster manager name.
  - Updated code comments and test assertions for better clarity on reserved labels and expected behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->