### PR TITLE
:book: Revert "docs: update argocd-agent solution with new param"

### DIFF
--- a/solutions/argocd-agent/README.md
+++ b/solutions/argocd-agent/README.md
@@ -159,14 +159,7 @@ helm -n argocd install argocd-agent-addon charts/argocd-agent-addon \
   --set-file agent.secrets.tlskey=/tmp/tls.key \
   --set-file agent.secrets.jwtkey=/tmp/jwt.key \
   --set agent.principal.server.address="172.18.255.200" \
-  --set agent.mode="managed" \
-  --set agent.principal.redis.address="172.18.255.201:6379" \
-  --set agent.principal.redis.compressionType="gzip" \
-  --set agent.redis.username="redis-username" \
-  --set agent.redis.password="redis-password" \
-  --set agent.principal.resourceProxy.enabled=true \
-  --set agent.principal.healthCheck.enabled=true \
-  --set agent.principal.metrics.enabled=true
+  --set agent.mode="managed" # or "autonomous" for autonomous mode
 ```
 
 Validate that the Argo CD Agent principal pod is running:


### PR DESCRIPTION
We are about to use a different approach (operator based) for argocd-agent install. Let's make the current addon a bit more minimalistic in the meantime.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Revert "docs: update argocd-agent solution with new param"
This reverts commit f0aecfb49aa71f198d0d4608a529f30c675c44db.

## Related issue(s)

Fixes #NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified the Argo CD Agent AddOn installation example: replaced a long list of Helm --set options with a single agent.mode setting (with a note on managed vs autonomous).
  - Streamlines setup for most users; advanced settings (e.g., Redis, resource proxy, health checks, metrics) are no longer shown and will rely on defaults or require manual configuration if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->