### PR TITLE
 🌱 Refactor agent start func to enable grpc integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	open-cluster-management.io/addon-framework v1.0.1-0.20250811135502-4bae358d84c6
 	open-cluster-management.io/api v1.0.1-0.20250903073454-c6702adf44cc
-	open-cluster-management.io/sdk-go v1.0.1-0.20250901084824-d4c9f78c2e6a
+	open-cluster-management.io/sdk-go v1.0.1-0.20250905083121-3fc951c340cc
 	sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03
 	sigs.k8s.io/cluster-inventory-api v0.0.0-20240730014211-ef0154379848
 	sigs.k8s.io/controller-runtime v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ open-cluster-management.io/addon-framework v1.0.1-0.20250811135502-4bae358d84c6 
 open-cluster-management.io/addon-framework v1.0.1-0.20250811135502-4bae358d84c6/go.mod h1:fOPWaRyo6upgHFskcL18Al1kI2Ua9HzrS8uothWEe84=
 open-cluster-management.io/api v1.0.1-0.20250903073454-c6702adf44cc h1:U8O6RhHjp088oWuQsGx6pwwFpOFgWo1gl9qhgIGgDpk=
 open-cluster-management.io/api v1.0.1-0.20250903073454-c6702adf44cc/go.mod h1:lEc5Wkc9ON5ym/qAtIqNgrE7NW7IEOCOC611iQMlnKM=
-open-cluster-management.io/sdk-go v1.0.1-0.20250901084824-d4c9f78c2e6a h1:3AUAQPzzQXqxs4Dk7BwAIIjsWaQEps9JsXp88HEXq3E=
-open-cluster-management.io/sdk-go v1.0.1-0.20250901084824-d4c9f78c2e6a/go.mod h1:JVQupKu0xVcuVP4IUJF7hjvrXK8plZiwGPZcdqngjXk=
+open-cluster-management.io/sdk-go v1.0.1-0.20250905083121-3fc951c340cc h1:wi6w+Gi7MhGepfDFNN71JGc5jIsWWJOtcXJFQfHripM=
+open-cluster-management.io/sdk-go v1.0.1-0.20250905083121-3fc951c340cc/go.mod h1:JVQupKu0xVcuVP4IUJF7hjvrXK8plZiwGPZcdqngjXk=
 sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03 h1:1ShFiMjGQOR/8jTBkmZrk1gORxnvMwm1nOy2/DbHg4U=
 sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03/go.mod h1:F1pT4mK53U6F16/zuaPSYpBaR7x5Kjym6aKJJC0/DHU=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/pkg/work/spoke/controllers/finalizercontroller/unmanaged_appliedmanifestwork_controller.go
