### PR TITLE
:bug: adjust base and max delay for appliedmanifestwork deletion

### DIFF
--- a/pkg/work/helper/helpers.go
+++ b/pkg/work/helper/helpers.go
@@ -190,7 +190,7 @@ func DeleteAppliedResources(
 			Namespace(resource.Namespace).
 			Get(ctx, resource.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
-			klog.V(2).Infof("Resource %v with key %s/%s is removed Successfully", gvr, resource.Namespace, resource.Name)
+			klog.Infof("Resource %v with key %s/%s is removed Successfully", gvr, resource.Namespace, resource.Name)
 			continue
 		}
 

--- a/pkg/work/spoke/controllers/finalizercontroller/appliedmanifestwork_finalize_controller_test.go
+++ b/pkg/work/spoke/controllers/finalizercontroller/appliedmanifestwork_finalize_controller_test.go
@@ -102,7 +102,7 @@ func TestFinalize(t *testing.T) {
 			},
 		},
 		{
-			name:               "requeue work when deleting resources are still visiable",
+			name:               "requeue work when deleting resources are still visible",
 			terminated:         true,
 			existingFinalizers: []string{workapiv1.AppliedManifestWorkFinalizer},
 			existingResources: []runtime.Object{
@@ -191,7 +191,7 @@ func TestFinalize(t *testing.T) {
 					*workapiv1.AppliedManifestWork, workapiv1.AppliedManifestWorkSpec, workapiv1.AppliedManifestWorkStatus](
 					fakeClient.WorkV1().AppliedManifestWorks()),
 				spokeDynamicClient: fakeDynamicClient,
-				rateLimiter:        workqueue.NewItemExponentialFailureRateLimiter(0, 1*time.Second),
+				rateLimiter:        workqueue.NewTypedItemExponentialFailureRateLimiter[string](0, 1*time.Second),
 			}
 
 			controllerContext := testingcommon.NewFakeSyncContext(t, testingWork.Name)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

There is a significant delay when deleting a ManifestWork if it contains a resource that takes a long time to delete, After adjust the delay, the max delay will be controlled under  60s

I0811 11:17:38.780296  1 resources pending deletions (delay=50ms)
I0811 11:17:38.833872  1 resources pending deletions (delay=100ms)
I0811 11:17:38.938012  1 resources pending deletions (delay=200ms)
I0811 11:17:39.146050  1 resources pending deletions (delay=400ms)
I0811 11:17:39.555019  1 resources pending deletions (delay=800ms)
I0811 11:17:40.362369  1 resources pending deletions (delay=1s)
I0811 11:17:41.967971  1 resources pending deletions (delay=3s)
I0811 11:17:45.175128  1 resources pending deletions (delay=6s)
I0811 11:17:51.582749  1 resources pending deletions (delay=12s)
I0811 11:18:04.390609  1 resources pending deletions (delay=25s)
I0811 11:18:29.997523  1 resources pending deletions (delay=51s)
I0811 11:19:21.201125  1 resources pending deletions (delay=60s)
I0811 11:20:21.208358  1 resources pending deletions (delay=60s)





## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to a typed, string-keyed rate limiter with adjusted backoff (50 ms min, 60 s max) to refine retry cadence for pending deletions.
* **Style**
  * Made a resource removal message log at Info level unconditionally.
  * Enhanced pending-deletion logs to include the manifest work name for clearer diagnostics.
* **Tests**
  * Updated tests to use the new typed rate limiter and backoff; fixed a test name typo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->