### PR TITLE
:bug:revert the app label

### DIFF
--- a/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-addon-manager-deployment.yaml
@@ -14,11 +14,11 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: {{ .ClusterManagerName }}-addon-manager-controller
+      app: clustermanager-addon-manager-controller
   template:
     metadata:
       labels:
-        app: {{ .ClusterManagerName }}-addon-manager-controller
+        app: clustermanager-addon-manager-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-placement-deployment.yaml
@@ -14,11 +14,11 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: {{ .ClusterManagerName }}-placement-controller
+      app: clustermanager-placement-controller
   template:
     metadata:
       labels:
-        app: {{ .ClusterManagerName }}-placement-controller
+        app: clustermanager-placement-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{ $key }}": "{{ $value }}"

--- a/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
+++ b/manifests/cluster-manager/management/cluster-manager-registration-deployment.yaml
@@ -14,11 +14,11 @@ spec:
   replicas: {{ .Replica }}
   selector:
     matchLabels:
-      app: {{ .ClusterManagerName }}-registration-controller
+      app: clustermanager-registration-controller
   template:
     metadata:
       labels:
-        app: {{ .ClusterManagerName }}-registration-controller
+        app: clustermanager-registration-controller
         {{ if gt (len .Labels) 0 }}
         {{ range $key, $value := .Labels }}
         "{{$key}}": "{{$value}}"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
cannot change the app label in the deployments, since it is used in the spec.selector.matchLabels, will affect the upgrade.
## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized deployment labels in cluster manager manifests by replacing dynamic app label values with static values for improved consistency. No changes to deployment functionality or configuration beyond label updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->