### PR TITLE
:bug: fix: prevent addon recreation during sequential PlacementDecision upd…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,3 +187,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
+
+replace open-cluster-management.io/sdk-go => github.com/haoqing0110/sdk-go v0.0.0-20260120095521-fe81e417c1e1

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
+github.com/haoqing0110/sdk-go v0.0.0-20260120095521-fe81e417c1e1 h1:tuv/cqv58yofGUOPiCzN3VA5tnWMBEtlzb/ylI7G1YE=
+github.com/haoqing0110/sdk-go v0.0.0-20260120095521-fe81e417c1e1/go.mod h1:4haPv/uuKqQ3gxi62/PPknlrUFi132ga0KYLwj5tpx0=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
@@ -587,8 +589,6 @@ open-cluster-management.io/addon-framework v1.1.1-0.20251222073158-b5846d76add9 
 open-cluster-management.io/addon-framework v1.1.1-0.20251222073158-b5846d76add9/go.mod h1:St9LTEuZ5ADLY9cVXSp+rVE/ZbPJ+hzNQ7/YcsiQVd8=
 open-cluster-management.io/api v1.1.1-0.20260116065909-8307845802e0 h1:FLYkctX92dosLXm8+SQhfXm3h9K4iiKAKUwJiK88bF4=
 open-cluster-management.io/api v1.1.1-0.20260116065909-8307845802e0/go.mod h1:YcmA6SpGEekIMxdoeVIIyOaBhMA6ImWRLXP4g8n8T+4=
-open-cluster-management.io/sdk-go v1.1.1-0.20260120013142-6d087c9a2a3d h1:V+2LZY0aPOStdRxnFvW+yL4y5UqC97R9x4lTQdjLVfg=
-open-cluster-management.io/sdk-go v1.1.1-0.20260120013142-6d087c9a2a3d/go.mod h1:4haPv/uuKqQ3gxi62/PPknlrUFi132ga0KYLwj5tpx0=
 sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03 h1:1ShFiMjGQOR/8jTBkmZrk1gORxnvMwm1nOy2/DbHg4U=
 sigs.k8s.io/about-api v0.0.0-20250131010323-518069c31c03/go.mod h1:F1pT4mK53U6F16/zuaPSYpBaR7x5Kjym6aKJJC0/DHU=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/test/integration/addon/addon_manager_install_test.go