+++ b/pkg/work/spoke/controllers/finalizercontroller/unmanaged_appliedmanifestwork_controller.go
@@ -147,7 +147,7 @@ func (m *unmanagedAppliedWorkController) evictAppliedManifestWork(ctx context.Co
 	if err != nil {
 		return err
 	}
-	m.recorder.Eventf("AppliedManifestWorkEvicted", appliedManifestWork.Name,
+	m.recorder.Eventf("AppliedManifestWorkEvicted",
 		"AppliedManifestWork %s evicted by agent %s after eviction grace period", appliedManifestWork.Name, m.agentID)
 	return nil
 }

--- a/test/integration-test.mk
+++ b/test/integration-test.mk
@@ -68,15 +68,10 @@ test-cloudevents-work-mqtt-integration: ensure-kubebuilder-tools build-work-inte
 .PHONY: test-cloudevents-work-mqtt-integration
 
 # In the cloud events scenario, skip the following tests
-# - executor_test.go, this feature is not supported yet by cloud events work client
-# - unmanaged_appliedwork_test.go, this test mainly focus on switching the hub kube-apiserver
-# - manifestworkreplicaset_test.go, this test needs to update the work status with the hub work client,
-#   cloud events work client does not support it. (TODO) may add e2e to for mwrs.
+# - executor_test.go, this feature is not supported yet since the executor field is not in the manifestbundle.
 test-cloudevents-work-grpc-integration: ensure-kubebuilder-tools build-work-integration
 	./work-integration.test -ginkgo.slow-spec-threshold=15s -ginkgo.v -ginkgo.fail-fast \
-		-ginkgo.skip-file manifestworkreplicaset_test.go \
 		-ginkgo.skip-file executor_test.go \
-		-ginkgo.skip-file unmanaged_appliedwork_test.go \
 		-test.driver=grpc \
 		-v=4 ${ARGS}
 .PHONY: test-cloudevents-work-grpc-integration

--- a/test/integration/registration/spokecluster_grpc_test.go
+++ b/test/integration/registration/spokecluster_grpc_test.go
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("Registration using GRPC", ginkgo.Ordered, ginkgo.Label(
 		gomega.Expect(tempDir).ToNot(gomega.BeEmpty())
 
 		bootstrapGRPCConfigFile = path.Join(tempDir, "grpcconfig")
-		_, gRPCServerOptions, gRPCCAKeyFile, err = util.CreateGRPCConfigs(bootstrapGRPCConfigFile)
+		_, gRPCServerOptions, gRPCCAKeyFile, err = util.CreateGRPCConfigs(bootstrapGRPCConfigFile, "8090")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		var grpcServerCtx context.Context

--- a/test/integration/util/grpc.go
+++ b/test/integration/util/grpc.go
@@ -97,7 +97,7 @@ func (h *GRPCServerRegistrationHook) Run(ctx context.Context) {
 	go h.AddOnInformers.Start(ctx.Done())
 }
 
-func CreateGRPCConfigs(configFileName string) (string, *sdkgrpc.GRPCServerOptions, string, error) {
+func CreateGRPCConfigs(configFileName string, port string) (string, *sdkgrpc.GRPCServerOptions, string, error) {
 	serverCertPairs, err := util.NewServerCertPairs()
 	if err != nil {
 		return "", nil, "", err
@@ -133,6 +133,7 @@ func CreateGRPCConfigs(configFileName string) (string, *sdkgrpc.GRPCServerOption
 	serverOptions.ClientCAFile = caFile
 	serverOptions.TLSCertFile = serverCertFile
 	serverOptions.TLSKeyFile = serverKeyFile
+	serverOptions.ServerBindPort = port
 
 	config := &grpc.GRPCConfig{
 		CertConfig: cert.CertConfig{

--- a/test/integration/util/unstructured.go
+++ b/test/integration/util/unstructured.go
@@ -285,7 +285,7 @@ func NewDeployment(namespace, name, sa string) (u *unstructured.Unstructured, gv
 	return u, gvr, nil
 }
 
-func NewDaesonSet(namespace, name string) (u *unstructured.Unstructured, gvr schema.GroupVersionResource, err error) {
+func NewDaemonSet(namespace, name string) (u *unstructured.Unstructured, gvr schema.GroupVersionResource, err error) {
 	u, err = loadResourceFromJSON(daemonsetJson)
 	if err != nil {
 		return u, gvr, err

--- a/test/integration/util/work.go
+++ b/test/integration/util/work.go
@@ -34,11 +34,6 @@ func NewWorkPatch(old, new *workapiv1.ManifestWork) ([]byte, error) {
 	return patchBytes, nil
 }
 
-func AppliedManifestWorkName(sourceDriver, hubHash string, work *workapiv1.ManifestWork) string {
-	if sourceDriver != KubeDriver {
-		// if the source is not kube, the uid will be used as the manifestwork name on the agent side
-		return fmt.Sprintf("%s-%s", hubHash, work.UID)
-	}
-
+func AppliedManifestWorkName(hubHash string, work *workapiv1.ManifestWork) string {
 	return fmt.Sprintf("%s-%s", hubHash, work.Name)
 }

--- a/test/integration/work/executor_test.go
+++ b/test/integration/work/executor_test.go
@@ -3,7 +3,6 @@ package work
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/onsi/ginkgo/v2"
@@ -17,18 +16,15 @@ import (
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 
-	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 	"open-cluster-management.io/ocm/pkg/features"
-	"open-cluster-management.io/ocm/pkg/work/spoke"
 	"open-cluster-management.io/ocm/test/integration/util"
 )
 
 var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
-	var o *spoke.WorkloadAgentOptions
-	var commOptions *commonoptions.AgentOptions
 	var cancel context.CancelFunc
 
 	var work *workapiv1.ManifestWork
+	var clusterName string
 	var manifests []workapiv1.Manifest
 	var executor *workapiv1.ManifestWorkExecutor
 
@@ -38,25 +34,23 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 	executorName := "test-executor"
 
 	ginkgo.BeforeEach(func() {
-		o = spoke.NewWorkloadAgentOptions()
-		o.StatusSyncInterval = 3 * time.Second
-		o.WorkloadSourceDriver = sourceDriver
-		o.WorkloadSourceConfig = sourceConfigFileName
-
 		err := features.SpokeMutableFeatureGate.Set("ExecutorValidatingCaches=true")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			_ = features.SpokeMutableFeatureGate.Set("ExecutorValidatingCaches=false")
+		})
 
-		commOptions = commonoptions.NewAgentOptions()
-		commOptions.SpokeClusterName = utilrand.String(5)
+		clusterName = utilrand.String(5)
 
-		ns := &corev1.Namespace{}
-		ns.Name = commOptions.SpokeClusterName
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName},
+		}
 		_, err = spokeKubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		var ctx context.Context
 		ctx, cancel = context.WithCancel(context.Background())
-		go startWorkAgent(ctx, o, commOptions)
+		go startWorkAgent(ctx, clusterName)
 
 		// reset manifests
 		manifests = nil
@@ -64,7 +58,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 	})
 
 	ginkgo.JustBeforeEach(func() {
-		work = util.NewManifestWork(commOptions.SpokeClusterName, "", manifests)
+		work = util.NewManifestWork(clusterName, "", manifests)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		work.Spec.Executor = executor
 	})
@@ -74,21 +68,21 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			cancel()
 		}
 		err := spokeKubeClient.CoreV1().Namespaces().Delete(
-			context.Background(), commOptions.SpokeClusterName, metav1.DeleteOptions{})
+			context.Background(), clusterName, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	ginkgo.Context("Apply the resource with executor", func() {
 		ginkgo.BeforeEach(func() {
 			manifests = []workapiv1.Manifest{
-				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
-				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm2, map[string]string{"c": "d"}, []string{})),
+				util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
+				util.ToManifest(util.NewConfigmap(clusterName, cm2, map[string]string{"c": "d"}, []string{})),
 			}
 			executor = &workapiv1.ManifestWorkExecutor{
 				Subject: workapiv1.ManifestWorkExecutorSubject{
 					Type: workapiv1.ExecutorSubjectTypeServiceAccount,
 					ServiceAccount: &workapiv1.ManifestWorkSubjectServiceAccount{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      executorName,
 					},
 				},
@@ -96,7 +90,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 		})
 
 		ginkgo.It("Executor does not have permission", func() {
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -112,10 +106,10 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 		})
 
 		ginkgo.It("Executor does not have permission to partial resources", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -128,16 +122,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -149,7 +143,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -163,19 +157,19 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			// ensure configmap cm1 exist and cm2 not exist
 			util.AssertExistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
+					util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 			util.AssertNonexistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm2, map[string]string{"a": "b"}, []string{})),
+					util.ToManifest(util.NewConfigmap(clusterName, cm2, map[string]string{"a": "b"}, []string{})),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 		})
 
 		ginkgo.It("Executor has permission for all resources", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -188,16 +182,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -209,7 +203,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -228,14 +222,14 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 	ginkgo.Context("Apply the resource with executor deleting validating", func() {
 		ginkgo.BeforeEach(func() {
 			manifests = []workapiv1.Manifest{
-				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
-				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm2, map[string]string{"c": "d"}, []string{})),
+				util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
+				util.ToManifest(util.NewConfigmap(clusterName, cm2, map[string]string{"c": "d"}, []string{})),
 			}
 			executor = &workapiv1.ManifestWorkExecutor{
 				Subject: workapiv1.ManifestWorkExecutorSubject{
 					Type: workapiv1.ExecutorSubjectTypeServiceAccount,
 					ServiceAccount: &workapiv1.ManifestWorkSubjectServiceAccount{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      executorName,
 					},
 				},
@@ -243,10 +237,10 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 		})
 
 		ginkgo.It("Executor does not have delete permission and delete option is foreground", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -259,16 +253,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -280,7 +274,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -296,10 +290,10 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 		})
 
 		ginkgo.It("Executor does not have delete permission and delete option is orphan", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -312,16 +306,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -336,7 +330,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			work.Spec.DeleteOption = &workapiv1.DeleteOption{
 				PropagationPolicy: workapiv1.DeletePropagationPolicyTypeOrphan,
 			}
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -352,10 +346,10 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 		})
 
 		ginkgo.It("Executor does not have delete permission and delete option is selectively orphan", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -368,16 +362,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      roleName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -395,13 +389,13 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					OrphaningRules: []workapiv1.OrphaningRule{
 						{
 							Resource:  "configmaps",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      cm1,
 						},
 					},
 				},
 			}
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -415,11 +409,11 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			// ensure configmap cm1 exist and cm2 not exist
 			util.AssertExistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
+					util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 			util.AssertNonexistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm2, map[string]string{"a": "b"}, []string{})),
+					util.ToManifest(util.NewConfigmap(clusterName, cm2, map[string]string{"a": "b"}, []string{})),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 		})
 	})
