### PR TITLE
:seedling: Add server configuration for clusterManager helm chart

### DIFF
--- a/deploy/cluster-manager/chart/cluster-manager/templates/cluster_manager.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/cluster_manager.yaml
@@ -41,4 +41,8 @@ spec:
   addOnManagerConfiguration:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.clusterManager.serverConfiguration }}
+  serverConfiguration:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/deploy/cluster-manager/chart/cluster-manager/values.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/values.yaml
@@ -113,9 +113,20 @@ clusterManager:
       mode: Enable
     registrationDrivers:
     - authType: csr
+#   - authType: grpc
+#   grpc:
+#     autoApprovedIdentities:
+#     - system:serviceaccount:open-cluster-management:agent-registration-bootstrap
   workConfiguration:
     workDriver: kube
   addOnManagerConfiguration: {}
 #   featureGates:
 #     - feature: ""
 #       mode: ""
+# serverConfiguration:
+#   endpointsExposure:
+#   - protocol: grpc
+#     grpc:
+#       type: hostname
+#       hostname:
+#         host: grpc-server-open-cluster-management-hub.apps.server-foundation-sno-lite-w8rlq.dev04.red-chesterfield.com

--- a/pkg/operator/helpers/chart/config.go
+++ b/pkg/operator/helpers/chart/config.go
@@ -141,6 +141,10 @@ type ClusterManagerConfig struct {
 	// +optional
 	AddOnManagerConfiguration operatorv1.AddOnManagerConfiguration `json:"addOnManagerConfiguration,omitempty"`
 
+	// ServerConfiguration contains the configuration of http/grpc server.
+	// +optional
+	ServerConfiguration operatorv1.ServerConfiguration `json:"serverConfiguration,omitempty"`
+
 	// ResourceRequirement specify QoS classes of deployments managed by clustermanager.
 	// It applies to all the containers in the deployments.
 	// +optional


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional server configuration for ClusterManager so users can specify HTTP/gRPC endpoint exposure and related settings when needed.

* **Documentation**
  * Added commented example configuration blocks illustrating registration driver and grpc endpoint options in the default values.

* **Tests**
  * Added test coverage for GRPC configuration scenarios to validate server configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->