### PR TITLE
🐛  skip importing terminating clusters

### DIFF
--- a/pkg/registration/hub/importer/importer.go
+++ b/pkg/registration/hub/importer/importer.go
@@ -116,6 +116,11 @@ func (i *Importer) sync(ctx context.Context, syncCtx factory.SyncContext, cluste
 		return err
 	}
 
+	// If the cluster is in terminating state, skip the reconcile
+	if !cluster.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
 	// If the cluster is imported, skip the reconcile
 	if meta.IsStatusConditionTrue(cluster.Status.Conditions, ManagedClusterConditionImported) {
 		return nil

--- a/pkg/registration/hub/importer/importer_test.go
+++ b/pkg/registration/hub/importer/importer_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestSync(t *testing.T) {
+	now := metav1.Now()
 	cases := []struct {
 		name     string
 		provider *fakeProvider
@@ -58,6 +59,15 @@ func TestSync(t *testing.T) {
 			provider: &fakeProvider{isOwned: true},
 			key:      "cluster1",
 			cluster:  &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster2"}},
+			validate: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertNoActions(t, actions)
+			},
+		},
+		{
+			name:     "cluster in terminating state",
+			provider: &fakeProvider{isOwned: true},
+			key:      "cluster1",
+			cluster:  &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster1", DeletionTimestamp: &now}},
 			validate: func(t *testing.T, actions []clienttesting.Action) {
 				testingcommon.AssertNoActions(t, actions)
 			},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of clusters in terminating state by skipping unnecessary processing steps, ensuring more efficient cluster removal from the system.

* **Tests**
  * Added test coverage for cluster termination scenarios to validate correct behavior during cluster removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->