### PR TITLE
🌱 Adopt shared golangci-lint scripts from sdk-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,6 @@ HELM?=$(PERMANENT_TMP_GOPATH)/bin/helm
 HELM_VERSION?=v3.14.0
 helm_gen_dir:=$(dir $(HELM))
 
-GOLANGCI_LINT?=$(PERMANENT_TMP_GOPATH)/bin/golangci-lint
-GOLANGCI_LINT_VERSION?=v2.4.0
-golangci_lint_gen_dir:=$(dir $(GOLANGCI_LINT))
-
 # RELEASED_CSV_VERSION indicates the last released operator version.
 # can find the released operator version from
 # https://github.com/k8s-operatorhub/community-operators/tree/main/operators/cluster-manager
@@ -89,8 +85,8 @@ update-csv: ensure-operator-sdk ensure-helm
 verify-crds: ensure-yaml-patch
 	bash -x hack/verify-crds.sh $(YAML_PATCH)
 
-verify-gocilint: ensure-golangci-lint
-	$(GOLANGCI_LINT) run --timeout=5m --modules-download-mode vendor ./...
+lint:
+	@curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh | bash
 
 install-golang-gci:
 	go install github.com/daixiang0/gci@v0.13.7
@@ -108,7 +104,7 @@ verify-fmt-imports: install-golang-gci
 	    echo "Diff output is empty"; \
 	fi
 
-verify: verify-fmt-imports verify-crds verify-gocilint
+verify: verify-fmt-imports verify-crds lint
 
 ensure-operator-sdk:
 ifeq "" "$(wildcard $(OPERATOR_SDK))"
@@ -133,11 +129,3 @@ else
 	$(info Using existing helm from "$(HELM)")
 endif
 
-ensure-golangci-lint:
-ifeq "" "$(wildcard $(GOLANGCI_LINT))"
-	$(info Installing golangci-lint into '$(GOLANGCI_LINT)')
-	mkdir -p '$(golangci_lint_gen_dir)'
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b '$(golangci_lint_gen_dir)' $(GOLANGCI_LINT_VERSION)
-else
-	$(info Using existing golangci-lint from "$(GOLANGCI_LINT)")
-endif


### PR DESCRIPTION
## Summary

Replace the local golangci-lint installation logic and `verify-gocilint` target in the Makefile with the shared `run-lint.sh` script from [sdk-go](https://github.com/open-cluster-management-io/sdk-go/tree/main/ci/lint). This ensures all OCM repositories stay in sync with a single source of lint tooling, version management, and Go version compatibility mapping.

**Changes:**
- Replace `verify-gocilint` / `ensure-golangci-lint` targets with a new `lint` target that downloads and runs the shared lint script via `curl`
- Remove `GOLANGCI_LINT`, `GOLANGCI_LINT_VERSION`, and `golangci_lint_gen_dir` variables (no longer needed)
- Update `verify` target dependency from `verify-gocilint` to `lint`
- Preserve the existing `.golangci.yaml` (already in v2 format) as the local config

**Benefits:**
- Automatic Go version detection and compatible golangci-lint version selection
- Centralized lint configuration updates across all OCM repos
- Simplified Makefile with no local installation logic

## Related issue(s)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build system's linting workflow to use a remote lint script, replacing the previous local linting mechanism. This streamlines the verification process without affecting existing workflows for Helm, Operator SDK, and other build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->