### PR TITLE
:warning:  Add duplicate manifest detection in ManifestWork webhook validation

### DIFF
--- a/pkg/work/webhook/common/validator.go
+++ b/pkg/work/webhook/common/validator.go
@@ -1,10 +1,13 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	workv1 "open-cluster-management.io/api/work/v1"
 )
@@ -33,11 +36,25 @@ func (m *Validator) ValidateManifests(manifests []workv1.Manifest) error {
 		return fmt.Errorf("the size of manifests is %v bytes which exceeds the %v limit", totalSize, m.limit)
 	}
 
-	for _, manifest := range manifests {
+	// Track seen manifests to detect duplicates
+	seen := sets.New[string]()
+
+	for i, manifest := range manifests {
 		err := validateManifest(manifest.Raw)
 		if err != nil {
 			return err
 		}
+
+		// Check for duplicate manifests
+		info, err := extractManifestInfo(manifest.Raw)
+		if err != nil {
+			return fmt.Errorf("failed to extract metadata from manifest at index %d: %w", i, err)
+		}
+
+		if seen.Has(info.key) {
+			return fmt.Errorf("duplicate manifest for resource %s/%s with resource type %s", info.namespace, info.name, info.gvk)
+		}
+		seen.Insert(info.key)
 	}
 
 	return nil
@@ -61,4 +78,27 @@ func validateManifest(manifest []byte) error {
 	}
 
 	return nil
+}
+
+// manifestInfo contains the metadata needed for duplicate detection and error messages.
+type manifestInfo struct {
+	key       string // unique key for duplicate detection: apiVersion/kind/namespace/name
+	name      string
+	namespace string
+	gvk       string // apiVersion.kind format for error messages
+}
+
+// extractManifestInfo extracts metadata from a manifest for duplicate detection.
+func extractManifestInfo(manifest []byte) (*manifestInfo, error) {
+	meta := &metav1.PartialObjectMetadata{}
+	if err := json.Unmarshal(manifest, meta); err != nil {
+		return nil, err
+	}
+
+	return &manifestInfo{
+		key:       fmt.Sprintf("%s/%s/%s/%s", meta.APIVersion, meta.Kind, meta.Namespace, meta.Name),
+		name:      meta.Name,
+		namespace: meta.Namespace,
+		gvk:       fmt.Sprintf("%s.%s", meta.APIVersion, meta.Kind),
+	}, nil
 }

--- a/pkg/work/webhook/common/validator_test.go
+++ b/pkg/work/webhook/common/validator_test.go
@@ -32,6 +32,40 @@ func newManifest(size int) workv1.Manifest {
 	manifest.Raw = objectStr
 	return manifest
 }
