### PR TITLE
:sparkles: add grpc config into the bootstrap secret

### DIFF
--- a/deploy/klusterlet/chart/klusterlet/templates/bootstrap_kubeconfig_secret.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/bootstrap_kubeconfig_secret.yaml
@@ -22,4 +22,7 @@ metadata:
 type: Opaque
 data:
   kubeconfig: "{{ .Values.bootstrapHubKubeConfig | b64enc }}"
+  {{- if .Values.grpcConfig }}
+  config.yaml: "{{ .Values.grpcConfig | b64enc }}"
+  {{- end }}
 {{- end }}

--- a/deploy/klusterlet/chart/klusterlet/values.yaml
+++ b/deploy/klusterlet/chart/klusterlet/values.yaml
@@ -78,6 +78,10 @@ enableSyncLabels: false
 # should be the kubeConfig file of the hub cluster via setting --set-file=<the kubeConfig file of hub cluster> optional
 bootstrapHubKubeConfig: ""
 
+# grpcConfig includes the information needed to build connect to gRPC server in the bootstrap secret for
+# cluster importing via setting --set-file=<the grpc config file> optional.
+grpcConfig: ""
+
 # when MultipleHubs feature gate in klusterlet.registrationConfiguration is enabled, could set multiple bootstrap hub kubeConfigs here.
 # otherwise can create these kubeConfig secret in the klusterlet.namespace manually on the managed cluster.
 multiHubBootstrapHubKubeConfigs:

--- a/pkg/operator/helpers/chart/config.go
+++ b/pkg/operator/helpers/chart/config.go
@@ -65,6 +65,10 @@ type KlusterletChartConfig struct {
 	// BootstrapHubKubeConfig should be the kubeConfig file of the hub cluster via setting --set-file=<the kubeConfig file of hub cluster> optional
 	BootstrapHubKubeConfig string `json:"bootstrapHubKubeConfig,omitempty"`
 
+	// GRPCConfig includes the information needed to build connect to gRPC server in the bootstrap secret for
+	// cluster importing via setting --set-file=<the grpc config file> optional.
+	GRPCConfig string `json:"grpcConfig,omitempty"`
+
 	// when MultipleHubs feature gate in klusterlet.registrationConfiguration is enabled, need to set multiple bootstrap hub kubeConfigs here.
 	MultiHubBootstrapHubKubeConfigs []BootStrapKubeConfig `json:"multiHubBootstrapHubKubeConfigs,omitempty"`
 
@@ -81,6 +85,7 @@ type BootStrapKubeConfig struct {
 	Name string `json:"name,omitempty"`
 	// the kubeConfig file of the hub cluster
 	KubeConfig string `json:"kubeConfig,omitempty"`
+	// TODO: add grpcConfig to support multiHubBootstrapHubKubeConfigs
 }
 
 type ImagesConfig struct {

--- a/pkg/operator/helpers/chart/render_test.go
+++ b/pkg/operator/helpers/chart/render_test.go
@@ -411,6 +411,20 @@ func TestKlusterletConfig(t *testing.T) {
 			},
 			expectedObjCnt: 7,
 		},
+		{
+			name:      "create namespace with bootstrap secret and grpc config",
+			namespace: "open-cluster-management-agent",
+			chartConfig: func() *KlusterletChartConfig {
+				config := NewDefaultKlusterletChartConfig()
+				config.Klusterlet.ClusterName = "testCluster"
+				config.Klusterlet.Mode = operatorv1.InstallModeSingleton
+				config.CreateNamespace = true
+				config.BootstrapHubKubeConfig = "kubeconfig"
+				config.GRPCConfig = "grpcconfig"
+				return config
+			},
+			expectedObjCnt: 7,
+		},
 	}
 
 	for _, c := range cases {
@@ -568,6 +582,13 @@ func TestKlusterletConfig(t *testing.T) {
 						data := object.Data["kubeconfig"]
 						if base64.StdEncoding.EncodeToString(data) == "" {
 							t.Errorf("failed to render kubeconfig")
+						}
+
+						if config.GRPCConfig != "" {
+							grpcConfig := object.Data["config.yaml"]
+							if base64.StdEncoding.EncodeToString(grpcConfig) == "" {
+								t.Errorf("failed to render grpc config")
+							}
 						}
 					}
 				}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional gRPC configuration can be supplied; when provided, a config file is included alongside the kubeconfig in the bootstrap secret to support cluster import scenarios.
  * Chart values now expose the gRPC setting for installation or upgrade.

* **Tests**
  * Added tests to verify rendering of the optional gRPC configuration is present in the generated bootstrap secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->