### PR TITLE
:bug: fixes issue when we update the clustermanager with new labels.

### DIFF
--- a/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .ClusterManagerName }}-addon-manager-controller
   namespace: {{ .ClusterManagerNamespace }}
   labels:
-    app: clustermanager-controller
+    app: {{ .ClusterManagerName }}-addon-manager-controller
     createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
@@ -15,16 +15,11 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: clustermanager-addon-manager-controller
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
+      app: {{ .ClusterManagerName }}-addon-manager-controller
   template:
     metadata:
       labels:
-        app: clustermanager-addon-manager-controller
+        app: {{ .ClusterManagerName }}-addon-manager-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-manifestworkreplicaset-deployment.yaml
@@ -16,11 +16,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .ClusterManagerName }}-work-controller
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
   template:
     metadata:
       labels:

--- a/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .ClusterManagerName }}-placement-controller
   namespace: {{ .ClusterManagerNamespace }}
   labels:
-    app: clustermanager-controller
+    app: {{ .ClusterManagerName }}-placement-controller
     createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
@@ -15,16 +15,12 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: clustermanager-placement-controller
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
+      app: {{ .ClusterManagerName }}-placement-controller
+
   template:
     metadata:
       labels:
-        app: clustermanager-placement-controller
+        app: {{ .ClusterManagerName }}-placement-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .ClusterManagerName }}-registration-controller
   namespace: {{ .ClusterManagerNamespace }}
   labels:
-    app: clustermanager-controller
+    app: {{ .ClusterManagerName }}-registration-controller
     createdByClusterManager: {{ .ClusterManagerName }}
     {{ if gt (len .Labels) 0 }}
     {{ range $key, $value := .Labels }}
@@ -15,16 +15,11 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: clustermanager-registration-controller
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
+      app: {{ .ClusterManagerName }}-registration-controller
   template:
     metadata:
       labels:
-        app: clustermanager-registration-controller
+        app: {{ .ClusterManagerName }}-registration-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{$key}}": "{{$value}}"

--- a/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-webhook-deployment.yaml
@@ -16,11 +16,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .ClusterManagerName }}-registration-webhook
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
   template:
     metadata:
       labels:

--- a/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-work-webhook-deployment.yaml
@@ -16,11 +16,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .ClusterManagerName }}-work-webhook
-      {{ if gt (len .Labels) 0 }}
-      {{ range $key, $value := .Labels }}
-      "{{ $key }}": "{{ $value }}"
-      {{ end }}
-      {{ end }}
   template:
     metadata:
       labels:

--- a/test/integration/operator/clustermanager_test.go
+++ b/test/integration/operator/clustermanager_test.go
@@ -1183,7 +1183,7 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 
 		ginkgo.It("should have labels on resources created by clustermanager", func() {
 
-			labels := map[string]string{"app": "clustermanager", "createdByClusterManager": "hub", "test-label": "test-value", "test-label2": "test-value2"}
+			labels := map[string]string{"createdByClusterManager": "hub", "test-label": "test-value", "test-label2": "test-value2"}
 			gomega.Eventually(func() error {
 				clusterManager, err := operatorClient.OperatorV1().ClusterManagers().Get(context.Background(), clusterManagerName, metav1.GetOptions{})
 				if err != nil {
@@ -1202,9 +1202,8 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected registration-controller labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
-				}
+				registrationLabels := registrationDeployment.GetLabels()
+				util.MapConsists(registrationLabels, labels)
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
@@ -1226,57 +1225,48 @@ var _ = ginkgo.Describe("ClusterManager Default Mode", ginkgo.Ordered, func() {
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected registration-webhook labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
-				}
+				util.MapConsists(registrationDeployment.GetLabels(), labels)
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Compare labels on work-webhook
 			gomega.Eventually(func() error {
-				registrationDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubWorkWebhookDeployment, metav1.GetOptions{})
+				k8sHubWorkWebhookDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubWorkWebhookDeployment, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected work-webhook labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
-				}
+				util.MapConsists(k8sHubWorkWebhookDeployment.GetLabels(), labels)
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Compare labels on placement-controller
 			gomega.Eventually(func() error {
-				registrationDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubPlacementDeployment, metav1.GetOptions{})
+				k8sHubPlacementDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubPlacementDeployment, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected placement-controller labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
-				}
+				util.MapConsists(k8sHubPlacementDeployment.GetLabels(), labels)
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Compare labels on addon-manager-controller
 			gomega.Eventually(func() error {
-				registrationDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubAddOnManagerDeployment, metav1.GetOptions{})
+				k8sHubAddOnManagerDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubAddOnManagerDeployment, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected labels addon-manager-controller to be %v, but got %v", labels, registrationDeployment.GetLabels())
-				}
+				util.MapConsists(k8sHubAddOnManagerDeployment.GetLabels(), labels)
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 
 			// Compare labels on work-controller
 			gomega.Eventually(func() error {
-				registrationDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).Get(context.Background(), hubWorkControllerDeployment, metav1.GetOptions{})
+				k8sHubWorkControllerDeployment, err := kubeClient.AppsV1().Deployments(hubNamespace).
+					Get(context.Background(), hubWorkControllerDeployment, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				if !helpers.MapCompare(registrationDeployment.GetLabels(), labels) {
-					return fmt.Errorf("expected work-controller labels to be %v, but got %v", labels, registrationDeployment.GetLabels())
-				}
+				util.MapConsists(k8sHubWorkControllerDeployment.GetLabels(), labels)
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
 		})

--- a/test/integration/util/helpers.go
+++ b/test/integration/util/helpers.go
@@ -1,0 +1,17 @@
+package util
+
+// MapConsists checks if the initialMap is a subset of the entireMap.
+func MapConsists(initialMap, entireMap map[string]string) bool {
+	if len(initialMap) == 0 {
+		println("Initial map is empty, returning true")
+		return true
+	}
+	for key, value := range initialMap {
+		if entireMap[key] != value {
+			println("Map does not consist, returning false")
+			return false
+		}
+	}
+	println("Map consists of the required values, returning true")
+	return true
+}


### PR DESCRIPTION
## Summary
This PR removes the3 additional tags in the label selectors of deployments that are created by clustermanager operator in open-cluster-management-hub namespace.
## Related issue(s)

Fixes #1046 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Deployment manifests now use dynamic label values based on the cluster manager name for improved flexibility.
  * Selector matchLabels in several manifests were simplified to only include the fixed app label, removing conditional dynamic labels.

* **Tests**
  * Updated integration tests to align with new label expectations and improved label verification logic.

* **Chores**
  * Added a utility function for checking if one set of labels is a subset of another, enhancing test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->