### PR TITLE
:book: docs: add Flower federated learning addon to Ecosystem

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -30,6 +30,7 @@ The list includes but is not limited to:
 - [Cluster API](https://github.com/open-cluster-management-io/ocm/tree/main/solutions/cluster-api)
 - [Clusternet](https://github.com/open-cluster-management-io/addon-contrib/tree/main/clusternet-addon)
 - [Fluid](https://github.com/open-cluster-management-io/addon-contrib/tree/main/fluid-addon)
+- [Flower](https://github.com/open-cluster-management-io/addon-contrib/tree/main/flower-addon)
 - [Helm](https://v0-16.open-cluster-management.io/docs/getting-started/integration/app-lifecycle/)
 - [ICOS Meta OS](https://www.icos-project.eu/docs/Administration/ICOS%20Agent/Orchestrators/controlplane/)
 - [Istio](https://github.com/open-cluster-management-io/multicluster-mesh)


### PR DESCRIPTION
Add Flower addon to the Ecosystem section of ADOPTERS.md.

[Flower](https://flower.ai/) is a federated learning framework. The [flower-addon](https://github.com/open-cluster-management-io/addon-contrib/tree/main/flower-addon) integrates Flower with OCM to enable automated distribution and orchestration of federated learning workloads across multi-cluster environments.

Signed-off-by: Meng Yan <yanmxa@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Flower addon links to the adopters list and ecosystem integrations section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->