### PR TITLE
:bug: only check the hub kubeconfig secret in cert rotation test

### DIFF
--- a/test/integration/registration/spokecluster_grpc_test.go
+++ b/test/integration/registration/spokecluster_grpc_test.go
@@ -272,8 +272,14 @@ var _ = ginkgo.Describe("Registration using GRPC", ginkgo.Ordered, ginkgo.Label(
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			})
 
-			ginkgo.By("getting managedclusters joined condition", func() {
-				assertManagedClusterJoined(grpcManagedClusterName, hubGRPCConfigSecret)
+			ginkgo.By("checking hub kubeconfig secret", func() {
+				// the hub kubeconfig secret should be filled after the csr is approved
+				gomega.Eventually(func() error {
+					if _, err := util.GetFilledHubKubeConfigSecret(kubeClient, testNamespace, hubGRPCConfigSecret); err != nil {
+						return err
+					}
+					return nil
+				}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 			})
 
 			// the agent should rotate the certificate because the certificate with a short valid time


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened integration tests for cluster registration workflows. Updated test verification approach to better validate prerequisites before executing cluster registration and certificate rotation procedures, enhancing overall test reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->