### PR TITLE
🐛 fix: ensure immediate eviction after grace period expires

### DIFF
--- a/pkg/work/spoke/controllers/finalizercontroller/unmanaged_appliedmanifestwork_controller_test.go
+++ b/pkg/work/spoke/controllers/finalizercontroller/unmanaged_appliedmanifestwork_controller_test.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clienttesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/util/workqueue"
 
 	fakeworkclient "open-cluster-management.io/api/client/work/clientset/versioned/fake"
 	workinformers "open-cluster-management.io/api/client/work/informers/externalversions"
@@ -204,7 +203,7 @@ func TestSyncUnamanagedAppliedWork(t *testing.T) {
 					},
 				},
 			},
-			expectedQueueLen:                   1,
+			expectedQueueLen:                   0, // Item is added to delayed queue via AddAfter, not the main queue
 			validateAppliedManifestWorkActions: testingcommon.AssertNoActions,
 		},
 		{
@@ -283,7 +282,6 @@ func TestSyncUnamanagedAppliedWork(t *testing.T) {
 				hubHash:                   c.hubHash,
 				agentID:                   c.agentID,
 				evictionGracePeriod:       c.evictionGracePeriod,
-				rateLimiter:               workqueue.NewItemExponentialFailureRateLimiter(0, c.evictionGracePeriod),
 			}
 
 			controllerContext := testingcommon.NewFakeSyncContext(t, c.appliedManifestWorkName)


### PR DESCRIPTION
## Summary

Fixed a bug where AppliedManifestWorks were not evicted immediately after the `appliedmanifestwork-eviction-grace-period` expired.

### Problem
The controller used an exponential backoff rate limiter to schedule requeue delays, which caused:
1. Exponentially increasing delays during grace period (1min → 2min → 4min → 8min...)
2. Unpredictable delays after grace period expired - could be delayed by minutes!

### Solution
Replaced rate limiter with direct time calculation. The controller now calculates the exact remaining time until eviction and schedules the next sync for that precise moment:
```go
evictionTime := evictionStartTime.Add(m.evictionGracePeriod)
remainingTime := evictionTime.Sub(now)
controllerContext.Queue().AddAfter(appliedManifestWork.Name, remainingTime)
```

### Changes
- Removed `rateLimiter` field and `workqueue` import
- Calculate exact remaining time instead of using exponential backoff
- Added V(4) logging to show scheduled eviction time and remaining time
- Updated unit test expectations (queue length 0 for items in delayed queue)

### Impact
AppliedManifestWorks are now evicted **immediately** when the grace period expires, instead of being delayed by minutes due to exponential backoff.

### Testing
- ✅ All unit tests pass: `go test ./pkg/work/spoke/controllers/finalizercontroller/...`
- ✅ Integration tests verify eviction behavior
- ✅ Code is mathematically correct by inspection

### Before vs After

**Before** (60-minute grace period):
- 0:00 - Eviction starts
- 1:00 - First requeue (1 min delay)
- 3:00 - Second requeue (2 min delay)
- 7:00 - Third requeue (4 min delay)
- ...exponential backoff continues...
- 60:00 - Grace period expires, but next sync could be minutes away! ❌

**After** (60-minute grace period):
- 0:00 - Eviction starts, scheduled for 60:00
- 60:00 - Grace period expires, immediate deletion ✅

## Related issue(s)

Fixes the AppliedManifestWork eviction timing bug where evictions were delayed significantly after the grace period expired.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced eviction scheduling precision for managed work items through more accurate time-based calculations, ensuring scheduled evictions are triggered at the intended times.

* **Tests**
  * Updated tests accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->