### PR TITLE
:bug: Fix progressive rollout on ManifestWorkReplicaSet spec changes

### DIFF
--- a/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_reconcile.go
+++ b/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_reconcile.go
@@ -209,41 +209,54 @@ func (d *deployReconciler) reconcile(ctx context.Context, mwrSet *workapiv1alpha
 }
 
 func (d *deployReconciler) clusterRolloutStatusFunc(clusterName string, manifestWork workv1.ManifestWork) (clustersdkv1alpha1.ClusterRolloutStatus, error) {
+	// Initialize default status as ToApply, LastTransitionTime is not needed for ToApply status.
 	clsRolloutStatus := clustersdkv1alpha1.ClusterRolloutStatus{
-		ClusterName:        clusterName,
-		LastTransitionTime: &manifestWork.CreationTimestamp,
-		// Default status is ToApply
-		Status: clustersdkv1alpha1.ToApply,
+		ClusterName: clusterName,
+		Status:      clustersdkv1alpha1.ToApply,
 	}
 
-	appliedCondition := apimeta.FindStatusCondition(manifestWork.Status.Conditions, workv1.WorkApplied)
+	// Get all relevant conditions
+	progressingCond := apimeta.FindStatusCondition(manifestWork.Status.Conditions, workv1.WorkProgressing)
+	degradedCond := apimeta.FindStatusCondition(manifestWork.Status.Conditions, workv1.WorkDegraded)
 
-	// Applied condition not exist return status as ToApply.
-	if appliedCondition == nil { //nolint:gocritic
+	// Return ToApply if:
+	// - No Progressing condition exists yet (work hasn't been reconciled by agent)
+	// - Progressing condition hasn't observed the latest spec
+	// - Degraded condition exists but hasn't observed the latest spec
+	//   (Degraded is optional, but if it exists, we wait for it to catch up)
+	if progressingCond == nil ||
+		progressingCond.ObservedGeneration != manifestWork.Generation ||
+		(degradedCond != nil && degradedCond.ObservedGeneration != manifestWork.Generation) {
 		return clsRolloutStatus, nil
-	} else if appliedCondition.Status == metav1.ConditionTrue ||
-		apimeta.IsStatusConditionTrue(manifestWork.Status.Conditions, workv1.WorkProgressing) {
-		// Applied OR Progressing conditions status true return status as Progressing
-		// ManifestWork Progressing status is not defined however the check is made for future work availability.
+	}
+
+	// Agent has observed the latest spec, determine status based on Progressing and Degraded conditions.
+	// Degraded is an optional condition only used to determine Failed case.
+	// - Progressing=True + Degraded=True → Failed (work is progressing but degraded)
+	// - Progressing=True (not degraded) → Progressing
+	// - Progressing=False → Succeeded
+	// - Unknown state → Progressing (conservative fallback)
+	//
+	// LastTransitionTime is used by rollout strategies to calculate:
+	// - Timeout for Progressing and Failed statuses
+	// - Minimum success time (soak time) for Succeeded status
+	switch {
+	case progressingCond.Status == metav1.ConditionTrue && degradedCond != nil && degradedCond.Status == metav1.ConditionTrue:
+		clsRolloutStatus.Status = clustersdkv1alpha1.Failed
+		clsRolloutStatus.LastTransitionTime = &degradedCond.LastTransitionTime
+
+	case progressingCond.Status == metav1.ConditionTrue:
 		clsRolloutStatus.Status = clustersdkv1alpha1.Progressing
-	} else if appliedCondition.Status == metav1.ConditionFalse {
-		// Applied Condition status false return status as failed
-		clsRolloutStatus.Status = clustersdkv1alpha1.Failed
-		clsRolloutStatus.LastTransitionTime = &appliedCondition.LastTransitionTime
-		return clsRolloutStatus, nil
-	}
+		clsRolloutStatus.LastTransitionTime = &progressingCond.LastTransitionTime
 
-	// Available condition return status as Succeeded
-	if apimeta.IsStatusConditionTrue(manifestWork.Status.Conditions, workv1.WorkAvailable) {
+	case progressingCond.Status == metav1.ConditionFalse:
 		clsRolloutStatus.Status = clustersdkv1alpha1.Succeeded
-		return clsRolloutStatus, nil
-	}
+		clsRolloutStatus.LastTransitionTime = &progressingCond.LastTransitionTime
 
-	// Degraded condition return status as Failed
-	// ManifestWork Degraded status is not defined however the check is made for future work availability.
-	if apimeta.IsStatusConditionTrue(manifestWork.Status.Conditions, workv1.WorkDegraded) {
-		clsRolloutStatus.Status = clustersdkv1alpha1.Failed
-		clsRolloutStatus.LastTransitionTime = &appliedCondition.LastTransitionTime
+	default:
+		// Unknown state, conservatively treat as still progressing
+		clsRolloutStatus.Status = clustersdkv1alpha1.Progressing
+		clsRolloutStatus.LastTransitionTime = &progressingCond.LastTransitionTime
 	}
 
 	return clsRolloutStatus, nil

--- a/pkg/work/hub/test/helper.go
+++ b/pkg/work/hub/test/helper.go
@@ -104,6 +104,12 @@ func CreateTestManifestWork(name, namespace string, placementName string, cluste
 		Type:   workapiv1.WorkAvailable,
 		Status: metav1.ConditionTrue,
 	})
+	meta.SetStatusCondition(&mw.Status.Conditions, metav1.Condition{
+		Type:               workapiv1.WorkProgressing,
+		Status:             metav1.ConditionFalse,
+		Reason:             "AppliedManifestWorkComplete",
+		ObservedGeneration: mw.Generation,
+	})
 
 	return mw
 }

