### PR TITLE
🐛 fix: remove flaky time.Sleep from hub timeout controller test

### DIFF
--- a/pkg/registration/spoke/registration/hub_timeout_controller_test.go
+++ b/pkg/registration/spoke/registration/hub_timeout_controller_test.go
@@ -13,30 +13,32 @@ import (
 
 func TestHubTimeoutController_Sync(t *testing.T) {
 	cases := []struct {
-		name        string
-		waitSeconds int
-		expect      bool
+		name            string
+		leaseAgeSeconds int
+		timeoutSeconds  int32
+		expect          bool
 	}{
 		{
-			name:        "not timeout",
-			waitSeconds: 1,
-			expect:      false,
+			name:            "not timeout",
+			leaseAgeSeconds: 2,
+			timeoutSeconds:  5,
+			expect:          false,
 		},
 		{
-			name:        "timeout",
-			waitSeconds: 5,
-			expect:      true,
+			name:            "timeout",
+			leaseAgeSeconds: 6,
+			timeoutSeconds:  5,
+			expect:          true,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			var leaseRenewTime = time.Now()
+			// Set lease renew time in the past to simulate aging
+			leaseRenewTime := time.Now().Add(-time.Duration(c.leaseAgeSeconds) * time.Second)
 
 			lease := testinghelpers.NewManagedClusterLease("managed-cluster-lease", leaseRenewTime)
 			leaseClient := kubefake.NewClientset(lease)
-
-			time.Sleep(time.Second * time.Duration(c.waitSeconds))
 
 			handled := false
 			controller := &hubTimeoutController{
@@ -46,7 +48,9 @@ func TestHubTimeoutController_Sync(t *testing.T) {
 					return nil
 				},
 				clusterName:    testinghelpers.TestManagedClusterName,
-				timeoutSeconds: 3,
+				timeoutSeconds: c.timeoutSeconds,
+				// Set startTime in the past to bypass the 10s grace period
+				startTime: time.Now().Add(-time.Second * 15),
 			}
 
 			err := controller.sync(context.Background(), testingcommon.NewFakeSyncContext(t, ""), "")


### PR DESCRIPTION
## Summary

- Fixed intermittent test failures in `TestHubTimeoutController_Sync` by removing dependency on `time.Sleep()` and real-time execution
- Eliminated race conditions caused by execution overhead in CI environments
- Made the test deterministic by simulating aged leases using time manipulation

## Changes

The `TestHubTimeoutController_Sync` test was failing intermittently in CI due to timing issues:

**Before:**
- Used `time.Sleep()` to wait for actual time to pass (1s for "not timeout", 5s for "timeout")
- Created lease with `time.Now()` then slept, expecting precise timing
- Hard-coded 3-second timeout threshold
- In busy CI environments, overhead could push the test beyond the threshold

**After:**
- Removed `time.Sleep()` completely
- Set lease renew time in the past using `time.Now().Add(-duration)` to deterministically simulate aged leases
- Made timeout threshold configurable per test case
- Increased safety margin from 1s to 3s (2s lease age vs 5s timeout)
- Set `startTime` in the past to bypass the 10s grace period check introduced for handling stale lease scenarios

**Test Results:**
- Verified test passes consistently across 5+ consecutive runs
- All package tests continue to pass
- No more timing-dependent behavior

## Related issue(s)

Fixes https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stolostron_ocm/610/pull-ci-stolostron-ocm-backplane-2.9-unit/2021941296557461504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved hub timeout controller tests with enhanced efficiency and clarity through refactored test parameters and optimized test execution methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->