### PR TITLE
:bug: fix: Check Applied condition before evaluating rollout status

### DIFF
--- a/test/integration/work/manifestworkreplicaset_test.go
+++ b/test/integration/work/manifestworkreplicaset_test.go
@@ -387,6 +387,12 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 		for _, work := range works.Items {
 			workCopy := work.DeepCopy()
 			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
+				Type:               workapiv1.WorkApplied,
+				Status:             metav1.ConditionTrue,
+				Reason:             "AppliedManifestWorkComplete",
+				ObservedGeneration: workCopy.Generation,
+			})
+			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
 				Type:               workapiv1.WorkProgressing,
 				Status:             metav1.ConditionFalse,
 				Reason:             "AppliedManifestWorkComplete",
@@ -404,6 +410,12 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		for _, work := range works.Items {
 			workCopy := work.DeepCopy()
+			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
+				Type:               workapiv1.WorkApplied,
+				Status:             metav1.ConditionTrue,
+				Reason:             "AppliedManifestWorkComplete",
+				ObservedGeneration: workCopy.Generation,
+			})
 			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
 				Type:               workapiv1.WorkProgressing,
 				Status:             metav1.ConditionFalse,
@@ -441,6 +453,12 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		for _, work := range works.Items {
 			workCopy := work.DeepCopy()
+			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
+				Type:               workapiv1.WorkApplied,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Applied",
+				ObservedGeneration: workCopy.Generation,
+			})
 			meta.SetStatusCondition(&workCopy.Status.Conditions, metav1.Condition{
 				Type:               workapiv1.WorkProgressing,
 				Status:             metav1.ConditionTrue,
@@ -497,6 +515,14 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		for _, work := range works.Items {
 			workCopy := work.DeepCopy()
+			meta.SetStatusCondition(
+				&workCopy.Status.Conditions,
+				metav1.Condition{
+					Type:               workapiv1.WorkApplied,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Applied",
+					ObservedGeneration: workCopy.Generation,
+				})
 			meta.SetStatusCondition(
 				&workCopy.Status.Conditions,
 				metav1.Condition{
@@ -564,6 +590,14 @@ var _ = ginkgo.Describe("ManifestWorkReplicaSet", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		for _, work := range works.Items {
 			workCopy := work.DeepCopy()
+			meta.SetStatusCondition(
+				&workCopy.Status.Conditions,
+				metav1.Condition{
+					Type:               workapiv1.WorkApplied,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Applied",
+					ObservedGeneration: workCopy.Generation,
+				})
 			meta.SetStatusCondition(
 				&workCopy.Status.Conditions,
 				metav1.Condition{


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/ocm/issues/1237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure an "Applied" condition is required and evaluated before Progressing/Degraded to prevent stale observations and incorrect rollout status.

* **New Features**
  * Centralized status-evaluation logic that consistently considers condition readiness and observed-generation when deriving rollout state.

* **Tests**
  * Expanded and new tests covering Applied-first evaluation, observed-generation scenarios, and condition-readiness outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->