### PR TITLE
:seedling: disabel mqtt integration test

### DIFF
--- a/.github/workflows/cloudevents-integration.yml
+++ b/.github/workflows/cloudevents-integration.yml
@@ -21,18 +21,19 @@ permissions:
   contents: read
 
 jobs:
-  mqtt-work-integration:
-    name: mqtt-work-integration
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v6.0.1
-      - name: install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: integration
-        run: make test-cloudevents-work-mqtt-integration
+  # Disable mqtt-work-integration: because the current source client does not support increasing resource generation.
+  # mqtt-work-integration:
+  #   name: mqtt-work-integration
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout code
+  #       uses: actions/checkout@v6.0.1
+  #     - name: install Go
+  #       uses: actions/setup-go@v6
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
+  #     - name: integration
+  #       run: make test-cloudevents-work-mqtt-integration
 
   grpc-work-integration:
     name: grpc-work-integration


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
because the current source client does not support increasing resources generation, to avoid requiring special handling, we disable the mqtt-integration-test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI integration workflow narrowed to run only gRPC-based integration tests; MQTT-based integration job disabled and will not execute.

* **Tests**
  * Integration tests updated to verify manifest condition stability and LastTransitionTime semantics under direct resource mutation, improve status-feedback coverage, and adjust test flows and assertions for more robust validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->