### PR TITLE
🐛 fix: correct variable usage and error messages in ManifestWorkReplicaSet e2e tests

### DIFF
--- a/test/e2e/manifestworkreplicaset_test.go
+++ b/test/e2e/manifestworkreplicaset_test.go
@@ -301,11 +301,11 @@ var _ = ginkgo.Describe("Test ManifestWorkReplicaSet", ginkgo.Label("manifestwor
 				}
 
 				if !meta.IsStatusConditionTrue(mwrSet.Status.Conditions, workapiv1alpha1.ManifestWorkReplicaSetConditionPlacementVerified) {
-					return err
+					return fmt.Errorf("manifestwork replicaset PlacementVerified condition is not true")
 				}
 
-				if mwReplicaSet.Status.Summary.Total != numOfClusters {
-					return fmt.Errorf("total number of clusters is not correct, expect %d, got %d", numOfClusters, mwReplicaSet.Status.Summary.Total)
+				if mwrSet.Status.Summary.Total != numOfClusters {
+					return fmt.Errorf("total number of clusters is not correct, expect %d, got %d", numOfClusters, mwrSet.Status.Summary.Total)
 				}
 				return nil
 			}).Should(gomega.Succeed())
@@ -388,11 +388,11 @@ var _ = ginkgo.Describe("Test ManifestWorkReplicaSet", ginkgo.Label("manifestwor
 				}
 
 				if !meta.IsStatusConditionTrue(mwrSet.Status.Conditions, workapiv1alpha1.ManifestWorkReplicaSetConditionPlacementVerified) {
-					return err
+					return fmt.Errorf("manifestwork replicaset PlacementVerified condition is not true")
 				}
 
-				if mwReplicaSet.Status.Summary.Total != numOfClusters {
-					return fmt.Errorf("total number of clusters is not correct, expect %d, got %d", numOfClusters, mwReplicaSet.Status.Summary.Total)
+				if mwrSet.Status.Summary.Total != numOfClusters {
+					return fmt.Errorf("total number of clusters is not correct, expect %d, got %d", numOfClusters, mwrSet.Status.Summary.Total)
 				}
 				return nil
 			}).Should(gomega.Succeed())


### PR DESCRIPTION
## Summary

- Fixed incorrect variable reference: Use freshly fetched `mwrSet` instead of stale `mwReplicaSet` when checking status summary (appears in two test cases)
- Fixed error handling: Return descriptive error messages instead of nil error when condition checks fail, improving test debugging

These bugs could cause test failures or provide misleading error messages. The fixes ensure tests validate against the latest object state and provide clear failure reasons.

## Related issue(s)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error messaging for ManifestWorkReplicaSet placement verification checks.
  * Corrected status field references in test assertions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->