### PR TITLE
🐛 Align PR title verifier prefixes with pull_request_template.md

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -21,15 +21,16 @@ jobs:
             exit 1
           fi
 
-          if ! [[ "$TITLE" =~ ^($'\u26A0'|$'\u2728'|$'\U0001F41B'|$'\U0001F4D6'|$'\U0001F680'|$'\U0001F331') ]]; then
+          if ! [[ "$TITLE" =~ ^(:sparkles:|:bug:|:book:|:memo:|:warning:|:seedling:|:question:|$'\u2728'|$'\U0001F41B'|$'\U0001F4D6'|$'\U0001F4DD'|$'\u26A0'$'\uFE0F'?|$'\U0001F331'|$'\u2753') ]]; then
             echo "Error: Invalid PR title format."
             echo "Your PR title must start with one of the following indicators:"
-            echo "- Breaking change: ⚠ (U+26A0)"
-            echo "- Non-breaking feature: ✨ (U+2728)"
-            echo "- Patch fix: 🐛 (U+1F41B)"
-            echo "- Docs: 📖 (U+1F4D6)"
-            echo "- Release: 🚀 (U+1F680)"
-            echo "- Infra/Tests/Other: 🌱 (U+1F331)"
+            echo "- :sparkles: ✨ feature"
+            echo "- :bug: 🐛 bug fix"
+            echo "- :book: 📖 docs"
+            echo "- :memo: 📝 proposal"
+            echo "- :warning: ⚠️ breaking change"
+            echo "- :seedling: 🌱 other/misc"
+            echo "- :question: ❓ requires manual review"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Align the PR title prefixes in the `pr-verify.yml` workflow with those defined in `.github/pull_request_template.md`
- Added missing prefixes: 📝 (proposal) and ❓ (requires manual review)
- Removed 🚀 (release) which is not listed in the PR template

## Related issue(s)
Follow-up to #1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened pull request title validation to accept a wider set of emoji indicators and shortcodes (including additional Unicode emojis and optional variation selectors).
  * Updated validation guidance to reference labeled prefixes (Feature, Bug fix, Docs, Proposal, Breaking change, Other/Misc, Requires manual review) while preserving the existing non-terminating validation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->