+
+func newManifestWithNameAndNamespace(name, namespace string) workv1.Manifest {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"namespace": namespace,
+				"name":      name,
+			},
+		},
+	}
+	objectStr, _ := obj.MarshalJSON()
+	manifest := workv1.Manifest{}
+	manifest.Raw = objectStr
+	return manifest
+}
+
+func newManifestWithKind(name, namespace, kind string) workv1.Manifest {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"namespace": namespace,
+				"name":      name,
+			},
+		},
+	}
+	objectStr, _ := obj.MarshalJSON()
+	manifest := workv1.Manifest{}
+	manifest.Raw = objectStr
+	return manifest
+}
 func Test_Validator(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -39,14 +73,48 @@ func Test_Validator(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name:          "not exceed the limit",
+			name:          "duplicate manifests from newManifest helper",
 			manifests:     []workv1.Manifest{newManifest(100 * 1024), newManifest(100 * 1024)},
-			expectedError: nil,
+			expectedError: fmt.Errorf("duplicate manifest for resource test/test with resource type v1.Secret"),
 		},
 		{
 			name:          "exceed the limit",
 			manifests:     []workv1.Manifest{newManifest(300 * 1024), newManifest(200 * 1024)},
 			expectedError: fmt.Errorf("the size of manifests is 512192 bytes which exceeds the 512000 limit"),
+		},
+		{
+			name: "duplicate manifests",
+			manifests: []workv1.Manifest{
+				newManifestWithNameAndNamespace("test1", "default"),
+				newManifestWithNameAndNamespace("test2", "default"),
+				newManifestWithNameAndNamespace("test1", "default"),
+			},
+			expectedError: fmt.Errorf("duplicate manifest for resource default/test1 with resource type v1.ConfigMap"),
+		},
+		{
+			name: "same name different namespace",
+			manifests: []workv1.Manifest{
+				newManifestWithNameAndNamespace("test", "ns1"),
+				newManifestWithNameAndNamespace("test", "ns2"),
+			},
+			expectedError: nil,
+		},
+		{
+			name: "same name different kind",
+			manifests: []workv1.Manifest{
+				newManifestWithKind("test", "default", "ConfigMap"),
+				newManifestWithKind("test", "default", "Secret"),
+			},
+			expectedError: nil,
+		},
+		{
+			name: "unique manifests",
+			manifests: []workv1.Manifest{
+				newManifestWithNameAndNamespace("cm1", "default"),
+				newManifestWithNameAndNamespace("cm2", "default"),
+				newManifestWithNameAndNamespace("cm3", "default"),
+			},
+			expectedError: nil,
 		},
 	}
 

--- a/test/e2e/work_webhook_test.go
+++ b/test/e2e/work_webhook_test.go
@@ -51,6 +51,16 @@ var _ = ginkgo.Describe("ManifestWork admission webhook", ginkgo.Label("validati
 			gomega.Expect(errors.IsBadRequest(err)).Should(gomega.BeTrue())
 		})
 
+		ginkgo.It("Should respond bad request when creating a manifestwork with duplicate manifests", func() {
+			work := newManifestWork(universalClusterName, workName, []runtime.Object{
+				util.NewConfigmap("default", "cm1", nil, nil),
+				util.NewConfigmap("default", "cm1", nil, nil), // duplicate
+			}...)
+			_, err := hub.WorkClient.WorkV1().ManifestWorks(universalClusterName).Create(context.Background(), work, metav1.CreateOptions{})
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(errors.IsBadRequest(err)).Should(gomega.BeTrue())
+		})
+
 		ginkgo.Context("executor", func() {
 			var hubUser string
 			var roleName string


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR adds validation to detect and reject duplicate manifests in ManifestWork resources. A manifest is considered duplicate when it has the same apiVersion, kind, namespace, and name as another manifest in the same ManifestWork.

This prevents issues where duplicate manifests with different specs can cause state inconsistency, as the Work Agent applies manifests sequentially and later entries would overwrite earlier ones.

## Changes

### Implementation Improvements (based on review feedback)

1. **Use `sets.Set[string]` instead of `map[string]int`** - Cleaner code for tracking seen manifests
2. **Use lightweight `manifestMeta` struct instead of `unstructured.Unstructured`** - Reduces computation resource by only decoding the metadata fields needed for duplicate detection (TypeMeta + ObjectMeta)
3. **Simplified error message** - Now shows `duplicate manifest at index %d: %s` without the first occurrence index

### Test Coverage

- Unit tests for duplicate detection scenarios
- E2E test added: `Should respond bad request when creating a manifestwork with duplicate manifests`

## Files Changed

- `pkg/work/webhook/common/validator.go` - Core validation logic
- `pkg/work/webhook/common/validator_test.go` - Unit tests
- `test/e2e/work_webhook_test.go` - E2E test for duplicate manifest validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest validation now detects duplicate manifests and reports duplicate index/key; validator instance is configurable with a manifest limit.

* **Bug Fixes**
  * Validation errors more clearly surface parsing, missing-field, and duplicate issues; duplicate manifest submissions are rejected.

* **Tests**
  * Added unit and end-to-end tests covering duplicate manifests, same-name different-namespace/kind, missing fields, limits, and unique-manifest scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->