+++ b/test/integration/addon/addon_manager_install_test.go
@@ -18,12 +18,14 @@ import (
 )
 
 var _ = ginkgo.Describe("Addon install", func() {
-	suffix := rand.String(5)
 	var cma *addonapiv1alpha1.ClusterManagementAddOn
 	var placementNamespace string
 	var clusterNames []string
 
 	ginkgo.BeforeEach(func() {
+		clusterNames = []string{}
+		suffix := rand.String(5)
+
 		// Create clustermanagement addon
 		cma = newClusterManagementAddon(fmt.Sprintf("test-%s", suffix))
 		_, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
@@ -31,7 +33,8 @@ var _ = ginkgo.Describe("Addon install", func() {
 
 		assertClusterManagementAddOnAnnotations(cma.Name)
 
-		placementNamespace = fmt.Sprintf("ns-%s", suffix)
+		placementNamespace = fmt.Sprintf("ns-%s-%s", suffix, rand.String(5))
+
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: placementNamespace}}
 		_, err = hubKubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -163,6 +166,133 @@ var _ = ginkgo.Describe("Addon install", func() {
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Should not recreate addon during sequential PlacementDecision updates", func() {
+			// Setup: Create placement and two PlacementDecisions (simulating max 100 clusters per decision)
+			placement := &clusterv1beta1.Placement{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: placementNamespace}}
+			_, err := hubClusterClient.ClusterV1beta1().Placements(placementNamespace).Create(context.Background(), placement, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			decision1 := &clusterv1beta1.PlacementDecision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-placement-1",
+					Namespace: placementNamespace,
+					Labels: map[string]string{
+						clusterv1beta1.PlacementLabel:          "test-placement",
+						clusterv1beta1.DecisionGroupIndexLabel: "0",
+					},
+				},
+			}
+			decision1, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).Create(context.Background(), decision1, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			decision2 := &clusterv1beta1.PlacementDecision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-placement-2",
+					Namespace: placementNamespace,
+					Labels: map[string]string{
+						clusterv1beta1.PlacementLabel:          "test-placement",
+						clusterv1beta1.DecisionGroupIndexLabel: "1",
+					},
+				},
+			}
+			decision2, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).Create(context.Background(), decision2, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// Initial state: decision1 has cluster1, decision2 has cluster2 and cluster3
+			decision1.Status.Decisions = []clusterv1beta1.ClusterDecision{
+				{ClusterName: clusterNames[1]},
+			}
+			_, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).UpdateStatus(context.Background(), decision1, metav1.UpdateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			decision2.Status.Decisions = []clusterv1beta1.ClusterDecision{
+				{ClusterName: clusterNames[2]},
+				{ClusterName: clusterNames[3]},
+			}
+			_, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).UpdateStatus(context.Background(), decision2, metav1.UpdateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			clusterManagementAddon, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			clusterManagementAddon.Spec.InstallStrategy = addonapiv1alpha1.InstallStrategy{
+				Type: addonapiv1alpha1.AddonInstallStrategyPlacements,
+				Placements: []addonapiv1alpha1.PlacementStrategy{
+					{
+						PlacementRef: addonapiv1alpha1.PlacementRef{Name: "test-placement", Namespace: placementNamespace},
+						RolloutStrategy: clusterv1alpha1.RolloutStrategy{
+							Type: clusterv1alpha1.All,
+						},
+					},
+				},
+			}
+
+			_, err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Update(context.Background(), clusterManagementAddon, metav1.UpdateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// Wait for initial addons to be created on cluster1, cluster2, cluster3
+			gomega.Eventually(func() error {
+				_, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[2]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[3]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+			// Capture cluster1's addon UID before the update - this is what we'll verify doesn't change
+			addon1, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			originalUID := string(addon1.UID)
+
+			// Sequential update: Move cluster1 from decision1 to decision2
+			// Step 1: Update decision1 to remove cluster1 and add cluster0
+			// Step 2: Update decision2 to include cluster1 (along with cluster2, cluster3)
+			decision1, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).Get(context.Background(), "test-placement-1", metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			decision1.Status.Decisions = []clusterv1beta1.ClusterDecision{
+				{ClusterName: clusterNames[0]},
+			}
+			_, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).UpdateStatus(context.Background(), decision1, metav1.UpdateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			decision2, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).Get(context.Background(), "test-placement-2", metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			decision2.Status.Decisions = []clusterv1beta1.ClusterDecision{
+				{ClusterName: clusterNames[1]},
+				{ClusterName: clusterNames[2]},
+				{ClusterName: clusterNames[3]},
+			}
+			_, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).UpdateStatus(context.Background(), decision2, metav1.UpdateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// Verify cluster0's addon is created (from decision1)
+			gomega.Eventually(func() error {
+				_, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[0]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				return err
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
+			// Critical verification: cluster1's addon should NOT be recreated
+			// The UID should remain unchanged, proving the addon was not deleted and recreated
+			gomega.Consistently(func() error {
+				addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if string(addon.UID) != originalUID {
+					return fmt.Errorf("addon UID changed for cluster %s, expected %s, got %s", clusterNames[1], originalUID, addon.UID)
+				}
+				return nil
+			}, "5s", "500ms").ShouldNot(gomega.HaveOccurred())
 		})
 	})
 })

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1961,7 +1961,7 @@ open-cluster-management.io/api/operator/v1
 open-cluster-management.io/api/utils/work/v1/workapplier
 open-cluster-management.io/api/work/v1
 open-cluster-management.io/api/work/v1alpha1
-# open-cluster-management.io/sdk-go v1.1.1-0.20260120013142-6d087c9a2a3d
+# open-cluster-management.io/sdk-go v1.1.1-0.20260120013142-6d087c9a2a3d => github.com/haoqing0110/sdk-go v0.0.0-20260120095521-fe81e417c1e1
 ## explicit; go 1.25.0
 open-cluster-management.io/sdk-go/pkg/apis/cluster/v1alpha1
 open-cluster-management.io/sdk-go/pkg/apis/cluster/v1beta1
@@ -2139,3 +2139,4 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v3
+# open-cluster-management.io/sdk-go => github.com/haoqing0110/sdk-go v0.0.0-20260120095521-fe81e417c1e1


### PR DESCRIPTION
…ates

When PlacementDecisions are updated sequentially (e.g., decision1 then decision2), the addon controller may see intermediate states where a cluster temporarily appears in neither decision, causing unnecessary addon deletion and recreation.

This change adds 100ms delay to all informer events to batch rapid sequential updates before reconciliation.

Changes:
- Add 100ms delay to all 4 informers in addon-management-controller
- Use sdk-go delay support via WithInformersQueueKeysFuncAndDelay()
- Add integration test to verify addon UID remains unchanged during updates

Technical details:
- WorkQueue's AddAfter() automatically deduplicates events with same key
- If multiple PlacementDecision updates occur within 100ms, only one reconcile happens
- Delete events are still processed immediately for timely cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized event batching in addon management to reduce processing overhead through delayed queue handling.

* **Tests**
  * Enhanced testing to verify addon stability and prevent unnecessary recreation during sequential placement updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->