### PR TITLE
🌱 Integrate SDK logging tracing into work agent controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	open-cluster-management.io/addon-framework v1.1.1-0.20251126020917-1a0a9be61322
 	open-cluster-management.io/api v1.1.1-0.20251124092621-2337d27c3b7f
-	open-cluster-management.io/sdk-go v1.1.1-0.20251126014056-a185f88d7b1b
+	open-cluster-management.io/sdk-go v1.1.1-0.20251204021848-5e7a48eb49a5
 	sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03
 	sigs.k8s.io/cluster-inventory-api v0.0.0-20240730014211-ef0154379848
 	sigs.k8s.io/controller-runtime v0.22.4

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,8 @@ open-cluster-management.io/addon-framework v1.1.1-0.20251126020917-1a0a9be61322 
 open-cluster-management.io/addon-framework v1.1.1-0.20251126020917-1a0a9be61322/go.mod h1:YqG/M9aLM/jhUXZDb2lEi2gGFU8NHAPTsQEFGk/tiS8=
 open-cluster-management.io/api v1.1.1-0.20251124092621-2337d27c3b7f h1:aOEXqgXvWSykMvzw9drHsLGUNP3xhsk1PcdRzfOVXoM=
 open-cluster-management.io/api v1.1.1-0.20251124092621-2337d27c3b7f/go.mod h1:Hk/3c114t6Ba5qhpqw+RoA93yEbE2CosG+JzzBZ6aCo=
-open-cluster-management.io/sdk-go v1.1.1-0.20251126014056-a185f88d7b1b h1:jnrHQDkoHLp5D43/P4chMyY3GqGyv3FdtAfyX2pcadY=
-open-cluster-management.io/sdk-go v1.1.1-0.20251126014056-a185f88d7b1b/go.mod h1:0EZ9M7AtD0b+x9lUo5pYlyFF2aKOk1y88looeOVybwU=
+open-cluster-management.io/sdk-go v1.1.1-0.20251204021848-5e7a48eb49a5 h1:eaaIq3YPE0PPsjGJQqJGvZETkTEjMiVx18O96KTl1a4=
+open-cluster-management.io/sdk-go v1.1.1-0.20251204021848-5e7a48eb49a5/go.mod h1:0EZ9M7AtD0b+x9lUo5pYlyFF2aKOk1y88looeOVybwU=
 sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03 h1:1ShFiMjGQOR/8jTBkmZrk1gORxnvMwm1nOy2/DbHg4U=
 sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03/go.mod h1:F1pT4mK53U6F16/zuaPSYpBaR7x5Kjym6aKJJC0/DHU=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/pkg/registration/spoke/addon/lease_controller_test.go
