### PR TITLE
🌱 Replace deprecated kubebuilder-release-tools PR verifier with inline scripts

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -1,11 +1,7 @@
 name: PR Verifier
 
 on:
-  # NB: using `pull_request_target` runs this in the context of
-  # the base repository, so it has permission to upload to the checks API.
-  # This means changes won't kick in to this file until merged onto the
-  # main branch.
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
@@ -14,13 +10,27 @@ permissions:
 jobs:
   verify:
     name: verify PR contents
-    permissions:
-      checks: write
-      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Verifier action
-        id: verifier
-        uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ -z "$TITLE" ]]; then
+            echo "Error: PR title cannot be empty."
+            exit 1
+          fi
+
+          if ! [[ "$TITLE" =~ ^($'\u26A0'|$'\u2728'|$'\U0001F41B'|$'\U0001F4D6'|$'\U0001F680'|$'\U0001F331') ]]; then
+            echo "Error: Invalid PR title format."
+            echo "Your PR title must start with one of the following indicators:"
+            echo "- Breaking change: ⚠ (U+26A0)"
+            echo "- Non-breaking feature: ✨ (U+2728)"
+            echo "- Patch fix: 🐛 (U+1F41B)"
+            echo "- Docs: 📖 (U+1F4D6)"
+            echo "- Release: 🚀 (U+1F680)"
+            echo "- Infra/Tests/Other: 🌱 (U+1F331)"
+            exit 1
+          fi
+
+          echo "PR title is valid: '$TITLE'"


### PR DESCRIPTION
## Summary
- The Docker image `gcr.io/kubebuilder/pr-verifier:v0.4.3` used by `kubernetes-sigs/kubebuilder-release-tools@v0.4.3` has been removed from GCR as of March 2025 (see [kubernetes-sigs/kubebuilder-release-tools#61](https://github.com/kubernetes-sigs/kubebuilder-release-tools/pull/61))
- Replaced the deprecated Docker-based action with an inline shell script that validates PR title format, following the [approach adopted by the Kubebuilder project itself](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.github/workflows/verify.yml)
- Switched from `pull_request_target` to `pull_request` and removed unnecessary `checks: write` / `pull-requests: read` permissions since the inline script doesn't need elevated access

## Test plan
- [x] Verified that the new workflow script matches the Kubebuilder project's own implementation
- [ ] Confirm the workflow passes on this PR with a valid emoji-prefixed title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced PR verification workflow to automatically validate PR title format on submission.
  * PR titles must start with one of: ⚠, ✨, 🐛, 📖, 🚀, or 🌱; clear guidance and error messages are shown for invalid or empty titles.
  * Simplified workflow permissions by removing redundant per-job permission settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->