### PR TITLE
🐛 fix: handle ComponentNamespace in CI test environment

### DIFF
--- a/pkg/common/options/agent_test.go
+++ b/pkg/common/options/agent_test.go
@@ -13,8 +13,17 @@ func TestNewAgentOptions(t *testing.T) {
 	if opts.HubKubeconfigDir != "/spoke/hub-kubeconfig" {
 		t.Errorf("unexpected HubKubeconfigDir: %s", opts.HubKubeconfigDir)
 	}
-	if opts.ComponentNamespace != "open-cluster-management-agent" {
-		t.Errorf("unexpected ComponentNamespace: %s", opts.ComponentNamespace)
+	// ComponentNamespace should either be the default or read from the service account namespace file
+	if opts.ComponentNamespace == "" {
+		t.Errorf("ComponentNamespace should not be empty")
+	}
+	// In test environments, it may be read from /var/run/secrets/kubernetes.io/serviceaccount/namespace
+	// Otherwise, it should be the default value
+	if _, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err != nil {
+		// No service account namespace file, should be default
+		if opts.ComponentNamespace != "open-cluster-management-agent" {
+			t.Errorf("unexpected ComponentNamespace: %s", opts.ComponentNamespace)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The `TestNewAgentOptions` test was failing in CI environments because it expected `ComponentNamespace` to always be `open-cluster-management-agent`, but `NewAgentOptions()` reads from `/var/run/secrets/kubernetes.io/serviceaccount/namespace` when running in a Kubernetes pod (which exists in CI environment).

This PR updates the test to accept either the default value (when running locally) or the actual pod namespace (when running in CI), while ensuring the namespace is never empty.

## Related issue(s)

Fixes the CI test failure in `TestNewAgentOptions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved agent options test logic to correctly handle Kubernetes environments with and without service account namespace configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->