### PR TITLE
✨ Add labels to resources created by work controller

### DIFF
--- a/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_reconcile.go
+++ b/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_reconcile.go
@@ -271,16 +271,25 @@ func CreateManifestWork(
 		return nil, fmt.Errorf("invalid cluster namespace")
 	}
 
+	// Get ManifestWorkReplicaSet labels
+	labels := mwrSet.Labels
+
 	// TODO consider how to trace the manifestworks spec changes for cloudevents work client
+
+	// Merge mwrSet.Labels with the required labels
+	mergedLabels := make(map[string]string)
+	for k, v := range labels {
+		mergedLabels[k] = v
+	}
+
+	mergedLabels[ManifestWorkReplicaSetControllerNameLabelKey] = manifestWorkReplicaSetKey(mwrSet)
+	mergedLabels[ManifestWorkReplicaSetPlacementNameLabelKey] = placementRefName
 
 	return &workv1.ManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mwrSet.Name,
 			Namespace: clusterNS,
-			Labels: map[string]string{
-				ManifestWorkReplicaSetControllerNameLabelKey: manifestWorkReplicaSetKey(mwrSet),
-				ManifestWorkReplicaSetPlacementNameLabelKey:  placementRefName,
-			},
+			Labels:    mergedLabels,
 		},
 		Spec: mwrSet.Spec.ManifestWorkTemplate,
 	}, nil

--- a/pkg/work/spoke/controllers/manifestcontroller/manifestwork_controller.go
+++ b/pkg/work/spoke/controllers/manifestcontroller/manifestwork_controller.go
@@ -139,7 +139,7 @@ func (m *ManifestWorkController) sync(ctx context.Context, controllerContext fac
 	}
 
 	// Apply appliedManifestWork
-	appliedManifestWork, err := m.applyAppliedManifestWork(ctx, manifestWork.Name, m.hubHash, m.agentID)
+	appliedManifestWork, err := m.applyAppliedManifestWork(ctx, manifestWork.Name, m.hubHash, m.agentID, manifestWork.ObjectMeta.Labels)
 	if err != nil {
 		return err
 	}
@@ -187,11 +187,13 @@ func (m *ManifestWorkController) sync(ctx context.Context, controllerContext fac
 	return nil
 }
 
-func (m *ManifestWorkController) applyAppliedManifestWork(ctx context.Context, workName, hubHash, agentID string) (*workapiv1.AppliedManifestWork, error) {
+func (m *ManifestWorkController) applyAppliedManifestWork(ctx context.Context, workName,
+	hubHash, agentID string, labels map[string]string) (*workapiv1.AppliedManifestWork, error) {
 	appliedManifestWorkName := fmt.Sprintf("%s-%s", m.hubHash, workName)
 	requiredAppliedWork := &workapiv1.AppliedManifestWork{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       appliedManifestWorkName,
+			Labels:     labels,
 			Finalizers: []string{workapiv1.AppliedManifestWorkFinalizer},
 		},
 		Spec: workapiv1.AppliedManifestWorkSpec{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds labels to the resources created by work controller on the Hub (manifestworks) and on the spoke (appliedmanifestworks). These are the labels added on the manifestworkreplicaset when they are created. 
## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - ManifestWorks created from a ManifestWorkReplicaSet now inherit and preserve all existing labels from the replica set, while ensuring required labels are applied.
  - AppliedManifestWork now includes labels propagated from its corresponding ManifestWork at creation time, improving label-based organization and querying.

- Tests
  - Added integration tests to verify label consistency between ManifestWorkReplicaSets and their ManifestWorks.
  - Added integration tests to ensure labels on ManifestWork are propagated to the corresponding AppliedManifestWork.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->