### PR TITLE
🐛 Reduce logging level of DumpSecret to v(4)

### DIFF
--- a/pkg/common/options/options_test.go
+++ b/pkg/common/options/options_test.go
@@ -14,8 +14,6 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clocktesting "k8s.io/utils/clock/testing"
 
-	"open-cluster-management.io/sdk-go/pkg/basecontroller/events"
-
 	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
 	"open-cluster-management.io/ocm/pkg/registration/register"
 	"open-cluster-management.io/ocm/pkg/registration/spoke/registration"
@@ -90,8 +88,8 @@ func TestComplete(t *testing.T) {
 			options.HubKubeconfigDir = dir
 
 			err = registration.DumpSecret(
-				kubeClient.CoreV1(), componentNamespace, "hub-kubeconfig-secret",
-				options.HubKubeconfigDir, context.TODO(), events.NewContextualLoggingEventRecorder(t.Name()))
+				context.TODO(), kubeClient.CoreV1(), componentNamespace, "hub-kubeconfig-secret",
+				options.HubKubeconfigDir)
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/registration/spoke/registration/secret_controller_test.go
+++ b/pkg/registration/spoke/registration/secret_controller_test.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 
-	"open-cluster-management.io/sdk-go/pkg/basecontroller/events"
-
 	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
 	"open-cluster-management.io/ocm/pkg/registration/register"
 	"open-cluster-management.io/ocm/pkg/registration/register/csr"
@@ -118,8 +116,7 @@ func TestDumpSecret(t *testing.T) {
 			}
 
 			err = DumpSecret(
-				kubeClient.CoreV1(), testNamespace, testSecretName, hubKubeconfigDir, context.TODO(),
-				events.NewContextualLoggingEventRecorder(t.Name()))
+				context.TODO(), kubeClient.CoreV1(), testNamespace, testSecretName, hubKubeconfigDir)
 			if err != nil {
 				t.Errorf("unexpected err: %v", err)
 			}

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -177,8 +177,8 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 
 	// dump data in hub kubeconfig secret into file system if it exists
 	err = registration.DumpSecret(
-		managementKubeClient.CoreV1(), o.agentOptions.ComponentNamespace, o.registrationOption.HubKubeconfigSecret,
-		o.agentOptions.HubKubeconfigDir, ctx, recorder)
+		ctx, managementKubeClient.CoreV1(), o.agentOptions.ComponentNamespace, o.registrationOption.HubKubeconfigSecret,
+		o.agentOptions.HubKubeconfigDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It generates a lot of noises otherwise

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified secret handling by consolidating logging mechanisms, reducing external dependencies, and standardizing parameter ordering for improved code consistency.

* **Tests**
  * Updated test cases to align with refactored secret handling implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->