### PR TITLE
🐛 Fix addon template E2E test flake by adding canary probe

### DIFF
--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -142,9 +142,10 @@ var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-
 		}).Should(gomega.Succeed())
 
 		ginkgo.By("Wait for addon agent to be fully functioning by syncing a canary configmap")
+		canaryName := fmt.Sprintf("addon-canary-probe-%s", rand.String(6))
 		canary := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "addon-canary-probe",
+				Name:      canaryName,
 				Namespace: universalClusterName,
 			},
 			Data: map[string]string{"probe": "true"},
@@ -153,19 +154,26 @@ var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-
 			context.Background(), canary, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+		ginkgo.DeferCleanup(func() {
+			err := hub.KubeClient.CoreV1().ConfigMaps(universalClusterName).Delete(
+				context.Background(), canaryName, metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				klog.Errorf("failed to delete hub canary configmap %s/%s: %v",
+					universalClusterName, canaryName, err)
+			}
+			err = spoke.KubeClient.CoreV1().ConfigMaps(addonInstallNamespace).Delete(
+				context.Background(), canaryName, metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				klog.Errorf("failed to delete spoke canary configmap %s/%s: %v",
+					addonInstallNamespace, canaryName, err)
+			}
+		})
+
 		gomega.Eventually(func() error {
 			_, err := spoke.KubeClient.CoreV1().ConfigMaps(addonInstallNamespace).Get(
-				context.Background(), canary.Name, metav1.GetOptions{})
+				context.Background(), canaryName, metav1.GetOptions{})
 			return err
 		}).Should(gomega.Succeed())
-
-		// Clean up the canary configmap from hub and spoke
-		err = hub.KubeClient.CoreV1().ConfigMaps(universalClusterName).Delete(
-			context.Background(), canary.Name, metav1.DeleteOptions{})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		err = spoke.KubeClient.CoreV1().ConfigMaps(addonInstallNamespace).Delete(
-			context.Background(), canary.Name, metav1.DeleteOptions{})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	ginkgo.AfterEach(func() {


### PR DESCRIPTION
## Summary

- Fix intermittent E2E test failure in "Template type addon should be functioning" caused by a gap between addon `Available` condition (Kubernetes workload readiness) and actual agent application readiness (hub connection + informer sync)
- Add a canary configmap probe in `BeforeEach` to verify the addon agent can sync configmaps from hub to spoke before running test assertions
- Clean up canary resources after verification to avoid interference with test cases

## Details

The addon `Available` condition uses `HealthProberTypeWorkloadAvailability`, which only checks that Deployment/DaemonSet pods have ready replicas. However, a running pod does not guarantee the agent has:
1. Loaded the hub-kubeconfig
2. Connected to the hub API server
3. Completed initial informer list/watch sync

The canary probe creates a small configmap on the hub and waits for it to appear on the spoke, confirming end-to-end agent functionality before any test case runs.

## Related issue(s)

Fixes flaky E2E test: `Addon management Template type addon should be functioning [addon-manager]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a canary readiness probe to verify addon agent readiness before proceeding.
  * Improved synchronization checks to wait for probe confirmation across clusters.
  * Added deferred cleanup and enhanced error handling to make tests more robust and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->