@@ -427,20 +421,20 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 	ginkgo.Context("Apply the resource with executor escalation validating", func() {
 		ginkgo.BeforeEach(func() {
 			manifests = []workapiv1.Manifest{
-				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
-				util.ToManifest(util.NewRoleForManifest(commOptions.SpokeClusterName, "role-cm-creator", rbacv1.PolicyRule{
+				util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
+				util.ToManifest(util.NewRoleForManifest(clusterName, "role-cm-creator", rbacv1.PolicyRule{
 					Verbs:     []string{"create", "update", "patch", "get", "list", "delete"},
 					APIGroups: []string{""},
 					Resources: []string{"configmaps"},
 				})),
-				util.ToManifest(util.NewRoleBindingForManifest(commOptions.SpokeClusterName, "role-cm-creator-binding",
+				util.ToManifest(util.NewRoleBindingForManifest(clusterName, "role-cm-creator-binding",
 					rbacv1.RoleRef{
 						Kind: "Role",
 						Name: "role-cm-creator",
 					},
 					rbacv1.Subject{
 						Kind:      "ServiceAccount",
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      executorName,
 					})),
 			}
@@ -448,7 +442,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 				Subject: workapiv1.ManifestWorkExecutorSubject{
 					Type: workapiv1.ExecutorSubjectTypeServiceAccount,
 					ServiceAccount: &workapiv1.ManifestWorkSubjectServiceAccount{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      executorName,
 					},
 				},
@@ -456,11 +450,11 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 		})
 
 		ginkgo.It("no permission", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      roleName,
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -472,16 +466,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      roleName,
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -493,7 +487,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -509,16 +503,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			// ensure configmap not exist
 			util.AssertNonexistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
+					util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 		})
 
 		ginkgo.It("no permission for already existing resource", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      roleName,
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -530,16 +524,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      roleName,
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -552,11 +546,11 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// make the role exist with lower permission
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "role-cm-creator",
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -568,7 +562,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -585,16 +579,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			// ensure configmap not exist
 			util.AssertNonexistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
+					util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 		})
 
 		ginkgo.It("with permission", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      roleName,
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -611,16 +605,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      roleName,
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -632,7 +626,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -648,16 +642,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			// ensure configmaps exist
 			util.AssertExistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
+					util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 		})
 
 		ginkgo.It("with permission for already exist resource", func() {
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      roleName,
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -674,16 +668,16 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 					},
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			_, err = spokeKubeClient.RbacV1().RoleBindings(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().RoleBindings(clusterName).Create(
 				context.TODO(), &rbacv1.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      roleName,
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Subjects: []rbacv1.Subject{
 						{
 							Kind:      "ServiceAccount",
-							Namespace: commOptions.SpokeClusterName,
+							Namespace: clusterName,
 							Name:      executorName,
 						},
 					},
@@ -696,11 +690,11 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// make the role exist with lower permission
-			_, err = spokeKubeClient.RbacV1().Roles(commOptions.SpokeClusterName).Create(
+			_, err = spokeKubeClient.RbacV1().Roles(clusterName).Create(
 				context.TODO(), &rbacv1.Role{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "role-cm-creator",
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
@@ -712,7 +706,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 				}, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -728,7 +722,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			// ensure configmaps exist
 			util.AssertExistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
+					util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 		})
 	})
@@ -782,13 +776,13 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 		}
 		ginkgo.BeforeEach(func() {
 			manifests = []workapiv1.Manifest{
-				util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, []string{})),
+				util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, []string{})),
 			}
 			executor = &workapiv1.ManifestWorkExecutor{
 				Subject: workapiv1.ManifestWorkExecutorSubject{
 					Type: workapiv1.ExecutorSubjectTypeServiceAccount,
 					ServiceAccount: &workapiv1.ManifestWorkSubjectServiceAccount{
-						Namespace: commOptions.SpokeClusterName,
+						Namespace: clusterName,
 						Name:      executorName,
 					},
 				},
@@ -796,7 +790,7 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 		})
 
 		ginkgo.It("Permission change", func() {
-			work, err = hubWorkClient.WorkV1().ManifestWorks(commOptions.SpokeClusterName).Create(
+			work, err = hubWorkClient.WorkV1().ManifestWorks(clusterName).Create(
 				context.Background(), work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -810,8 +804,8 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			ginkgo.By("ensure configmaps do not exist")
 			util.AssertNonexistenceOfConfigMaps(manifests, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 
-			createRBAC(commOptions.SpokeClusterName, executorName)
-			addConfigMapToManifestWork(hubWorkClient, work.Name, commOptions.SpokeClusterName, cm2)
+			createRBAC(clusterName, executorName)
+			addConfigMapToManifestWork(hubWorkClient, work.Name, clusterName, cm2)
 
 			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied,
 				metav1.ConditionTrue, []metav1.ConditionStatus{metav1.ConditionTrue, metav1.ConditionTrue},
@@ -823,8 +817,8 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			ginkgo.By("ensure configmaps cm1 and cm2 exist")
 			util.AssertExistenceOfConfigMaps(manifests, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 
-			deleteRBAC(commOptions.SpokeClusterName)
-			addConfigMapToManifestWork(hubWorkClient, work.Name, commOptions.SpokeClusterName, "cm3")
+			deleteRBAC(clusterName)
+			addConfigMapToManifestWork(hubWorkClient, work.Name, clusterName, "cm3")
 
 			util.AssertWorkCondition(work.Namespace, work.Name, hubWorkClient, workapiv1.WorkApplied,
 				metav1.ConditionFalse, []metav1.ConditionStatus{metav1.ConditionFalse, metav1.ConditionFalse,
@@ -836,15 +830,15 @@ var _ = ginkgo.Describe("ManifestWork Executor Subject", func() {
 			ginkgo.By("ensure configmap cm1 cm2 exist(will not delete the applied resource even the permison is revoked) but cm3 does not exist")
 			util.AssertExistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm1, map[string]string{"a": "b"}, nil)),
+					util.ToManifest(util.NewConfigmap(clusterName, cm1, map[string]string{"a": "b"}, nil)),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 			util.AssertExistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, cm2, map[string]string{"a": "b"}, nil)),
+					util.ToManifest(util.NewConfigmap(clusterName, cm2, map[string]string{"a": "b"}, nil)),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 			util.AssertNonexistenceOfConfigMaps(
 				[]workapiv1.Manifest{
-					util.ToManifest(util.NewConfigmap(commOptions.SpokeClusterName, "cm3", map[string]string{"a": "b"}, nil)),
+					util.ToManifest(util.NewConfigmap(clusterName, "cm3", map[string]string{"a": "b"}, nil)),
 				}, spokeKubeClient, eventuallyTimeout, eventuallyInterval)
 		})
 	})

--- a/test/integration/work/suite_test.go
+++ b/test/integration/work/suite_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -35,10 +37,12 @@ import (
 	cemetrics "open-cluster-management.io/sdk-go/pkg/cloudevents/server/grpc/metrics"
 	sdkgrpc "open-cluster-management.io/sdk-go/pkg/server/grpc"
 
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
 	"open-cluster-management.io/ocm/pkg/features"
 	serviceswork "open-cluster-management.io/ocm/pkg/server/services/work"
 	"open-cluster-management.io/ocm/pkg/work/helper"
 	"open-cluster-management.io/ocm/pkg/work/hub"
+	"open-cluster-management.io/ocm/pkg/work/spoke"
 	"open-cluster-management.io/ocm/test/integration/util"
 )
 
@@ -164,31 +168,23 @@ var _ = ginkgo.BeforeSuite(func() {
 		hubWorkClient, err = workclientset.NewForConfig(cfg)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		sourceConfigFileName = path.Join(tempDir, "grpcconfig")
-		gRPCURL, gRPCServerOptions, _, err := util.CreateGRPCConfigs(sourceConfigFileName)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		sourceConfigFileName, hubHash = startGRPCServer(envCtx, tempDir, cfg)
 
-		hubHash = helper.HubHash(gRPCURL)
-
-		hook, err := util.NewGRPCServerWorkHook(cfg)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		go hook.Run(envCtx)
-
-		grpcEventServer := cloudeventsgrpc.NewGRPCBroker()
-		grpcEventServer.RegisterService(payload.ManifestBundleEventDataType,
-			serviceswork.NewWorkService(hook.WorkClient, hook.WorkInformers.Work().V1().ManifestWorks()))
-
-		authorizer := util.NewMockAuthorizer()
-		server := sdkgrpc.NewGRPCServer(gRPCServerOptions).
-			WithUnaryAuthorizer(authorizer).
-			WithStreamAuthorizer(authorizer).
-			WithRegisterFunc(func(s *grpc.Server) {
-				pbv1.RegisterCloudEventServiceServer(s, grpcEventServer)
-			}).
-			WithExtraMetrics(cemetrics.CloudEventsGRPCMetrics()...)
-
+		// start hub controller
 		go func() {
-			err := server.Run(envCtx)
+			// in grpc driver, hub controller still calls hub kube-apiserver.
+			sourceKubeConfigFileName := path.Join(tempDir, "kubeconfig")
+			err = util.CreateKubeconfigFile(cfg, sourceKubeConfigFileName)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			opts := hub.NewWorkHubManagerOptions()
+			opts.WorkDriver = "kube"
+			opts.WorkDriverConfig = sourceKubeConfigFileName
+			hubConfig := hub.NewWorkHubManagerConfig(opts)
+			err := hubConfig.RunWorkHubManager(envCtx, &controllercmd.ControllerContext{
+				KubeConfig:    cfg,
+				EventRecorder: util.NewIntegrationTestEventRecorder("hub"),
+			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		}()
 	default:
@@ -222,3 +218,68 @@ var _ = ginkgo.AfterSuite(func() {
 		os.RemoveAll(tempDir)
 	}
 })
+
+type agentOptionsDecorator func(opt *spoke.WorkloadAgentOptions, commonOpt *commonoptions.AgentOptions) (
+	*spoke.WorkloadAgentOptions, *commonoptions.AgentOptions)
+
+func startWorkAgent(ctx context.Context, clusterName string, decorators ...agentOptionsDecorator) {
+	o := spoke.NewWorkloadAgentOptions()
+	o.StatusSyncInterval = 3 * time.Second
+	o.WorkloadSourceDriver = sourceDriver
+	o.WorkloadSourceConfig = sourceConfigFileName
+	if sourceDriver != util.KubeDriver {
+		o.CloudEventsClientID = fmt.Sprintf("%s-work-agent", clusterName)
+		o.CloudEventsClientCodecs = []string{"manifestbundle"}
+	}
+
+	commOptions := commonoptions.NewAgentOptions()
+	commOptions.SpokeClusterName = clusterName
+
+	for _, decorator := range decorators {
+		o, commOptions = decorator(o, commOptions)
+	}
+
+	agentConfig := spoke.NewWorkAgentConfig(commOptions, o)
+	err := agentConfig.RunWorkloadAgent(ctx, &controllercmd.ControllerContext{
+		KubeConfig:    spokeRestConfig,
+		EventRecorder: util.NewIntegrationTestEventRecorder("integration"),
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func startGRPCServer(ctx context.Context, temp string, cfg *rest.Config) (string, string) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	bindPort := fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
+	_ = ln.Close()
+
+	configFileName := path.Join(temp, "grpcconfig")
+	gRPCURL, gRPCServerOptions, _, err := util.CreateGRPCConfigs(configFileName, bindPort)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	hubHash := helper.HubHash(gRPCURL)
+
+	hook, err := util.NewGRPCServerWorkHook(cfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	go hook.Run(ctx)
+
+	grpcEventServer := cloudeventsgrpc.NewGRPCBroker()
+	grpcEventServer.RegisterService(payload.ManifestBundleEventDataType,
+		serviceswork.NewWorkService(hook.WorkClient, hook.WorkInformers.Work().V1().ManifestWorks()))
+
+	authorizer := util.NewMockAuthorizer()
+	server := sdkgrpc.NewGRPCServer(gRPCServerOptions).
+		WithUnaryAuthorizer(authorizer).
+		WithStreamAuthorizer(authorizer).
+		WithRegisterFunc(func(s *grpc.Server) {
+			pbv1.RegisterCloudEventServiceServer(s, grpcEventServer)
+		}).
+		WithExtraMetrics(cemetrics.CloudEventsGRPCMetrics()...)
+
+	go func() {
+		err := server.Run(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}()
+
+	return configFileName, hubHash
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1813,7 +1813,7 @@ open-cluster-management.io/api/operator/v1
 open-cluster-management.io/api/utils/work/v1/workapplier
 open-cluster-management.io/api/work/v1
 open-cluster-management.io/api/work/v1alpha1
-# open-cluster-management.io/sdk-go v1.0.1-0.20250901084824-d4c9f78c2e6a
+# open-cluster-management.io/sdk-go v1.0.1-0.20250905083121-3fc951c340cc
 ## explicit; go 1.24.0
 open-cluster-management.io/sdk-go/pkg/apis/cluster/v1alpha1
 open-cluster-management.io/sdk-go/pkg/apis/cluster/v1beta1

--- a/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/agent/codec/manifestbundle.go
+++ b/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/agent/codec/manifestbundle.go
@@ -62,6 +62,7 @@ func (c *ManifestBundleCodec) Encode(source string, eventType types.CloudEventsT
 	evt := types.NewEventBuilder(source, eventType).
 		WithResourceID(string(work.UID)).
 		WithStatusUpdateSequenceID(sequenceGenerator.Generate().String()).
+		WithResourceName(work.Name).
 		WithResourceVersion(resourceVersion).
 		WithClusterName(work.Namespace).
 		WithOriginalSource(originalSource).
@@ -104,6 +105,17 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 		return nil, fmt.Errorf("failed to get resourceid extension: %v", err)
 	}
 
+	var resourceName string
+	if v, ok := evtExtensions[types.ExtensionResourceName]; ok {
+		resourceName, err = cloudeventstypes.ToString(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get resourcename extension: %v", err)
+		}
+	} else {
+		// fall back to set resourceName to resourceID
+		resourceName = resourceID
+	}
+
 	resourceVersion, err := cloudeventstypes.ToInteger(evtExtensions[types.ExtensionResourceVersion])
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resourceversion extension: %v", err)
@@ -123,7 +135,7 @@ func (c *ManifestBundleCodec) Decode(evt *cloudevents.Event) (*workv1.ManifestWo
 			UID:             kubetypes.UID(resourceID),
 			Generation:      int64(resourceVersion),
 			ResourceVersion: fmt.Sprintf("%d", resourceVersion),
-			Name:            resourceID,
+			Name:            resourceName,
 			Namespace:       clusterName,
 			Labels: map[string]string{
 				common.CloudEventsOriginalSourceLabelKey: evt.Source(),

--- a/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types/types.go
+++ b/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/generic/types/types.go
@@ -57,6 +57,9 @@ const (
 	// ExtensionResourceID is the cloud event extension key of the resource ID.
 	ExtensionResourceID = "resourceid"
 
+	// ExtensionResourceName is the cloud event extension key of the resource name.
+	ExtensionResourceName = "resourcename"
+
 	// ExtensionResourceVersion is the cloud event extension key of the resource version.
 	ExtensionResourceVersion = "resourceversion"
 
@@ -228,6 +231,7 @@ type EventBuilder struct {
 	clusterName       string
 	originalSource    string
 	resourceID        string
+	resourceName      string
 	sequenceID        string
 	resourceVersion   *int64
 	eventType         CloudEventsType
@@ -243,6 +247,11 @@ func NewEventBuilder(source string, eventType CloudEventsType) *EventBuilder {
 
 func (b *EventBuilder) WithResourceID(resourceID string) *EventBuilder {
 	b.resourceID = resourceID
+	return b
+}
+
+func (b *EventBuilder) WithResourceName(resourceName string) *EventBuilder {
+	b.resourceName = resourceName
 	return b
 }
 
@@ -283,6 +292,13 @@ func (b *EventBuilder) NewEvent() cloudevents.Event {
 
 	if len(b.resourceID) != 0 {
 		evt.SetExtension(ExtensionResourceID, b.resourceID)
+	}
+
+	if len(b.resourceName) != 0 {
+		evt.SetExtension(ExtensionResourceName, b.resourceName)
+	} else {
+		// if resourceName is not set, uses resourceID as the resourceName
+		evt.SetExtension(ExtensionResourceName, b.resourceID)
 	}
 
 	if b.resourceVersion != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed eviction event formatting so eviction events show the correct agent and work details.

- Tests
  - Re-enabled several previously skipped integration scenarios (MQTT/GRPC).
  - Refactored tests to use per-cluster identifiers and decorator-based agent setup; made GRPC port configurable.
  - Standardized applied-manifest naming and corrected a daemonset test helper name.

- Refactor
  - Migrated controller logs to structured logging and added targeted requeue behavior for specific error states.

- Chores
  - Bumped an SDK dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->