### PR TITLE
🐛 fix(addon): remove internal annotation from v1alpha1 after conversion

### DIFF
--- a/pkg/addon/webhook/v1beta1/managedclusteraddon_conversion.go
+++ b/pkg/addon/webhook/v1beta1/managedclusteraddon_conversion.go
@@ -48,6 +48,9 @@ func (src *ManagedClusterAddOn) ConvertTo(dstRaw conversion.Hub) error {
 	// This field was removed in v1beta1, so we store it in annotation
 	if installNs, ok := src.Annotations[InstallNamespaceAnnotation]; ok {
 		v1alpha1Obj.Spec.InstallNamespace = installNs
+		// Remove the internal annotation from v1alpha1 object
+		// This annotation is only used for v1beta1 storage, not for v1alpha1 API
+		delete(v1alpha1Obj.Annotations, InstallNamespaceAnnotation)
 	}
 
 	// Manually populate deprecated ConfigReferent field in ConfigReferences

--- a/pkg/addon/webhook/v1beta1/managedclusteraddon_conversion_test.go
+++ b/pkg/addon/webhook/v1beta1/managedclusteraddon_conversion_test.go
@@ -106,9 +106,8 @@ func TestManagedClusterAddOnConvertTo(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-addon",
 						Namespace: "cluster1",
-						Annotations: map[string]string{
-							"addon.open-cluster-management.io/v1alpha1-install-namespace": "test-namespace",
-						},
+						// The internal annotation should be removed after conversion to v1alpha1
+						Annotations: map[string]string{},
 					},
 					Spec: addonv1alpha1.ManagedClusterAddOnSpec{
 						InstallNamespace: "test-namespace",
@@ -174,6 +173,43 @@ func TestManagedClusterAddOnConvertTo(t *testing.T) {
 						HealthCheck: addonv1alpha1.HealthCheck{
 							Mode: addonv1alpha1.HealthCheckModeCustomized,
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "conversion removes internal annotation but preserves user annotations",
+			src: &ManagedClusterAddOn{
+				ManagedClusterAddOn: addonv1beta1.ManagedClusterAddOn{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-addon",
+						Namespace: "cluster1",
+						Annotations: map[string]string{
+							"addon.open-cluster-management.io/v1alpha1-install-namespace": "test-namespace",
+							"abc.def":         "hahaha",
+							"user.annotation": "should-be-preserved",
+						},
+					},
+					Spec: addonv1beta1.ManagedClusterAddOnSpec{},
+				},
+			},
+			expected: &internalv1alpha1.ManagedClusterAddOn{
+				ManagedClusterAddOn: addonv1alpha1.ManagedClusterAddOn{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ManagedClusterAddOn",
+						APIVersion: "addon.open-cluster-management.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-addon",
+						Namespace: "cluster1",
+						// Internal annotation removed, user annotations preserved
+						Annotations: map[string]string{
+							"abc.def":         "hahaha",
+							"user.annotation": "should-be-preserved",
+						},
+					},
+					Spec: addonv1alpha1.ManagedClusterAddOnSpec{
+						InstallNamespace: "test-namespace",
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
- Fix conversion webhook to remove internal annotation from v1alpha1 API responses
- Update test cases to verify the fix

## Problem
When updating a ManagedClusterAddOn using v1beta1 API (e.g., adding an annotation), then retrieving it using v1alpha1 API, the internal annotation `addon.open-cluster-management.io/v1alpha1-install-namespace` incorrectly appears in the v1alpha1 object's annotations.

## Root Cause
The `ConvertTo` method (v1beta1 → v1alpha1) correctly converts the annotation to `Spec.InstallNamespace` field, but the auto-generated conversion function `out.ObjectMeta = in.ObjectMeta` copies all annotations from v1beta1 to v1alpha1, including the internal annotation. Without explicit removal, this internal annotation gets saved to etcd and pollutes the stored v1alpha1 object.

## Solution
- Remove the internal annotation after converting it to the `InstallNamespace` field
- This annotation is only used for v1beta1 storage, not for v1alpha1 API

## Changes
1. **Conversion logic** (`pkg/addon/webhook/v1beta1/managedclusteraddon_conversion.go:47-54`)
   - Added `delete(v1alpha1Obj.Annotations, InstallNamespaceAnnotation)` after conversion
   
2. **Test updates** (`pkg/addon/webhook/v1beta1/managedclusteraddon_conversion_test.go`)
   - Updated existing test expectations (no internal annotation in v1alpha1)
   - Added new test case to verify internal annotation removal while preserving user annotations

## Testing
- ✅ All unit tests pass
- ✅ New test verifies annotation removal behavior
- ✅ User annotations are correctly preserved

## Related Issue
Fixes: ACM-28133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed API version conversion process to properly remove internal system annotations while ensuring all user-provided annotations are preserved, maintaining data integrity during migrations.
  * Enhanced InstallNamespace field propagation during version conversion to ensure correct behavior across different API format versions and prevent data loss.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->