+++ b/pkg/registration/spoke/addon/lease_controller_test.go
@@ -16,6 +16,7 @@ import (
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonfake "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
+	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
 	"open-cluster-management.io/sdk-go/pkg/patcher"
 
 	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
@@ -260,7 +261,7 @@ func TestSync(t *testing.T) {
 		},
 		{
 			name:     "sync all addons",
-			queueKey: "key",
+			queueKey: factory.DefaultQueueKey,
 			addOns: []runtime.Object{
 				&addonv1alpha1.ManagedClusterAddOn{
 					ObjectMeta: metav1.ObjectMeta{
@@ -284,7 +285,7 @@ func TestSync(t *testing.T) {
 			},
 			validateActions: func(t *testing.T, ctx *testingcommon.FakeSyncContext, actions []clienttesting.Action) {
 				if ctx.Queue().Len() != 2 {
-					t.Errorf("expected two addons in queue, but failed")
+					t.Errorf("expected two addons in queue, but get %d", ctx.Queue().Len())
 				}
 			},
 		},

--- a/pkg/work/spoke/auth/cache/executor_cache_controller.go
+++ b/pkg/work/spoke/auth/cache/executor_cache_controller.go
@@ -254,7 +254,7 @@ func (c *CacheController) sync(ctx context.Context, _ factory.SyncContext, execu
 	logger := klog.FromContext(ctx).WithValues("executorKey", executorKey)
 	ctx = klog.NewContext(ctx, logger)
 	logger.V(4).Info("Executor cache sync")
-	if executorKey == "key" {
+	if executorKey == factory.DefaultQueueKey {
 		// cleanup unnecessary cache
 		logger.V(4).Info("Cache items before cleanup", "count", c.executorCaches.Count())
 		c.cleanupUnnecessaryCache()

--- a/pkg/work/spoke/controllers/finalizercontroller/add_finalizer_controller.go
+++ b/pkg/work/spoke/controllers/finalizercontroller/add_finalizer_controller.go
@@ -11,6 +11,7 @@ import (
 	worklister "open-cluster-management.io/api/client/work/listers/work/v1"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
+	"open-cluster-management.io/sdk-go/pkg/logging"
 	"open-cluster-management.io/sdk-go/pkg/patcher"
 
 	"open-cluster-management.io/ocm/pkg/common/queue"
@@ -55,6 +56,11 @@ func (m *AddFinalizerController) sync(ctx context.Context, _ factory.SyncContext
 	if err != nil {
 		return err
 	}
+
+	// set tracing key from work if there is any
+	logger = logging.SetLogTracingByObject(logger, manifestWork)
+	ctx = klog.NewContext(ctx, logger)
+
 	return m.syncManifestWork(ctx, manifestWork)
 }
 

--- a/pkg/work/spoke/controllers/finalizercontroller/manifestwork_finalize_controller.go
+++ b/pkg/work/spoke/controllers/finalizercontroller/manifestwork_finalize_controller.go
@@ -16,6 +16,7 @@ import (
 	worklister "open-cluster-management.io/api/client/work/listers/work/v1"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
+	"open-cluster-management.io/sdk-go/pkg/logging"
 	"open-cluster-management.io/sdk-go/pkg/patcher"
 
 	"open-cluster-management.io/ocm/pkg/common/queue"
@@ -68,7 +69,6 @@ func (m *ManifestWorkFinalizeController) sync(ctx context.Context, controllerCon
 
 	logger := klog.FromContext(ctx).WithName(appliedManifestWorkFinalizer).
 		WithValues("appliedManifestWorkName", appliedManifestWorkName, "manifestWorkName", manifestWorkName)
-	ctx = klog.NewContext(ctx, logger)
 
 	logger.V(5).Info("Reconciling ManifestWork")
 
@@ -82,6 +82,9 @@ func (m *ManifestWorkFinalizeController) sync(ctx context.Context, controllerCon
 	case err != nil:
 		return err
 	case !manifestWork.DeletionTimestamp.IsZero():
+		// set tracing key from work if there is any
+		logger = logging.SetLogTracingByObject(logger, manifestWork)
+		ctx = klog.NewContext(ctx, logger)
 		err := m.deleteAppliedManifestWork(ctx, manifestWork, appliedManifestWorkName)
 		if err != nil {
 			return err

--- a/pkg/work/spoke/controllers/manifestcontroller/manifestwork_controller.go
+++ b/pkg/work/spoke/controllers/manifestcontroller/manifestwork_controller.go
@@ -25,6 +25,7 @@ import (
 	worklister "open-cluster-management.io/api/client/work/listers/work/v1"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
+	"open-cluster-management.io/sdk-go/pkg/logging"
 	"open-cluster-management.io/sdk-go/pkg/patcher"
 
 	commonhelper "open-cluster-management.io/ocm/pkg/common/helpers"
@@ -124,7 +125,6 @@ func NewManifestWorkController(
 func (m *ManifestWorkController) sync(ctx context.Context, controllerContext factory.SyncContext, manifestWorkName string) error {
 	logger := klog.FromContext(ctx).WithValues("manifestWorkName", manifestWorkName)
 	logger.V(5).Info("Reconciling ManifestWork")
-	ctx = klog.NewContext(ctx, logger)
 
 	oldManifestWork, err := m.manifestWorkLister.Get(manifestWorkName)
 	if apierrors.IsNotFound(err) {
@@ -135,6 +135,10 @@ func (m *ManifestWorkController) sync(ctx context.Context, controllerContext fac
 		return err
 	}
 	manifestWork := oldManifestWork.DeepCopy()
+
+	// set tracing key from work if there is any
+	logger = logging.SetLogTracingByObject(logger, manifestWork)
+	ctx = klog.NewContext(ctx, logger)
 
 	// no work to do if we're deleted
 	if !manifestWork.DeletionTimestamp.IsZero() {

--- a/pkg/work/spoke/controllers/statuscontroller/availablestatus_controller.go
+++ b/pkg/work/spoke/controllers/statuscontroller/availablestatus_controller.go
@@ -21,6 +21,7 @@ import (
 	worklister "open-cluster-management.io/api/client/work/listers/work/v1"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
+	"open-cluster-management.io/sdk-go/pkg/logging"
 	"open-cluster-management.io/sdk-go/pkg/patcher"
 
 	commonhelper "open-cluster-management.io/ocm/pkg/common/helpers"
@@ -82,7 +83,6 @@ func NewAvailableStatusController(
 func (c *AvailableStatusController) sync(ctx context.Context, controllerContext factory.SyncContext, manifestWorkName string) error {
 	logger := klog.FromContext(ctx).WithValues("manifestWorkName", manifestWorkName)
 	logger.V(4).Info("Reconciling ManifestWork")
-	ctx = klog.NewContext(ctx, logger)
 
 	// sync a particular manifestwork
 	manifestWork, err := c.manifestWorkLister.Get(manifestWorkName)
@@ -93,6 +93,10 @@ func (c *AvailableStatusController) sync(ctx context.Context, controllerContext 
 	if err != nil {
 		return fmt.Errorf("unable to fetch manifestwork %q: %w", manifestWorkName, err)
 	}
+
+	// set tracing key from work if there is any
+	logger = logging.SetLogTracingByObject(logger, manifestWork)
+	ctx = klog.NewContext(ctx, logger)
 
 	err = c.syncManifestWork(ctx, manifestWork)
 	if err != nil {

--- a/pkg/work/spoke/spokeagent.go
+++ b/pkg/work/spoke/spokeagent.go
@@ -66,7 +66,7 @@ func (o *WorkAgentConfig) RunWorkloadAgent(ctx context.Context, controllerContex
 	logger := klog.NewKlogr()
 	podName := os.Getenv("POD_NAME")
 	if podName != "" {
-		logger = logger.WithValues("podName", podName)
+		logger = logger.WithValues("podName", podName, "clusterName", o.agentOptions.SpokeClusterName)
 	}
 	ctx = klog.NewContext(ctx, logger)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1954,7 +1954,7 @@ open-cluster-management.io/api/operator/v1
 open-cluster-management.io/api/utils/work/v1/workapplier
 open-cluster-management.io/api/work/v1
 open-cluster-management.io/api/work/v1alpha1
-# open-cluster-management.io/sdk-go v1.1.1-0.20251126014056-a185f88d7b1b
+# open-cluster-management.io/sdk-go v1.1.1-0.20251204021848-5e7a48eb49a5
 ## explicit; go 1.24.0
 open-cluster-management.io/sdk-go/pkg/apis/cluster/v1alpha1
 open-cluster-management.io/sdk-go/pkg/apis/cluster/v1beta1
@@ -2009,6 +2009,7 @@ open-cluster-management.io/sdk-go/pkg/cloudevents/server/grpc/authz/kube
 open-cluster-management.io/sdk-go/pkg/cloudevents/server/grpc/heartbeat
 open-cluster-management.io/sdk-go/pkg/cloudevents/server/grpc/metrics
 open-cluster-management.io/sdk-go/pkg/helpers
+open-cluster-management.io/sdk-go/pkg/logging
 open-cluster-management.io/sdk-go/pkg/patcher
 open-cluster-management.io/sdk-go/pkg/server/grpc
 open-cluster-management.io/sdk-go/pkg/server/grpc/authn

--- a/vendor/open-cluster-management.io/sdk-go/pkg/basecontroller/factory/base_controller.go
+++ b/vendor/open-cluster-management.io/sdk-go/pkg/basecontroller/factory/base_controller.go
@@ -80,7 +80,7 @@ func (c *baseController) Run(ctx context.Context, workers int) {
 	queueContext, queueContextCancel := context.WithCancel(ctx)
 
 	for i := 1; i <= workers; i++ {
-		logger.Info("Starting worker of controller ...", "numberOfWorkers", i)
+		logger.Info("Starting worker of controller ...", "worker-ID", i)
 		workerWg.Add(1)
 		go func() {
 			defer func() {
@@ -157,10 +157,10 @@ func (c *baseController) processNextWorkItem(queueCtx context.Context) {
 	queueKey := key
 
 	if err := c.sync(queueCtx, syncCtx, queueKey); err != nil {
-		if logger.V(4).Enabled() || key != "key" {
-			utilruntime.HandleErrorWithContext(queueCtx, err, "controller failed to sync", "key", key, "error", err)
+		if logger.V(4).Enabled() || key != DefaultQueueKey {
+			utilruntime.HandleErrorWithContext(queueCtx, err, "controller failed to sync", "key", key)
 		} else {
-			utilruntime.HandleErrorWithContext(queueCtx, err, "reconciliation failed", "error", err)
+			utilruntime.HandleErrorWithContext(queueCtx, err, "reconciliation failed")
 		}
 		c.syncContext.Queue().AddRateLimited(key)
 		return

--- a/vendor/open-cluster-management.io/sdk-go/pkg/basecontroller/factory/factory.go
+++ b/vendor/open-cluster-management.io/sdk-go/pkg/basecontroller/factory/factory.go
@@ -10,7 +10,7 @@ import (
 )
 
 // DefaultQueueKey is the queue key used for string trigger based controllers.
-const DefaultQueueKey = "key"
+const DefaultQueueKey = "basecontroller-default-key"
 
 // DefaultQueueKeysFunc returns a slice with a single element - the DefaultQueueKey
 func DefaultQueueKeysFunc(_ runtime.Object) []string {

--- a/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/source/client/manifestwork.go
+++ b/vendor/open-cluster-management.io/sdk-go/pkg/cloudevents/clients/work/source/client/manifestwork.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"open-cluster-management.io/sdk-go/pkg/logging"
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -109,6 +110,9 @@ func (c *ManifestWorkSourceClient) Create(ctx context.Context, manifestWork *wor
 		return nil, returnErr
 	}
 
+	// Add logging tracing annotation
+	logging.SetLogTracingFromContext(ctx, newWork)
+
 	if errs := utils.ValidateWork(newWork); len(errs) != 0 {
 		returnErr = errors.NewInvalid(common.ManifestWorkGK, manifestWork.Name, errs)
 		return nil, returnErr
@@ -158,6 +162,9 @@ func (c *ManifestWorkSourceClient) Delete(ctx context.Context, name string, opts
 	deletingWork := work.DeepCopy()
 	now := metav1.Now()
 	deletingWork.DeletionTimestamp = &now
+
+	// Add logging tracing annotation
+	logging.SetLogTracingFromContext(ctx, deletingWork)
 
 	if err := c.cloudEventsClient.Publish(ctx, eventType, deletingWork); err != nil {
 		returnErr := cloudeventserrors.ToStatusError(common.ManifestWorkGR, name, err)
@@ -295,6 +302,9 @@ func (c *ManifestWorkSourceClient) Patch(ctx context.Context, name string, pt ku
 	}
 	newWork.Generation = generation
 	newWork.ResourceVersion = rv
+
+	// Add logging tracing annotation
+	logging.SetLogTracingFromContext(ctx, newWork)
 
 	if errs := utils.ValidateWork(newWork); len(errs) != 0 {
 		returnErr = errors.NewInvalid(common.ManifestWorkGK, name, errs)

--- a/vendor/open-cluster-management.io/sdk-go/pkg/logging/logging.go
+++ b/vendor/open-cluster-management.io/sdk-go/pkg/logging/logging.go
@@ -1,0 +1,160 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cloudeventstypes "github.com/cloudevents/sdk-go/v2/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"strings"
+)
+
+type ContextTracingKey string
+
+const (
+	LogTracingPrefix                        = "logging.open-cluster-management.io/"
+	ExtensionLogTracing                     = "logtracing"
+	ContextTracingOPIDKey ContextTracingKey = "op-id"
+)
+
+// DefaultContextTracingKeys is a global variable of interested keys in context used for log tracing
+var DefaultContextTracingKeys = []ContextTracingKey{ContextTracingOPIDKey}
+
+func SetLogTracingByObject(logger klog.Logger, object metav1.Object) klog.Logger {
+	if object == nil {
+		return logger
+	}
+	annotations := object.GetAnnotations()
+	for key, value := range annotations {
+		if !strings.HasPrefix(key, LogTracingPrefix) {
+			continue
+		}
+		tracingKey := strings.TrimPrefix(key, LogTracingPrefix)
+		logger = logger.WithValues(tracingKey, value)
+	}
+	return logger
+}
+
+func getTracingMapFromExtension(evt *cloudevents.Event) (map[string]string, error) {
+	logTracingMap := make(map[string]string)
+
+	logTracingValue, ok := evt.Extensions()[ExtensionLogTracing]
+	if !ok {
+		return logTracingMap, nil
+	}
+
+	logTracingValueString, err := cloudeventstypes.ToString(logTracingValue)
+	if err != nil {
+		return logTracingMap, err
+	}
+
+	err = json.Unmarshal([]byte(logTracingValueString), &logTracingMap)
+	if err != nil {
+		return logTracingMap, err
+	}
+
+	return logTracingMap, nil
+}
+
+func setTracingMapToExtension(evt *cloudevents.Event, tracingMap map[string]string) error {
+	tracingValueRaw, err := json.Marshal(tracingMap)
+	if err != nil {
+		return err
+	}
+	evt.SetExtension(ExtensionLogTracing, string(tracingValueRaw))
+	return nil
+}
+
+func SetLogTracingByCloudEvent(logger klog.Logger, evt *cloudevents.Event) klog.Logger {
+	if evt == nil {
+		return logger
+	}
+
+	logTracingMap, err := getTracingMapFromExtension(evt)
+	if err != nil {
+		logger.Error(err, "Failed to get log tracing map")
+		return logger
+	}
+
+	for key, value := range logTracingMap {
+		if !strings.HasPrefix(key, LogTracingPrefix) {
+			continue
+		}
+		tracingKey := strings.TrimPrefix(key, LogTracingPrefix)
+		logger = logger.WithValues(tracingKey, value)
+	}
+	return logger
+}
+
+// SetLogTracingFromContext is used in cloudevent work source client to set up the
+// log tracing annotation for the manifestwork.
+func SetLogTracingFromContext(ctx context.Context, object metav1.Object) {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	for _, key := range DefaultContextTracingKeys {
+		value := ctx.Value(key)
+		if value == nil {
+			continue
+		}
+		annotations[LogTracingPrefix+string(key)] = fmt.Sprintf("%v", value)
+	}
+
+	if len(annotations) != 0 {
+		object.SetAnnotations(annotations)
+	}
+}
+
+func LogTracingFromEventToObject(evt *cloudevents.Event, obj metav1.Object) error {
+	if obj == nil {
+		return nil
+	}
+	if evt == nil {
+		return nil
+	}
+
+	logTracingMap, err := getTracingMapFromExtension(evt)
+	if err != nil {
+		return err
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	for key, value := range logTracingMap {
+		if !strings.HasPrefix(key, LogTracingPrefix) {
+			continue
+		}
+		annotations[key] = value
+	}
+
+	if len(annotations) != 0 {
+		obj.SetAnnotations(annotations)
+	}
+
+	return nil
+}
+
+func LogTracingFromObjectToEvent(obj metav1.Object, evt *cloudevents.Event) error {
+	if obj == nil {
+		return nil
+	}
+	if evt == nil {
+		return nil
+	}
+
+	tracingMap := make(map[string]string)
+	for key, value := range obj.GetAnnotations() {
+		if !strings.HasPrefix(key, LogTracingPrefix) {
+			continue
+		}
+		tracingMap[key] = value
+	}
+
+	return setTracingMapToExtension(evt, tracingMap)
+}


### PR DESCRIPTION
This change adds log tracing support to the work agent controllers by:
- Upgrading SDK to version with logging.SetLogTracingByObject helper
- Setting tracing keys from ManifestWork objects in all work controllers
- Adding clusterName to the base logger for better log context
- Propagating tracing context through cloud events

The tracing keys enable better correlation of logs across the work lifecycle from source to agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced per-object tracing and logging across controllers.
  * Added an extra contextual log field (clusterName) when POD_NAME is set.
  * Updated a module dependency version.
* **Tests**
  * Updated tests and controller queue handling to use the default queue key and improved assertion messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->