### PR TITLE
🐛 fail fast on MTU mismatch before SelfSubjectAccessReview

### DIFF
--- a/pkg/common/helpers/ssar.go
+++ b/pkg/common/helpers/ssar.go
@@ -1,3 +1,4 @@
+
 package helpers
 
 import (
@@ -164,6 +165,9 @@ func generateSelfSubjectAccessReviews(resource authorizationv1.ResourceAttribute
 					Verb:        verb,
 				},
 			},
+
+
+			
 		})
 	}
 	return reviews

--- a/pkg/common/helpers/ssar.go
+++ b/pkg/common/helpers/ssar.go
@@ -2,21 +2,58 @@ package helpers
 
 import (
 	"context"
+	"fmt"
+	"net"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
+func detectLocalMTU() (int, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return 0, err
+	}
+
+	maxMTU := 0
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if iface.MTU > maxMTU {
+			maxMTU = iface.MTU
+		}
+	}
+
+	if maxMTU == 0 {
+		return 0, fmt.Errorf("unable to detect MTU")
+	}
+
+	return maxMTU, nil
+}
+
 func CreateSelfSubjectAccessReviews(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
-	selfSubjectAccessReviews []authorizationv1.SelfSubjectAccessReview) (bool, *authorizationv1.SelfSubjectAccessReview, error) {
+	selfSubjectAccessReviews []authorizationv1.SelfSubjectAccessReview,
+) (bool, *authorizationv1.SelfSubjectAccessReview, error) {
+
+	mtu, err := detectLocalMTU()
+	if err == nil && mtu > 1500 {
+		return false, nil, fmt.Errorf(
+			"MTU mismatch detected: managed cluster MTU (%d) exceeds typical hub path MTU (1500). "+
+				"This can cause TLS handshake timeouts during bootstrap or certificate rotation. "+
+				"Please align MTU values between hub and managed cluster.",
+			mtu,
+		)
+	}
 
 	for i := range selfSubjectAccessReviews {
 		subjectAccessReview := selfSubjectAccessReviews[i]
-
-		ssar, err := kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, &subjectAccessReview, metav1.CreateOptions{})
+		ssar, err := kubeClient.AuthorizationV1().
+			SelfSubjectAccessReviews().
+			Create(ctx, &subjectAccessReview, metav1.CreateOptions{})
 		if err != nil {
 			return false, &subjectAccessReview, err
 		}


### PR DESCRIPTION
Fix klusterlet TLS handshake timeouts caused by MTU mismatch
Klusterlet bootstrap and certificate rotation can fail when the managed
cluster MTU exceeds the hub path MTU due to large TLS handshake packets
during SelfSubjectAccessReview calls.
This change adds a pre-flight MTU validation to fail fast with a clear,
actionable error message instead of a silent TLS handshake timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added network MTU detection and validation that surfaces errors when detected MTU exceeds expected limits ( >1500 ), preventing connectivity and operational issues caused by incompatible network settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->