### PR TITLE
:seedling: support grpc auto approval user config

### DIFF
--- a/manifests/cluster-manager/management/registration/deployment.yaml
+++ b/manifests/cluster-manager/management/registration/deployment.yaml
@@ -96,6 +96,9 @@ spec:
           - "--grpc-ca-file=/var/run/secrets/hub/grpc/certs/tls.crt"
           - "--grpc-key-file=/var/run/secrets/hub/grpc/certs/tls.key"
           {{end}}
+          {{ if .GRPAutoApprovedCUsers }}
+          - "--auto-approved-grpc-users={{ .GRPAutoApprovedCUsers }}"
+          {{ end }}
         env:
           - name: POD_NAME
             valueFrom:

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -42,6 +42,7 @@ type HubConfig struct {
 	LabelsString                      string
 	GRPCAuthEnabled                   bool
 	GRPCServerImage                   string
+	GRPAutoApprovedCUsers             string
 }
 
 type Webhook struct {

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_runtime_reconcile.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_runtime_reconcile.go
@@ -109,7 +109,7 @@ func (c *runtimeReconcile) reconcile(ctx context.Context, cm *operatorapiv1.Clus
 				}
 
 				config.GRPCServerImage = registrationDriver.GRPC.ImagePullSpec
-				// TODO set AutoApprovedIdentities
+				config.GRPAutoApprovedCUsers = strings.Join(registrationDriver.GRPC.AutoApprovedIdentities, ",")
 			}
 		}
 		config.EnabledRegistrationDrivers = strings.Join(enabledRegistrationDrivers, ",")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional configuration to auto-approve specified gRPC users for the registration controller.
  - When provided, the configured identities are propagated to the deployment as a command-line argument.
  - Supports easier onboarding of trusted identities in gRPC-based registration.

- Tests
  - Expanded integration tests to cover gRPC auto-approval behavior and verify expected deployment arguments.
  - Introduced a test label to simplify filtering related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->