### PR TITLE
:bug: set tokenrequest UID to empty to avoid conflict with the ServiceAccount UID validation

### DIFF
--- a/pkg/server/services/tokenrequest/tokenreqeust.go
+++ b/pkg/server/services/tokenrequest/tokenreqeust.go
@@ -56,6 +56,9 @@ func (t *TokenRequestService) HandleStatusUpdate(ctx context.Context, evt *cloud
 
 	switch eventType.Action {
 	case types.CreateRequestAction:
+		// Clear the UID to avoid conflict with the ServiceAccount UID validation
+		// introduced by the TokenRequestServiceAccountUIDValidation feature gate (k8s 1.34+).
+		tokenRequest.UID = ""
 		// Create a token for the service account
 		tokenResponse, err := t.client.CoreV1().ServiceAccounts(tokenRequest.Namespace).CreateToken(ctx, tokenRequest.Name, tokenRequest, metav1.CreateOptions{})
 		if err != nil {


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved ServiceAccount UID validation conflicts affecting token request operations in Kubernetes 1.34+. Token requests will now process successfully without encountering validation errors when working with updated Kubernetes cluster environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->