--- a/test/integration/work/manifestworkreplicaset_test.go
+++ b/test/integration/work/manifestworkreplicaset_test.go
@@ -386,8 +386,12 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		for _, work := range works.Items {
 			workCopy := work.DeepCopy()
-			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{Type: workapiv1.WorkApplied, Status: metav1.ConditionTrue, Reason: "ApplyTest"})
-			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{Type: workapiv1.WorkAvailable, Status: metav1.ConditionTrue, Reason: "ApplyTest"})
+			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
+				Type:               workapiv1.WorkProgressing,
+				Status:             metav1.ConditionFalse,
+				Reason:             "AppliedManifestWorkComplete",
+				ObservedGeneration: workCopy.Generation,
+			})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			_, err := hubWorkClient.WorkV1().ManifestWorks(workCopy.Namespace).UpdateStatus(context.TODO(), workCopy, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -400,8 +404,12 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		for _, work := range works.Items {
 			workCopy := work.DeepCopy()
-			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{Type: workapiv1.WorkApplied, Status: metav1.ConditionTrue, Reason: "ApplyTest"})
-			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{Type: workapiv1.WorkAvailable, Status: metav1.ConditionTrue, Reason: "ApplyTest"})
+			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
+				Type:               workapiv1.WorkProgressing,
+				Status:             metav1.ConditionFalse,
+				Reason:             "AppliedManifestWorkComplete",
+				ObservedGeneration: workCopy.Generation,
+			})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			_, err := hubWorkClient.WorkV1().ManifestWorks(workCopy.Namespace).UpdateStatus(context.TODO(), workCopy, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -433,7 +441,18 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		for _, work := range works.Items {
 			workCopy := work.DeepCopy()
-			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{Type: workapiv1.WorkApplied, Status: metav1.ConditionFalse, Reason: "ApplyTest"})
+			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
+				Type:               workapiv1.WorkProgressing,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Applying",
+				ObservedGeneration: workCopy.Generation,
+			})
+			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
+				Type:               workapiv1.WorkDegraded,
+				Status:             metav1.ConditionTrue,
+				Reason:             "ApplyFailed",
+				ObservedGeneration: workCopy.Generation,
+			})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			_, err := hubWorkClient.WorkV1().ManifestWorks(workCopy.Namespace).UpdateStatus(context.TODO(), workCopy, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -480,7 +499,12 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 			workCopy := work.DeepCopy()
 			meta.SetStatusCondition(
 				&workCopy.Status.Conditions,
-				metav1.Condition{Type: workapiv1.WorkApplied, Status: metav1.ConditionTrue, Reason: "ApplyTest"})
+				metav1.Condition{
+					Type:               workapiv1.WorkProgressing,
+					Status:             metav1.ConditionFalse,
+					Reason:             "AppliedManifestWorkComplete",
+					ObservedGeneration: workCopy.Generation,
+				})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			_, err := hubWorkClient.WorkV1().
 				ManifestWorks(workCopy.Namespace).UpdateStatus(context.TODO(), workCopy, metav1.UpdateOptions{})
