### PR TITLE
🌱 Disable registry push in post workflow

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -86,7 +86,7 @@ jobs:
           subject-name: quay.io/open-cluster-management/${{ matrix.image-name }}
           subject-digest: ${{ env.IMAGE_DIGEST }}
           sbom-path: 'sbom.spdx.json'
-          push-to-registry: true
+          push-to-registry: false
   image-manifest:
     name: image manifest
     runs-on: ubuntu-latest
@@ -132,7 +132,7 @@ jobs:
           subject-name: quay.io/open-cluster-management/${{ matrix.image-name }}
           subject-digest: ${{ env.IMAGE_DIGEST_LATEST }}
           sbom-path: 'sbom.spdx.json'
-          push-to-registry: true
+          push-to-registry: false
   trigger-clusteradm-e2e:
     needs: [ images, image-manifest ]
     name: trigger clusteradm e2e


### PR DESCRIPTION
Set push-to-registry to false to prevent automatic pushing to the registry during post workflow execution.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #