### PR TITLE
🐛 Ignore already existing error when creating cluster

### DIFF
--- a/test/e2e/addon_lease_test.go
+++ b/test/e2e/addon_lease_test.go
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("Addon Health Check", ginkgo.Label("addon-lease"), func(
 					return err
 				}
 				if !meta.IsStatusConditionTrue(found.Status.Conditions, "Available") {
-					return fmt.Errorf("condition should be available")
+					return fmt.Errorf("condition should be available, got %v", found.Status.Conditions)
 				}
 				return nil
 			}).Should(gomega.Succeed())

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("Enable addon management feature gate", ginkgo.Ordered, 
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		ginkgo.By(fmt.Sprintf("create the addon %v on the managed cluster namespace %v", addOnName, universalClusterName))
-		err = hub.CreateManagedClusterAddOn(universalClusterName, addOnName, "test-ns") // the install namespace will be ignored
+		err = hub.CreateManagedClusterAddOn(universalClusterName, addOnName, addonInstallNamespace)
 		if err != nil {
 			klog.Errorf("failed to create managed cluster addon %v on the managed cluster namespace %v: %v", addOnName, universalClusterName, err)
 			gomega.Expect(errors.IsAlreadyExists(err)).To(gomega.BeTrue())


### PR DESCRIPTION
In integration test, there is change that creating cluster fails since the cluster is created in the test. The alreadyExist error should be ignored

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registration is idempotent: re-registering an existing cluster no longer errors; creation now handles AlreadyExists and emits quieter, structured logs derived from request context.

* **Chores**
  * Add-on install namespace is now stored in add-on status via a concurrency-safe retry-on-conflict update to ensure it persists reliably.

* **Tests**
  * E2E add-on test uses shared install-namespace variable.
  * Lease test now reports actual condition details in failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->