@@ -542,7 +566,20 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 			workCopy := work.DeepCopy()
 			meta.SetStatusCondition(
 				&workCopy.Status.Conditions,
-				metav1.Condition{Type: workapiv1.WorkApplied, Status: metav1.ConditionFalse, Reason: "ApplyTest"})
+				metav1.Condition{
+					Type:               workapiv1.WorkProgressing,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Applying",
+					ObservedGeneration: workCopy.Generation,
+				})
+			meta.SetStatusCondition(
+				&workCopy.Status.Conditions,
+				metav1.Condition{
+					Type:               workapiv1.WorkDegraded,
+					Status:             metav1.ConditionTrue,
+					Reason:             "ApplyFailed",
+					ObservedGeneration: workCopy.Generation,
+				})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			_, err := hubWorkClient.WorkV1().
 				ManifestWorks(workCopy.Namespace).UpdateStatus(context.TODO(), workCopy, metav1.UpdateOptions{})


### PR DESCRIPTION
Problem:
When a ManifestWorkReplicaSet spec is updated, all clusters update
simultaneously instead of progressively with configured minSuccessTime
intervals (e.g., 1-minute soak period between clusters).

Root Cause:
soak time = currentime - manifestwork condition LastTransitionTime, when the manifestwork is updated, the LastTransitionTime won't update, cause the rollout controller treats the updated manifestwork as already passing the soak time. 

Fix:
1. Use Progressing and Degraded(optional) condition in ManifestWork for the rollout case.
2. Progressing and Degraded(optional) condition is added by CEL expression, for example:
```
apiVersion: work.open-cluster-management.io/v1alpha1
kind: ManifestWorkReplicaSet
metadata:
  name: mwrset
  namespace: default
spec:
  placementRefs:
    - name: placement-test # Name of a created Placement
      rolloutStrategy:
        type: Progressive
        progressive:
          minSuccessTime: 1m
          progressDeadline: 10m
          maxFailures: 5%
          maxConcurrency: 1
  manifestWorkTemplate:
    workload:
      manifests:
        - apiVersion: apps/v1
          kind: Deployment
          metadata:
            name: hello
            namespace: default
          spec:
            selector:
              matchLabels:
                app: hello
            template:
              metadata:
                labels:
                  app: hello
              spec:
                containers:
                  - name: hello
                    image: busybox
                    command:
                      ["sh", "-c", 'echo "Hello, Kubernetes!" && sleep 36000']
    manifestConfigs:
      - resourceIdentifier:
          group: apps
          resource: deployments
          namespace: default
          name: hello
        conditionRules:
          - condition: Progressing
            type: CEL
            celExpressions:
              - |
                !(
                  (object.metadata.generation == object.status.observedGeneration) &&
                  has(object.status.conditions) &&
                  object.status.conditions.exists(c, c.type == 'Progressing' && c.status == 'True' && c.reason == 'NewReplicaSetAvailable')
                )
            messageExpression: |
              result ? "Applying" : "Completed"
          - condition: Degraded
            type: CEL
            celExpressions:
              - |
                (object.metadata.generation == object.status.observedGeneration) &&
                (has(object.status.readyReplicas) && has(object.status.replicas) && object.status.readyReplicas < object.status.replicas)
            messageExpression: |
              result ? "Degraded" : "Healthy"
```

Gaps:
1. When minSuccessTime is set to 1m, the actual rollout interval will be 1-3 minutes, becase: 
- CEL expression conditions sync time is defined by klusterlet-agent `--status-sync-interval=60s`, it's 60s in a fresh installed OCM, and the default 10s if not defined. 
- When minSuccessTime is defined, for example, 1 minute, the controller will requeue the MWRs every 1 minute.
- For example, the deployment is complete at time A. The worst case is: 
  The progressing condition is set to false at time A + 59 seconds.
  The requeue time is time A - 2 seconds, time A + 58 seconds, time A + 118 seconds, and time A + 178seconds (pass minSuccessTime).

2. When the status-sync-interval is set to a very short time, there will be a chance that the progressing condition observedGeneration is updated, but with old LastTransaction. (need to further debug this)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #https://github.com/open-cluster-management-io/ocm/issues/1201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Revised rollout status evaluation to rely on Progressing and Degraded conditions, with clear states: ToApply, Progressing, Succeeded, Failed; LastTransitionTime handling improved and no longer tied to resource creation time.

* **Tests**
  * Expanded and updated tests and helpers to validate new Progressing/Degraded-based flows, observed generation handling, and LastTransitionTime propagation across success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->