### PR TITLE
:seedling: support cert auto approve for grpc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.10.0
 	github.com/valyala/fasttemplate v1.2.2
-	golang.org/x/net v0.43.0
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.18.5
 	k8s.io/api v0.33.4
@@ -156,6 +155,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.3 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
+	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect

--- a/pkg/common/helpers/constants.go
+++ b/pkg/common/helpers/constants.go
@@ -7,3 +7,6 @@ const (
 )
 
 const GRPCCAuthSigner = "open-cluster-management.io/grpc"
+
+// CSRUserAnnotation will be added to a CSR and used to identify the user who request the CSR
+const CSRUserAnnotation = "open-cluster-management.io/csruser"

--- a/pkg/registration/register/csr/approver_beta_test.go
+++ b/pkg/registration/register/csr/approver_beta_test.go
@@ -146,11 +146,15 @@ func Test_v1beta1CSRApprovingController_sync(t *testing.T) {
 			}
 
 			ctrl := &csrApprovingController[*certificatesv1beta1.CertificateSigningRequest]{
-				lister:   informerFactory.Certificates().V1beta1().CertificateSigningRequests().Lister(),
-				approver: newCSRV1beta1Approver(kubeClient),
+				lister:        informerFactory.Certificates().V1beta1().CertificateSigningRequests().Lister(),
+				approver:      newCSRV1beta1Approver(kubeClient),
+				csrInfoGetter: getCSRv1beta1Info,
 				reconcilers: []Reconciler{
-					&csrBootstrapReconciler{},
+					&csrBootstrapReconciler{
+						signer: certificatesv1beta1.KubeAPIServerClientSignerName,
+					},
 					&csrRenewalReconciler{
+						signer:        certificatesv1beta1.KubeAPIServerClientSignerName,
 						kubeClient:    kubeClient,
 						eventRecorder: eventstesting.NewTestingEventRecorder(t),
 					},

--- a/pkg/server/services/csr/csr.go
+++ b/pkg/server/services/csr/csr.go
@@ -19,7 +19,9 @@ import (
 	csrce "open-cluster-management.io/sdk-go/pkg/cloudevents/clients/csr"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types"
 	"open-cluster-management.io/sdk-go/pkg/cloudevents/server"
+	"open-cluster-management.io/sdk-go/pkg/cloudevents/server/grpc/authn"
 
+	"open-cluster-management.io/ocm/pkg/common/helpers"
 	"open-cluster-management.io/ocm/pkg/server/services"
 )
 
@@ -84,6 +86,11 @@ func (c *CSRService) HandleStatusUpdate(ctx context.Context, evt *cloudevents.Ev
 
 	switch eventType.Action {
 	case types.CreateRequestAction:
+		// The agent requests a CSR, and the gRPC server creates the CSR on the hub. As a result,
+		// the username in the csr is the service account of gRPC server rather than the user of agent.
+		// The approver controller in the registration will not be able to know where this CSR originates
+		// from. Therefore, this annotation with the agent's username is added for CSR approval checks.
+		csr.Annotations = map[string]string{helpers.CSRUserAnnotation: fmt.Sprintf("%v", ctx.Value(authn.ContextUserKey))}
 		_, err := c.csrClient.CertificatesV1().CertificateSigningRequests().Create(ctx, csr, metav1.CreateOptions{})
 		return err
 	default:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CLI flags to auto-approve specified gRPC users and set gRPC certificate signing duration (default 720h).
  - gRPC path runs CSR approving and signing controllers in parallel.
  - New exported constant to record CSR creating user as an annotation.

- **Improvements**
  - CSR handling is signer-aware with a standardized exported CSR info shape and multi-version CSR support.

- **Tests**
  - New integration/unit tests for mTLS, CSR auto-approval, event filtering, and certificate rotation.

- **Chores**
  - Dependency cleanup in go.mod.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->