### PR TITLE
:sparkles: manager: implement import-renderers

### DIFF
--- a/manifests/cluster-manager/management/registration/deployment.yaml
+++ b/manifests/cluster-manager/management/registration/deployment.yaml
@@ -70,6 +70,9 @@ spec:
           {{if .ClusterImporterEnabled}}
           - "--agent-image={{ .AgentImage }}"
           - "--bootstrap-serviceaccount={{ .OperatorNamespace }}/agent-registration-bootstrap"
+          {{if .ImporterRenderers}}
+          - "--import-renderers={{ .ImporterRenderers }}"
+          {{end}}
           {{end}}
           {{ if .HostedMode }}
           - "--kubeconfig=/var/run/secrets/hub/kubeconfig"

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -26,6 +26,7 @@ type HubConfig struct {
 	AgentImage                     string
 	CloudEventsDriverEnabled       bool
 	ClusterImporterEnabled         bool
+	ImporterRenderers              string
 	WorkDriver                     string
 	AutoApproveUsers               string
 	ImagePullSecret                string

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -196,6 +196,9 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	config.ClusterImporterEnabled = helpers.FeatureGateEnabled(registrationFeatureGates, ocmfeature.DefaultHubRegistrationFeatureGates, ocmfeature.ClusterImporter)
 	if config.ClusterImporterEnabled {
 		config.AgentImage = os.Getenv("AGENT_IMAGE")
+		if clusterManager.Spec.RegistrationConfiguration != nil && clusterManager.Spec.RegistrationConfiguration.ImporterConfiguration != nil {
+			config.ImporterRenderers = strings.Join(clusterManager.Spec.RegistrationConfiguration.ImporterConfiguration.Renderers, ",")
+		}
 	}
 
 	var workFeatureGates []operatorapiv1.FeatureGate


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add a way to customize `--import-renderers`

## Related issue(s)

Needs https://github.com/open-cluster-management-io/api/pull/415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configurable importer renderers. When cluster importer is enabled, users can now specify a list of renderers as a comma-separated value in the deployment configuration.

* **Tests**
  * Added comprehensive test coverage validating importer renderers configuration across various scenarios, including single, multiple, and empty renderers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->