### PR TITLE
:bug: replace broken kubebuilder-tools download with setup-envtest

### DIFF
--- a/test/integration-test.mk
+++ b/test/integration-test.mk
@@ -3,23 +3,33 @@ TEST_TMP :=/tmp
 export KUBEBUILDER_ASSETS ?=$(TEST_TMP)/kubebuilder/bin
 
 K8S_VERSION ?=1.30.0
-KB_TOOLS_ARCHIVE_NAME :=kubebuilder-tools-$(K8S_VERSION)-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz
-KB_TOOLS_ARCHIVE_PATH := $(TEST_TMP)/$(KB_TOOLS_ARCHIVE_NAME)
+SETUP_ENVTEST := $(shell go env GOPATH)/bin/setup-envtest
 
 # download the kubebuilder-tools to get kube-apiserver binaries from it
 ensure-kubebuilder-tools:
 ifeq "" "$(wildcard $(KUBEBUILDER_ASSETS))"
 	$(info Downloading kube-apiserver into '$(KUBEBUILDER_ASSETS)')
 	mkdir -p '$(KUBEBUILDER_ASSETS)'
-	curl -s -f -L https://storage.googleapis.com/kubebuilder-tools/$(KB_TOOLS_ARCHIVE_NAME) -o '$(KB_TOOLS_ARCHIVE_PATH)'
-	tar -C '$(KUBEBUILDER_ASSETS)' --strip-components=2 -zvxf '$(KB_TOOLS_ARCHIVE_PATH)'
+ifeq "" "$(wildcard $(SETUP_ENVTEST))"
+	$(info Installing setup-envtest into '$(SETUP_ENVTEST)')
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+endif
+	ENVTEST_K8S_PATH=$$($(SETUP_ENVTEST) use $(K8S_VERSION) --bin-dir $(KUBEBUILDER_ASSETS) -p path); \
+	if [ -z "$$ENVTEST_K8S_PATH" ]; then \
+		echo "Error: setup-envtest returned empty path"; \
+		exit 1; \
+	fi; \
+	if [ ! -d "$$ENVTEST_K8S_PATH" ]; then \
+		echo "Error: setup-envtest path does not exist: $$ENVTEST_K8S_PATH"; \
+		exit 1; \
+	fi; \
+	cp -r $$ENVTEST_K8S_PATH/* $(KUBEBUILDER_ASSETS)/
 else
 	$(info Using existing kube-apiserver from "$(KUBEBUILDER_ASSETS)")
 endif
 .PHONY: ensure-kubebuilder-tools
 
 clean-integration-test:
-	$(RM) '$(KB_TOOLS_ARCHIVE_PATH)'
 	rm -rf $(TEST_TMP)/kubebuilder
 	$(RM) ./*integration.test
 .PHONY: clean-integration-test


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved integration test environment setup by switching to a setup-envtest-based installation for Kubernetes test binaries.
  * Now conditionally installs setup-envtest when missing and uses existing test binaries when available to speed up runs.
  * Simplified cleanup behavior for test tool artifacts to streamline test workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->