### PR TITLE
🐛 Should start clusterprofile informer when featuregate is enabled

### DIFF
--- a/pkg/registration/hub/manager.go
+++ b/pkg/registration/hub/manager.go
@@ -349,7 +349,7 @@ func (m *HubManagerOptions) RunControllerManagerWithInformers(
 	go workInformers.Start(ctx.Done())
 	go kubeInformers.Start(ctx.Done())
 	go addOnInformers.Start(ctx.Done())
-	if features.HubMutableFeatureGate.Enabled(ocmfeature.DefaultClusterSet) {
+	if features.HubMutableFeatureGate.Enabled(ocmfeature.ClusterProfile) {
 		go clusterProfileInformers.Start(ctx.Done())
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the condition for starting certain background processes to align with a different feature setting. No visible changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->