### PR TITLE
🌱 Remove resolved TODO comments

### DIFF
--- a/pkg/addon/templateagent/registration.go
+++ b/pkg/addon/templateagent/registration.go
@@ -157,7 +157,6 @@ func CustomSignerConfigurations(addonName, agentName string,
 		}
 		config := addonapiv1alpha1.RegistrationConfig{
 			SignerName: customSignerConfig.SignerName,
-			// TODO: confirm the subject
 			Subject: addonapiv1alpha1.Subject{
 				User:   agent.DefaultUser(cluster.Name, addonName, agentName),
 				Groups: agent.DefaultGroups(cluster.Name, addonName),

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_managed_reconcile.go
@@ -60,7 +60,6 @@ func (r *managedReconcile) reconcile(ctx context.Context, klusterlet *operatorap
 	if !config.DisableAddonNamespace {
 		// For now, whether in Default or Hosted mode, the addons will be deployed on the managed cluster.
 		// sync image pull secret from management cluster to managed cluster for addon namespace
-		// TODO(zhujian7): In the future, we may consider deploy addons on the management cluster in Hosted mode.
 		// Ensure the addon namespace on the managed cluster
 		if err := ensureNamespace(
 			ctx,

--- a/pkg/operator/operators/klusterlet/options.go
+++ b/pkg/operator/operators/klusterlet/options.go
@@ -34,7 +34,7 @@ type Options struct {
 
 // RunKlusterletOperator starts a new klusterlet operator
 func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
-	// Build kube client and informer for managed cluster
+	// Build kube client and informer
 	kubeClient, err := kubernetes.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return err

--- a/pkg/work/webhook/v1/manifestwork_validating.go
+++ b/pkg/work/webhook/v1/manifestwork_validating.go
@@ -88,7 +88,7 @@ func validateExecutor(kubeClient kubernetes.Interface, work *workv1.ManifestWork
 				Type: workv1.ExecutorSubjectTypeServiceAccount,
 				ServiceAccount: &workv1.ManifestWorkSubjectServiceAccount{
 					// give the default value "system:serviceaccount::klusterlet-work-sa"
-					Namespace: "",                   // TODO: Not sure what value is reasonable
+					Namespace: "",
 					Name:      "klusterlet-work-sa", // the default sa of the work agent
 				},
 			},


### PR DESCRIPTION
- Remove TODO comment about confirming subject in CustomSignerConfigurations
- Remove TODO comment about namespace value in manifestwork validating webhook
- Remove outdated TODO comment about addon deployment in Hosted mode, since Namespace creation is responsibility of addon developers, and image pull secrets are synced to namespaces with addon.open-cluster-management.io/namespace label by the AddonPullImageSecretController

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed outdated inline TODO comments to improve code readability; no behavioral or configuration changes.
* **Chores**
  * Minor cleanup across internal modules to reduce noise and aid maintenance. No API/CLI/UI changes, no impact on workflows or operations; no action required from users or operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->