### PR TITLE
Replace FOSSA App with dependency-scoped license compliance workflow

### DIFF
--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -1,0 +1,41 @@
+name: License Compliance
+
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'vendor/**'
+    branches:
+      - main
+      - release-*
+  push:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'vendor/**'
+    branches:
+      - main
+      - release-*
+
+permissions:
+  contents: read
+
+jobs:
+  license-compliance:
+    name: license-compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Run FOSSA Scan
+        uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+
+      - name: Run FOSSA Test
+        uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true


### PR DESCRIPTION
## Summary
- Replace the always-on FOSSA GitHub App integration with a GitHub Actions workflow
- The new workflow only triggers license compliance checks when dependency files (`go.mod`, `go.sum`, `vendor/`) are modified
- Avoids unnecessary license scanning on PRs that only change business logic code

## Motivation
The FOSSA GitHub App runs on every PR regardless of whether dependencies changed, which:
1. Adds unnecessary latency to PRs that don't touch dependencies
2. Can block unrelated PRs when there are pre-existing license issues on the main branch

## Changes
- Added `.github/workflows/license-compliance.yml` using the official `fossas/fossa-action@v1`
- Configured `paths` filter to only trigger on `go.mod`, `go.sum`, and `vendor/**` changes
- Requires `FOSSA_API_KEY` secret to be configured in the repository settings

## Notes
- The FOSSA GitHub App integration should be removed from the repository settings to avoid duplicate checks
- A `FOSSA_API_KEY` secret needs to be added to the repository for the workflow to function

## Test plan
- [ ] Verify the workflow triggers correctly when `go.mod`/`go.sum`/`vendor/` files change
- [ ] Verify the workflow does NOT trigger on PRs that only modify source code
- [ ] Verify FOSSA scan results are reported correctly
- [ ] Remove the FOSSA GitHub App from repository integrations after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated license compliance checks to the continuous integration pipeline to ensure dependency licensing standards are met on pull requests and pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->