### PR TITLE
✨   Update transition time for Applied + StatusFeedbackSynced

### DIFF
--- a/pkg/work/helper/helpers.go
+++ b/pkg/work/helper/helpers.go
@@ -129,6 +129,14 @@ func MergeStatusConditions(conditions []metav1.Condition, newConditions []metav1
 
 	merged = append(merged, conditions...)
 	for _, condition := range newConditions {
+		for i := range merged {
+			if merged[i].Type == condition.Type {
+				if merged[i].ObservedGeneration != condition.ObservedGeneration {
+					meta.RemoveStatusCondition(&merged, condition.Type)
+				}
+				break
+			}
+		}
 		// merge two conditions if necessary
 		meta.SetStatusCondition(&merged, condition)
 	}

--- a/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler.go
+++ b/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler.go
@@ -77,7 +77,7 @@ func (m *manifestworkReconciler) reconcile(
 		}
 
 		// Add applied status condition
-		manifestCondition.Conditions = append(manifestCondition.Conditions, buildAppliedStatusCondition(result))
+		manifestCondition.Conditions = append(manifestCondition.Conditions, buildAppliedStatusCondition(result, manifestWork.Generation))
 
 		newManifestConditions = append(newManifestConditions, manifestCondition)
 
@@ -239,21 +239,23 @@ func allInCondition(conditionType string, manifests []workapiv1.ManifestConditio
 	return exists, exists
 }
 
-func buildAppliedStatusCondition(result applyResult) metav1.Condition {
+func buildAppliedStatusCondition(result applyResult, generation int64) metav1.Condition {
 	if result.Error != nil {
 		return metav1.Condition{
-			Type:    workapiv1.ManifestApplied,
-			Status:  metav1.ConditionFalse,
-			Reason:  "AppliedManifestFailed",
-			Message: fmt.Sprintf("Failed to apply manifest: %v", result.Error),
+			Type:               workapiv1.ManifestApplied,
+			Status:             metav1.ConditionFalse,
+			Reason:             "AppliedManifestFailed",
+			Message:            fmt.Sprintf("Failed to apply manifest: %v", result.Error),
+			ObservedGeneration: generation,
 		}
 	}
 
 	return metav1.Condition{
-		Type:    workapiv1.ManifestApplied,
-		Status:  metav1.ConditionTrue,
-		Reason:  "AppliedManifestComplete",
-		Message: "Apply manifest complete",
+		Type:               workapiv1.ManifestApplied,
+		Status:             metav1.ConditionTrue,
+		Reason:             "AppliedManifestComplete",
+		Message:            "Apply manifest complete",
+		ObservedGeneration: generation,
 	}
 }
 

--- a/pkg/work/spoke/controllers/statuscontroller/availablestatus_controller.go
+++ b/pkg/work/spoke/controllers/statuscontroller/availablestatus_controller.go
@@ -136,6 +136,10 @@ func (c *AvailableStatusController) syncManifestWork(ctx context.Context, origin
 
 		// Read status of the resource according to feedback rules.
 		values, statusFeedbackCondition := c.getFeedbackValues(obj, option)
+		valuesChanged := !equality.Semantic.DeepEqual(manifest.StatusFeedbacks.Values, values)
+		if valuesChanged {
+			meta.RemoveStatusCondition(manifestConditions, statusFeedbackCondition.Type)
+		}
 		meta.SetStatusCondition(manifestConditions, statusFeedbackCondition)
 		manifestWork.Status.ResourceStatus.Manifests[index].StatusFeedbacks.Values = values
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Updated based on 1292. 

1. Add observedGeneration for Applied and StatusFeedback Synced type condition
2. Update lastTransitionTime for Applied when observedGeneration updated 
3. Update lastTransitionTime for StatusFeedback when values in the status feedback response are updated.

## Related issue(s)
#1292  

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conditions now remove stale entries when a resource's generation changes, preventing outdated duplicates.
  * Applied and feedback conditions record the manifest's observed generation so condition visibility matches manifest generation.
  * Status feedback now refreshes LastTransitionTime when feedback values change, ensuring time-based transitions reflect real updates.

* **Tests**
  * New and extended tests validate ObservedGeneration and LastTransitionTime updates for applied, available, and feedback conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->