### PR TITLE
🐛 Empty agentInstallNamespace should not override addonTemplate namespace

### DIFF
--- a/pkg/addon/templateagent/template_agent_test.go
+++ b/pkg/addon/templateagent/template_agent_test.go
@@ -868,6 +868,47 @@ func TestAgentInstallNamespace(t *testing.T) {
 			),
 			expected: "test-install-namespace",
 		},
+		{
+			name: "empty string agentInstallNamespace should use template namespace",
+			addonTemplate: &addonapiv1alpha1.AddOnTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hello-template",
+				},
+				Spec: addonapiv1alpha1.AddOnTemplateSpec{
+					AgentSpec: workapiv1.ManifestWorkSpec{
+						Workload: workapiv1.ManifestsTemplate{
+							Manifests: []workapiv1.Manifest{
+								{RawExtension: runtime.RawExtension{Raw: deploymentRaw}},
+							},
+						},
+					},
+				},
+			},
+			addonDeploymentConfig: &addonapiv1alpha1.AddOnDeploymentConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hello-config",
+					Namespace: "default",
+				},
+				Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
+					AgentInstallNamespace: "",
+					CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
+						{
+							Name:  "LOG_LEVEL",
+							Value: "4",
+						},
+					},
+				},
+			},
+			managedClusterAddonBuilder: newManagedClusterAddonBuilder(
+				&addonapiv1alpha1.ManagedClusterAddOn{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      addonName,
+						Namespace: clusterName,
+					},
+				},
+			),
+			expected: "test-ns",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

This PR adds a test case to ensure that when `agentInstallNamespace` is empty in an `AddOnDeploymentConfig`, it does not override the namespace defined in the `addonTemplate`.

Previously, when users referenced an `AddOnDeploymentConfig` for any purpose (customizedVariables, nodePlacement, registries, etc.) without explicitly setting `agentInstallNamespace`, the default value would silently override the namespace defined in the `addonTemplate`. This PR adds test coverage to validate that an empty `agentInstallNamespace` respects the template's namespace.

## Related issue(s)

Fixes #1209

## Background

The issue occurs when:
1. User creates an `addonTemplate` with a deployment in a custom namespace (e.g., `my-custom-namespace`)
2. User creates an `addOnDeploymentConfig` to set **any configuration** (customizedVariables, nodePlacement, etc.)
3. User does **not** set `agentInstallNamespace` in the `addOnDeploymentConfig`
4. Previously, the addon would be deployed to `open-cluster-management-agent-addon` instead of `my-custom-namespace`

With the API changes allowing empty string for `agentInstallNamespace`, this test validates that the OCM implementation correctly respects the template namespace when `agentInstallNamespace` is not set (empty string).

## Test Coverage

- Added test case "empty string agentInstallNamespace should use template namespace" in `pkg/addon/templateagent/template_agent_test.go`
- The test verifies that when `AgentInstallNamespace: ""` is set in `AddOnDeploymentConfig`, the template namespace (`test-ns`) is used instead of being overridden
- All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**No user-facing changes in this release.** This update includes internal quality improvements.

* **Tests**
  * Enhanced test coverage for edge case handling in namespace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->