### PR TITLE
🐛 Fix helm command syntax in e2e test deployment

### DIFF
--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -23,11 +23,11 @@ deploy-hub: deploy-hub-helm hub-kubeconfig cluster-ip
 deploy-hub-helm: ensure-helm
 	$(HELM) install cluster-manager deploy/cluster-manager/chart/cluster-manager --namespace=open-cluster-management \
 			--create-namespace \
-			--set images.overrides.operatorImage=$(OPERATOR_IMAGE_NAME), \
+			--set images.overrides.operatorImage=$(OPERATOR_IMAGE_NAME) \
 			--set images.overrides.registrationImage=$(REGISTRATION_IMAGE) \
-			--set images.overrides.workImage=$(WORK_IMAGE),
-			--set images.overrides.placementImage=$(PLACEMENT_IMAGE), \
-			--set images.overrides.addOnManagerImage=$(ADDON_MANAGER_IMAGE), \
+			--set images.overrides.workImage=$(WORK_IMAGE) \
+			--set images.overrides.placementImage=$(PLACEMENT_IMAGE) \
+			--set images.overrides.addOnManagerImage=$(ADDON_MANAGER_IMAGE) \
 			--set replicaCount=1
 
 deploy-hub-operator: ensure-kustomize
@@ -70,7 +70,7 @@ deploy-spoke-operator-helm: ensure-helm
 	$(HELM) install klusterlet deploy/klusterlet/chart/klusterlet --namespace=open-cluster-management \
         --create-namespace \
         --set-file bootstrapHubKubeConfig=$(HUB_KUBECONFIG) \
-        --set klusterlet.create=false, \
+        --set klusterlet.create=false \
         --set images.overrides.operatorImage=$(OPERATOR_IMAGE_NAME) \
         --set images.overrides.registrationImage=$(REGISTRATION_IMAGE) \
         --set images.overrides.workImage=$(WORK_IMAGE)


### PR DESCRIPTION
Remove unnecessary commas from --set flags in helm commands. Multiple --set flags don't require commas between them.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/ocm/issues/1167