### PR TITLE
:seedling: upgrade open-cluster-management.io api to deprecate addon InstallNamespace in v1alpha1

### DIFF
--- a/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
@@ -59,7 +59,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/open-cluster-management/registration-operator:latest
-    createdAt: "2025-09-15T05:44:58Z"
+    createdAt: "2025-10-10T01:31:41Z"
     description: Manages the installation and upgrade of the ClusterManager.
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
     categories: Integration & Delivery,OpenShift Optional
     certified: "false"
     containerImage: quay.io/open-cluster-management/registration-operator:latest
-    createdAt: "2025-09-15T05:44:58Z"
+    createdAt: "2025-10-10T01:31:41Z"
     description: Manages the installation and upgrade of the Klusterlet.
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	k8s.io/kubectl v0.33.4
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	open-cluster-management.io/addon-framework v1.0.1-0.20250916042555-c8a4fa748ce9
-	open-cluster-management.io/api v1.0.1-0.20250911094832-3b7c6bea0358
+	open-cluster-management.io/api v1.0.1-0.20251009064814-48b723491429
 	open-cluster-management.io/sdk-go v1.0.1-0.20250911065113-bff262df709b
 	sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03
 	sigs.k8s.io/cluster-inventory-api v0.0.0-20240730014211-ef0154379848

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJ
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 open-cluster-management.io/addon-framework v1.0.1-0.20250916042555-c8a4fa748ce9 h1:x0InHHM8GqY0qGYGyJx8SG7qNIOtMGs7n4EwowLksGA=
 open-cluster-management.io/addon-framework v1.0.1-0.20250916042555-c8a4fa748ce9/go.mod h1:IrMjmd3dLjJtrP2Aqa0Sf/3lDysJHa4j5lNQQ13NxVs=
-open-cluster-management.io/api v1.0.1-0.20250911094832-3b7c6bea0358 h1:IAaFH8HW+7G2I4htQJhVreD6KlQTwB+EkjPhuMthqoY=
-open-cluster-management.io/api v1.0.1-0.20250911094832-3b7c6bea0358/go.mod h1:lEc5Wkc9ON5ym/qAtIqNgrE7NW7IEOCOC611iQMlnKM=
+open-cluster-management.io/api v1.0.1-0.20251009064814-48b723491429 h1:jU4r3zijNA+Ab17oF7lBck0YHc7f7wM8r2RqZJw6ZSs=
+open-cluster-management.io/api v1.0.1-0.20251009064814-48b723491429/go.mod h1:lEc5Wkc9ON5ym/qAtIqNgrE7NW7IEOCOC611iQMlnKM=
 open-cluster-management.io/sdk-go v1.0.1-0.20250911065113-bff262df709b h1:tzgcM+yJJBgMwYYbjfzW4kL8p7bsHnScE5lS/69lksE=
 open-cluster-management.io/sdk-go v1.0.1-0.20250911065113-bff262df709b/go.mod h1:JVQupKu0xVcuVP4IUJF7hjvrXK8plZiwGPZcdqngjXk=
 sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03 h1:1ShFiMjGQOR/8jTBkmZrk1gORxnvMwm1nOy2/DbHg4U=

--- a/manifests/cluster-manager/hub/crds/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/manifests/cluster-manager/hub/crds/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -86,6 +86,7 @@ spec:
               installNamespace:
                 default: open-cluster-management-agent-addon
                 description: |-
+                  Deprecated: Use AddonDeploymentConfig instead.
                   installNamespace is the namespace on the managed cluster to install the addon agent.
                   If it is not set, open-cluster-management-agent-addon namespace is used to install the addon agent.
                 maxLength: 63

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1749,7 +1749,7 @@ open-cluster-management.io/addon-framework/pkg/agent
 open-cluster-management.io/addon-framework/pkg/assets
 open-cluster-management.io/addon-framework/pkg/index
 open-cluster-management.io/addon-framework/pkg/utils
-# open-cluster-management.io/api v1.0.1-0.20250911094832-3b7c6bea0358
+# open-cluster-management.io/api v1.0.1-0.20251009064814-48b723491429
 ## explicit; go 1.24.0
 open-cluster-management.io/api/addon/v1alpha1
 open-cluster-management.io/api/client/addon/clientset/versioned

--- a/vendor/open-cluster-management.io/api/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/vendor/open-cluster-management.io/api/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -86,6 +86,7 @@ spec:
               installNamespace:
                 default: open-cluster-management-agent-addon
                 description: |-
+                  Deprecated: Use AddonDeploymentConfig instead.
                   installNamespace is the namespace on the managed cluster to install the addon agent.
                   If it is not set, open-cluster-management-agent-addon namespace is used to install the addon agent.
                 maxLength: 63

--- a/vendor/open-cluster-management.io/api/addon/v1alpha1/types_managedclusteraddon.go
+++ b/vendor/open-cluster-management.io/api/addon/v1alpha1/types_managedclusteraddon.go
@@ -34,6 +34,7 @@ type ManagedClusterAddOn struct {
 // ManagedClusterAddOnSpec defines the install configuration of
 // an addon agent on managed cluster.
 type ManagedClusterAddOnSpec struct {
+	// Deprecated: Use AddonDeploymentConfig instead.
 	// installNamespace is the namespace on the managed cluster to install the addon agent.
 	// If it is not set, open-cluster-management-agent-addon namespace is used to install the addon agent.
 	// +optional


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/ocm/issues/1205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added a deprecation note to the ManagedClusterAddOn installNamespace field description, guiding users to use AddonDeploymentConfig instead.

* Chores
  * Updated release metadata timestamps for ClusterServiceVersion entries to the latest date.
  * Bumped open-cluster-management API dependency to a newer version for alignment with upstream updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->