### PR TITLE
📖 add troubleshooting note for MTU mismatch bootstrap failure

### DIFF
--- a/pkg/common/helpers/ssar.go
+++ b/pkg/common/helpers/ssar.go
@@ -2,21 +2,58 @@ package helpers
 
 import (
 	"context"
+	"fmt"
+	"net"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
+func detectLocalMTU() (int, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return 0, err
+	}
+
+	maxMTU := 0
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if iface.MTU > maxMTU {
+			maxMTU = iface.MTU
+		}
+	}
+
+	if maxMTU == 0 {
+		return 0, fmt.Errorf("unable to detect MTU")
+	}
+
+	return maxMTU, nil
+}
+
 func CreateSelfSubjectAccessReviews(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
-	selfSubjectAccessReviews []authorizationv1.SelfSubjectAccessReview) (bool, *authorizationv1.SelfSubjectAccessReview, error) {
+	selfSubjectAccessReviews []authorizationv1.SelfSubjectAccessReview,
+) (bool, *authorizationv1.SelfSubjectAccessReview, error) {
+
+	mtu, err := detectLocalMTU()
+	if err == nil && mtu > 1500 {
+		return false, nil, fmt.Errorf(
+			"MTU mismatch detected: managed cluster MTU (%d) exceeds typical hub path MTU (1500). "+
+				"This can cause TLS handshake timeouts during bootstrap or certificate rotation. "+
+				"Please align MTU values between hub and managed cluster.",
+			mtu,
+		)
+	}
 
 	for i := range selfSubjectAccessReviews {
 		subjectAccessReview := selfSubjectAccessReviews[i]
-
-		ssar, err := kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, &subjectAccessReview, metav1.CreateOptions{})
+		ssar, err := kubeClient.AuthorizationV1().
+			SelfSubjectAccessReviews().
+			Create(ctx, &subjectAccessReview, metav1.CreateOptions{})
 		if err != nil {
 			return false, &subjectAccessReview, err
 		}

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -1,0 +1,34 @@
+# Troubleshooting
+
+This document describes common issues and troubleshooting guidance for
+Open Cluster Management components.
+
+---
+
+## Klusterlet bootstrap fails with TLS handshake timeout due to MTU mismatch
+
+Klusterlet bootstrap or certificate rotation may fail when the managed
+cluster network MTU is larger than the hub cluster network MTU.
+
+In such cases, some bootstrap API calls (for example,
+`SelfSubjectAccessReview`) can generate TLS handshake packets that exceed
+the hub path MTU. These packets may be silently dropped, resulting in
+errors such as:
+
+
+### Symptoms
+
+- Klusterlet fails to complete bootstrap
+- Managed cluster appears disconnected or degraded
+- Failures recur during certificate rotation
+- Basic connectivity checks (for example, `curl` to the hub API) may still succeed
+
+### Resolution
+
+Ensure that the managed cluster network MTU does not exceed the hub
+cluster network MTU during bootstrap and certificate rotation.
+Aligning MTU settings between hub and managed clusters prevents these
+TLS handshake timeouts.
+
+Related issue:
+https://github.com/open-cluster-management-io/ocm/issues/1314

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -1,3 +1,4 @@
+
 # Troubleshooting
 
 This document describes common issues and troubleshooting guidance for
@@ -32,3 +33,4 @@ TLS handshake timeouts.
 
 Related issue:
 https://github.com/open-cluster-management-io/ocm/issues/1314
+

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -1,4 +1,5 @@
 
+
 # Troubleshooting
 
 This document describes common issues and troubleshooting guidance for
@@ -17,12 +18,14 @@ the hub path MTU. These packets may be silently dropped, resulting in
 errors such as:
 
 
+
 ### Symptoms
 
 - Klusterlet fails to complete bootstrap
 - Managed cluster appears disconnected or degraded
 - Failures recur during certificate rotation
 - Basic connectivity checks (for example, `curl` to the hub API) may still succeed
+
 
 ### Resolution
 
@@ -33,4 +36,5 @@ TLS handshake timeouts.
 
 Related issue:
 https://github.com/open-cluster-management-io/ocm/issues/1314
+
 


### PR DESCRIPTION
Adds troubleshooting documentation for klusterlet bootstrap and
certificate rotation failures caused by MTU mismatch between hub and
managed clusters.

Related to #1314.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MTU mismatch detection and validation between hub and managed clusters; operations now validate local MTU and surface an error when a significant mismatch is detected.

* **Documentation**
  * Added a troubleshooting guide with symptoms and resolution steps for TLS handshake timeouts related to MTU configuration mismatches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->