### PR TITLE
✨ Placement decision score

### DIFF
--- a/pkg/placement/controllers/scheduling/scheduling_controller.go
+++ b/pkg/placement/controllers/scheduling/scheduling_controller.go
@@ -1,16 +1,19 @@
 package scheduling
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"math"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	errorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -242,7 +245,7 @@ func (c *schedulingController) syncPlacement(ctx context.Context, syncCtx factor
 	c.metricsRecorder.StartSchedule(queueKey)
 	scheduleResult, status := c.scheduler.Schedule(ctx, placement, clusters)
 	// generate placement decision and status
-	decisions, groupStatus, s := c.generatePlacementDecisionsAndStatus(placement, scheduleResult.Decisions())
+	decisions, groupStatus, s := c.generatePlacementDecisionsAndStatus(placement, scheduleResult.Decisions(), scheduleResult.PrioritizerScores())
 	if s.IsError() {
 		status = s
 	}
@@ -268,14 +271,14 @@ func (c *schedulingController) syncPlacement(ctx context.Context, syncCtx factor
 	// create/update placement decisions
 	c.metricsRecorder.StartBind(queueKey)
 	defer c.metricsRecorder.Done(queueKey)
-	err = c.bind(ctx, placement, decisions, scheduleResult.PrioritizerScores(), status)
+	updatedDecisions, err := c.bind(ctx, placement, decisions, scheduleResult.PrioritizerScores(), status)
 	if err != nil {
 		return err
 	}
 
 	// update placement status if necessary to signal no bindings
 	if err := c.updateStatus(
-		ctx, placement, groupStatus, int32(len(scheduleResult.Decisions())), misconfiguredCondition, satisfiedCondition); err != nil { // nolint:gosec
+		ctx, placement, groupStatus, int32(len(scheduleResult.Decisions())), updatedDecisions, misconfiguredCondition, satisfiedCondition); err != nil { // nolint:gosec
 		return err
 	}
 
@@ -288,11 +291,16 @@ func (c *schedulingController) updateStatus(
 	placement *clusterapiv1beta1.Placement,
 	decisionGroupStatus []*clusterapiv1beta1.DecisionGroupStatus,
 	numberOfSelectedClusters int32,
+	updatedDecisions bool,
 	conditions ...metav1.Condition,
 ) error {
 	newPlacement := placement.DeepCopy()
 	newPlacement.Status.NumberOfSelectedClusters = numberOfSelectedClusters
 	newPlacement.Status.DecisionGroups = []clusterapiv1beta1.DecisionGroupStatus{}
+	if updatedDecisions {
+		now := metav1.Now()
+		newPlacement.Status.LastScoreUpdateTime = &now
+	}
 
 	for _, status := range decisionGroupStatus {
 		newPlacement.Status.DecisionGroups = append(newPlacement.Status.DecisionGroups, *status)
@@ -381,13 +389,14 @@ func newMisconfiguredCondition(status *framework.Status) metav1.Condition {
 func (c *schedulingController) generatePlacementDecisionsAndStatus(
 	placement *clusterapiv1beta1.Placement,
 	clusters []*clusterapiv1.ManagedCluster,
+	scores PrioritizerScore,
 ) ([]*clusterapiv1beta1.PlacementDecision, []*clusterapiv1beta1.DecisionGroupStatus, *framework.Status) {
 	placementDecisionIndex := 1
 	var placementDecisions []*clusterapiv1beta1.PlacementDecision
 	var decisionGroupStatus []*clusterapiv1beta1.DecisionGroupStatus
 
 	// generate decision group
-	decisionGroups, status := c.generateDecisionGroups(placement, clusters)
+	decisionGroups, status := c.generateDecisionGroups(placement, clusters, scores)
 
 	// generate placement decision for each decision group
 	for decisionGroupIndex, decisionGroup := range decisionGroups {
@@ -408,6 +417,7 @@ func (c *schedulingController) generatePlacementDecisionsAndStatus(
 func (c *schedulingController) generateDecisionGroups(
 	placement *clusterapiv1beta1.Placement,
 	clusters []*clusterapiv1.ManagedCluster,
+	scores PrioritizerScore,
 ) (clusterDecisionGroups, *framework.Status) {
 	var groups []clusterDecisionGroup
 
@@ -428,12 +438,12 @@ func (c *schedulingController) generateDecisionGroups(
 	// First groups the clusters by ClusterSelector defined in spec.DecisionStrategy.GroupStrategy.DecisionGroups.
 	for _, d := range placement.Spec.DecisionStrategy.GroupStrategy.DecisionGroups {
 		// filter clusters by cluster selector
-		matched, status := filterClustersBySelector(d.ClusterSelector, clusters, clusterNameSet)
+		matched, status := filterClustersBySelector(d.ClusterSelector, clusters, clusterNameSet, scores)
 		if status.IsError() {
 			return groups, status
 		}
-		// If matched clusters number meets groupLength, divide into multiple groups.
-		decisionGroups := divideDecisionGroups(d.GroupName, matched, groupLength)
+		// Sort group and divide into multiple groups if matched clusters number meets groupLength.
+		decisionGroups := divideDecisionGroups(d.GroupName, matched, groupLength, placement.Spec.SortBy)
 		groups = append(groups, decisionGroups...)
 	}
 
@@ -442,11 +452,12 @@ func (c *schedulingController) generateDecisionGroups(
 	for _, cluster := range clusterNameSet.UnsortedList() {
 		matched = append(matched, clusterapiv1beta1.ClusterDecision{
 			ClusterName: cluster,
+			Score:       scores[cluster],
 		})
 	}
 
-	// If the rest of clusters number meets groupLength, divide into multiple groups.
-	decisionGroups := divideDecisionGroups("", matched, groupLength)
+	// Sort remaining clusters and divide into multiple groups if matched clusters number meets groupLength.
+	decisionGroups := divideDecisionGroups("", matched, groupLength, placement.Spec.SortBy)
 	groups = append(groups, decisionGroups...)
 
 	// generate at least on empty decisionGroup, this is to ensure there's an empty placement decision if no cluster selected.
@@ -532,33 +543,41 @@ func (c *schedulingController) bind(
 	placementdecisions []*clusterapiv1beta1.PlacementDecision,
 	clusterScores PrioritizerScore,
 	status *framework.Status,
-) error {
+) (updatedDecisions bool, err error) {
 	var errs []error
-	placementDecisionNames := sets.NewString()
+
+	// query existing placementdecisions of the placement
+	requirement, err := labels.NewRequirement(clusterapiv1beta1.PlacementLabel, selection.Equals, []string{placement.Name})
+	if err != nil {
+		return updatedDecisions, err
+	}
+	labelSelector := labels.NewSelector().Add(*requirement)
+	existingPlacementDecisions, err := c.placementDecisionLister.PlacementDecisions(placement.Namespace).List(labelSelector)
+	if err != nil {
+		return updatedDecisions, err
+	}
+
+	if skip, err := shouldSkipScoreUpdate(placement, placementdecisions, existingPlacementDecisions); skip || err != nil {
+		return updatedDecisions, err
+	}
 
 	// create/update placement decisions
+	placementDecisionNames := sets.NewString()
 	for _, pd := range placementdecisions {
 		placementDecisionNames.Insert(pd.Name)
-		err := c.createOrUpdatePlacementDecision(ctx, placement, pd, clusterScores, status)
+		updated, err := c.createOrUpdatePlacementDecision(ctx, placement, pd, clusterScores, status)
+		updatedDecisions = updatedDecisions || updated
 		if err != nil {
 			errs = append(errs, err)
 		}
 	}
-
-	// query all placementdecisions of the placement
-	requirement, err := labels.NewRequirement(clusterapiv1beta1.PlacementLabel, selection.Equals, []string{placement.Name})
-	if err != nil {
-		return err
-	}
-	labelSelector := labels.NewSelector().Add(*requirement)
-	pds, err := c.placementDecisionLister.PlacementDecisions(placement.Namespace).List(labelSelector)
-	if err != nil {
-		return err
+	if len(errs) != 0 {
+		return updatedDecisions, errorhelpers.NewMultiLineAggregate(errs)
 	}
 
 	// delete redundant placementdecisions
 	errs = []error{}
-	for _, pd := range pds {
+	for _, pd := range existingPlacementDecisions {
 		if placementDecisionNames.Has(pd.Name) {
 			continue
 		}
@@ -575,7 +594,7 @@ func (c *schedulingController) bind(
 			"DecisionDelete", "DecisionDeleted",
 			"Decision %s is deleted with placement %s in namespace %s", pd.Name, placement.Name, placement.Namespace)
 	}
-	return errorhelpers.NewMultiLineAggregate(errs)
+	return updatedDecisions, errorhelpers.NewMultiLineAggregate(errs)
 }
 
 // createOrUpdatePlacementDecision creates a new PlacementDecision if it does not exist and
@@ -586,12 +605,12 @@ func (c *schedulingController) createOrUpdatePlacementDecision(
 	placementDecision *clusterapiv1beta1.PlacementDecision,
 	clusterScores PrioritizerScore,
 	status *framework.Status,
-) error {
+) (updatedDecisions bool, err error) {
 	placementDecisionName := placementDecision.Name
 	clusterDecisions := placementDecision.Status.Decisions
 
 	if len(clusterDecisions) > maxNumOfClusterDecisions {
-		return fmt.Errorf("the number of clusterdecisions %q exceeds the max limitation %q", len(clusterDecisions), maxNumOfClusterDecisions)
+		return false, fmt.Errorf("the number of clusterdecisions %q exceeds the max limitation %q", len(clusterDecisions), maxNumOfClusterDecisions)
 	}
 
 	existPlacementDecision, err := c.placementDecisionLister.PlacementDecisions(placementDecision.Namespace).Get(placementDecisionName)
@@ -601,14 +620,14 @@ func (c *schedulingController) createOrUpdatePlacementDecision(
 		existPlacementDecision, err = c.clusterClient.ClusterV1beta1().PlacementDecisions(
 			placement.Namespace).Create(ctx, placementDecision, metav1.CreateOptions{})
 		if err != nil {
-			return err
+			return false, err
 		}
 		c.eventsRecorder.Eventf(
 			placement, existPlacementDecision, corev1.EventTypeNormal,
 			"DecisionCreate", "DecisionCreated",
 			"Decision %s is created with placement %s in namespace %s", existPlacementDecision.Name, placement.Name, placement.Namespace)
 	case err != nil:
-		return err
+		return false, err
 	}
 
 	// update the status and labels of the placementdecision if decisions change
@@ -625,11 +644,11 @@ func (c *schedulingController) createOrUpdatePlacementDecision(
 	if updated {
 		// Record events when status is updated
 		c.recordDecisionEvents(placement, existPlacementDecision, clusterScores, status)
-		return err
+		return true, err
 	}
 	// Do not record events when label is updated
 	_, err = placementDecisionPatcher.PatchLabelAnnotations(ctx, newPlacementDecision, newPlacementDecision.ObjectMeta, existPlacementDecision.ObjectMeta)
-	return err
+	return false, err
 }
 
 // recordDecisionEvents records DecisionUpdate and ScoreUpdate events for placement decision
@@ -711,6 +730,7 @@ func filterClustersBySelector(
 	groupSelector clusterapiv1beta1.GroupClusterSelector,
 	clusters []*clusterapiv1.ManagedCluster,
 	clusterNames sets.Set[string],
+	scores PrioritizerScore,
 ) ([]clusterapiv1beta1.ClusterDecision, *framework.Status) {
 	var matched []clusterapiv1beta1.ClusterDecision
 	// set CEL env to nil since placement decision groups do not support CEL expressions.
@@ -735,6 +755,7 @@ func filterClustersBySelector(
 
 		matched = append(matched, clusterapiv1beta1.ClusterDecision{
 			ClusterName: cluster.Name,
+			Score:       scores[cluster.Name],
 		})
 		clusterNames.Delete(cluster.Name)
 	}
@@ -743,13 +764,16 @@ func filterClustersBySelector(
 }
 
 // divideDecisionGroups divide the matched clusters to the groups and ensuring that each group has the specified length.
-func divideDecisionGroups(groupName string, matched []clusterapiv1beta1.ClusterDecision, groupLength int) []clusterDecisionGroup {
+func divideDecisionGroups(groupName string, matched []clusterapiv1beta1.ClusterDecision, groupLength int, sortBy clusterapiv1beta1.PlacementSortByType) []clusterDecisionGroup {
 	var groups []clusterDecisionGroup
 
-	// sort the matched cluster decisions by name before divide
-	sort.SliceStable(matched, func(i, j int) bool {
-		return matched[i].ClusterName < matched[j].ClusterName
-	})
+	// sort the matched cluster decisions before divide
+	switch sortBy {
+	case clusterapiv1beta1.PlacementSortByScore:
+		slices.SortStableFunc(matched, compareClusterDecisionScore)
+	default:
+		slices.SortStableFunc(matched, compareClusterDecisionName)
+	}
 
 	for len(matched) > 0 {
 		groupClusters := matched
@@ -768,4 +792,76 @@ func divideDecisionGroups(groupName string, matched []clusterapiv1beta1.ClusterD
 	}
 
 	return groups
+}
+
+func compareClusterDecisionName(a, b clusterapiv1beta1.ClusterDecision) int {
+	return strings.Compare(a.ClusterName, b.ClusterName)
+}
+
+func compareClusterDecisionScore(a, b clusterapiv1beta1.ClusterDecision) int {
+	// Swap a <-> b when comparing score for descending sort order
+	if cmp := cmp.Compare(b.Score, a.Score); cmp != 0 {
+		return cmp
+	}
+	// Secondary sort on names in ascending order
+	return compareClusterDecisionName(a, b)
+}
+
+// shouldSkipScoreUpdate checks if the placement is currently rate limited on score changes, and if there are any differences between
+// decisions other than changes in score. A change to the sort order of decisions when placement has `SortBy: Score` is subject to the same rate limit.
+func shouldSkipScoreUpdate(placement *clusterapiv1beta1.Placement, newDecisions, existingDecisions []*clusterapiv1beta1.PlacementDecision) (bool, error) {
+	if placement.Spec.ScoreRateLimit == "" || placement.Status.LastScoreUpdateTime == nil {
+		return false, nil
+	}
+	if len(newDecisions) != len(existingDecisions) {
+		return false, nil
+	}
+
+	rateLimit, err := time.ParseDuration(placement.Spec.ScoreRateLimit)
+	if err != nil {
+		return false, err
+	}
+	if rateLimit <= 0 || time.Since(placement.Status.LastScoreUpdateTime.Time) > rateLimit {
+		// Greater than rate limit since last update, no need to check scores
+		return false, nil
+	}
+
+	existingClusterDecisions := map[string]clusterapiv1beta1.ClusterDecision{}
+	for _, pd := range existingDecisions {
+		for _, cd := range pd.Status.Decisions {
+			// ClusterDecisions are keyed by cluster name and decision group so that changes to groupings
+			// will always ignore rate limiting
+			key := clusterDecisionKey(pd, cd.ClusterName)
+			existingClusterDecisions[key] = cd
+		}
+	}
+
+	for _, pd := range newDecisions {
+		for _, cd := range pd.Status.Decisions {
+			key := clusterDecisionKey(pd, cd.ClusterName)
+			if existingCD, ok := existingClusterDecisions[key]; ok {
+				// Check if anything besides score has changed
+				existingCD.Score = cd.Score
+				if !equality.Semantic.DeepEqual(cd, existingCD) {
+					return false, nil
+				}
+			} else {
+				// Cluster decision was removed
+				return false, nil
+			}
+			delete(existingClusterDecisions, key)
+		}
+	}
+
+	if len(existingClusterDecisions) > 0 {
+		// Cluster was added
+		return false, nil
+	}
+	return true, nil
+}
+
+func clusterDecisionKey(placementDecision *clusterapiv1beta1.PlacementDecision, clusterName string) string {
+	decisionGroup := placementDecision.Labels[clusterapiv1beta1.DecisionGroupNameLabel]
+	decisionGroupIdx := placementDecision.Labels[clusterapiv1beta1.DecisionGroupIndexLabel]
+	return strings.Join([]string{decisionGroup, decisionGroupIdx, clusterName}, ":")
 }

--- a/pkg/placement/controllers/scheduling/scheduling_controller.go
+++ b/pkg/placement/controllers/scheduling/scheduling_controller.go
@@ -1,16 +1,19 @@
 package scheduling
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"math"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	errorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -242,7 +245,7 @@ func (c *schedulingController) syncPlacement(ctx context.Context, syncCtx factor
 	c.metricsRecorder.StartSchedule(queueKey)
 	scheduleResult, status := c.scheduler.Schedule(ctx, placement, clusters)
 	// generate placement decision and status
-	decisions, groupStatus, s := c.generatePlacementDecisionsAndStatus(placement, scheduleResult.Decisions())
+	decisions, groupStatus, s := c.generatePlacementDecisionsAndStatus(placement, scheduleResult.Decisions(), scheduleResult.PrioritizerScores())
 	if s.IsError() {
 		status = s
 	}
@@ -268,14 +271,14 @@ func (c *schedulingController) syncPlacement(ctx context.Context, syncCtx factor
 	// create/update placement decisions
 	c.metricsRecorder.StartBind(queueKey)
 	defer c.metricsRecorder.Done(queueKey)
-	err = c.bind(ctx, placement, decisions, scheduleResult.PrioritizerScores(), status)
+	updatedDecisions, err := c.bind(ctx, placement, decisions, scheduleResult.PrioritizerScores(), status)
 	if err != nil {
 		return err
 	}
 
 	// update placement status if necessary to signal no bindings
 	if err := c.updateStatus(
-		ctx, placement, groupStatus, int32(len(scheduleResult.Decisions())), misconfiguredCondition, satisfiedCondition); err != nil { // nolint:gosec
+		ctx, placement, groupStatus, int32(len(scheduleResult.Decisions())), updatedDecisions, misconfiguredCondition, satisfiedCondition); err != nil { // nolint:gosec
 		return err
 	}
 
@@ -288,11 +291,16 @@ func (c *schedulingController) updateStatus(
 	placement *clusterapiv1beta1.Placement,
 	decisionGroupStatus []*clusterapiv1beta1.DecisionGroupStatus,
 	numberOfSelectedClusters int32,
+	updatedDecisions bool,
 	conditions ...metav1.Condition,
 ) error {
 	newPlacement := placement.DeepCopy()
 	newPlacement.Status.NumberOfSelectedClusters = numberOfSelectedClusters
 	newPlacement.Status.DecisionGroups = []clusterapiv1beta1.DecisionGroupStatus{}
+	if updatedDecisions {
+		now := metav1.Now()
+		newPlacement.Status.LastScoreUpdateTime = &now
+	}
 
 	for _, status := range decisionGroupStatus {
 		newPlacement.Status.DecisionGroups = append(newPlacement.Status.DecisionGroups, *status)
@@ -381,13 +389,14 @@ func newMisconfiguredCondition(status *framework.Status) metav1.Condition {
 func (c *schedulingController) generatePlacementDecisionsAndStatus(
 	placement *clusterapiv1beta1.Placement,
 	clusters []*clusterapiv1.ManagedCluster,
+	scores PrioritizerScore,
 ) ([]*clusterapiv1beta1.PlacementDecision, []*clusterapiv1beta1.DecisionGroupStatus, *framework.Status) {
 	placementDecisionIndex := 1
 	var placementDecisions []*clusterapiv1beta1.PlacementDecision
 	var decisionGroupStatus []*clusterapiv1beta1.DecisionGroupStatus
 
 	// generate decision group
-	decisionGroups, status := c.generateDecisionGroups(placement, clusters)
+	decisionGroups, status := c.generateDecisionGroups(placement, clusters, scores)
 
 	// generate placement decision for each decision group
 	for decisionGroupIndex, decisionGroup := range decisionGroups {
@@ -408,6 +417,7 @@ func (c *schedulingController) generatePlacementDecisionsAndStatus(
 func (c *schedulingController) generateDecisionGroups(
 	placement *clusterapiv1beta1.Placement,
 	clusters []*clusterapiv1.ManagedCluster,
+	scores PrioritizerScore,
 ) (clusterDecisionGroups, *framework.Status) {
 	var groups []clusterDecisionGroup
 
@@ -428,12 +438,12 @@ func (c *schedulingController) generateDecisionGroups(
 	// First groups the clusters by ClusterSelector defined in spec.DecisionStrategy.GroupStrategy.DecisionGroups.
 	for _, d := range placement.Spec.DecisionStrategy.GroupStrategy.DecisionGroups {
 		// filter clusters by cluster selector
-		matched, status := filterClustersBySelector(d.ClusterSelector, clusters, clusterNameSet)
+		matched, status := filterClustersBySelector(d.ClusterSelector, clusters, clusterNameSet, scores)
 		if status.IsError() {
 			return groups, status
 		}
-		// If matched clusters number meets groupLength, divide into multiple groups.
-		decisionGroups := divideDecisionGroups(d.GroupName, matched, groupLength)
+		// Sort group and divide into multiple groups if matched clusters number meets groupLength.
+		decisionGroups := divideDecisionGroups(d.GroupName, matched, groupLength, placement.Spec.SortBy)
 		groups = append(groups, decisionGroups...)
 	}
 
@@ -442,11 +452,12 @@ func (c *schedulingController) generateDecisionGroups(
 	for _, cluster := range clusterNameSet.UnsortedList() {
 		matched = append(matched, clusterapiv1beta1.ClusterDecision{
 			ClusterName: cluster,
+			Score:       scores[cluster],
 		})
 	}
 
-	// If the rest of clusters number meets groupLength, divide into multiple groups.
-	decisionGroups := divideDecisionGroups("", matched, groupLength)
+	// Sort remaining clusters and divide into multiple groups if matched clusters number meets groupLength.
+	decisionGroups := divideDecisionGroups("", matched, groupLength, placement.Spec.SortBy)
 	groups = append(groups, decisionGroups...)
 
 	// generate at least on empty decisionGroup, this is to ensure there's an empty placement decision if no cluster selected.
@@ -532,33 +543,41 @@ func (c *schedulingController) bind(
 	placementdecisions []*clusterapiv1beta1.PlacementDecision,
 	clusterScores PrioritizerScore,
 	status *framework.Status,
-) error {
+) (updatedDecisions bool, err error) {
 	var errs []error
-	placementDecisionNames := sets.NewString()
+
+	// query existing placementdecisions of the placement
+	requirement, err := labels.NewRequirement(clusterapiv1beta1.PlacementLabel, selection.Equals, []string{placement.Name})
+	if err != nil {
+		return updatedDecisions, err
+	}
+	labelSelector := labels.NewSelector().Add(*requirement)
+	existingPlacementDecisions, err := c.placementDecisionLister.PlacementDecisions(placement.Namespace).List(labelSelector)
+	if err != nil {
+		return updatedDecisions, err
+	}
+
+	if skip, err := shouldSkipScoreUpdate(placement, placementdecisions, existingPlacementDecisions); skip || err != nil {
+		return updatedDecisions, err
+	}
 
 	// create/update placement decisions
+	placementDecisionNames := sets.NewString()
 	for _, pd := range placementdecisions {
 		placementDecisionNames.Insert(pd.Name)
-		err := c.createOrUpdatePlacementDecision(ctx, placement, pd, clusterScores, status)
+		updated, err := c.createOrUpdatePlacementDecision(ctx, placement, pd, clusterScores, status)
+		updatedDecisions = updatedDecisions || updated
 		if err != nil {
 			errs = append(errs, err)
 		}
 	}
-
-	// query all placementdecisions of the placement
-	requirement, err := labels.NewRequirement(clusterapiv1beta1.PlacementLabel, selection.Equals, []string{placement.Name})
-	if err != nil {
-		return err
-	}
-	labelSelector := labels.NewSelector().Add(*requirement)
-	pds, err := c.placementDecisionLister.PlacementDecisions(placement.Namespace).List(labelSelector)
-	if err != nil {
-		return err
+	if len(errs) != 0 {
+		return updatedDecisions, errorhelpers.NewMultiLineAggregate(errs)
 	}
 
 	// delete redundant placementdecisions
 	errs = []error{}
-	for _, pd := range pds {
+	for _, pd := range existingPlacementDecisions {
 		if placementDecisionNames.Has(pd.Name) {
 			continue
 		}
@@ -575,7 +594,7 @@ func (c *schedulingController) bind(
 			"DecisionDelete", "DecisionDeleted",
 			"Decision %s is deleted with placement %s in namespace %s", pd.Name, placement.Name, placement.Namespace)
 	}
-	return errorhelpers.NewMultiLineAggregate(errs)
+	return updatedDecisions, errorhelpers.NewMultiLineAggregate(errs)
 }
 
 // createOrUpdatePlacementDecision creates a new PlacementDecision if it does not exist and
@@ -586,12 +605,12 @@ func (c *schedulingController) createOrUpdatePlacementDecision(
 	placementDecision *clusterapiv1beta1.PlacementDecision,
 	clusterScores PrioritizerScore,
 	status *framework.Status,
-) error {
+) (updatedDecisions bool, err error) {
 	placementDecisionName := placementDecision.Name
 	clusterDecisions := placementDecision.Status.Decisions
 
 	if len(clusterDecisions) > maxNumOfClusterDecisions {
-		return fmt.Errorf("the number of clusterdecisions %d exceeds the max limitation %d", len(clusterDecisions), maxNumOfClusterDecisions)
+		return false, fmt.Errorf("the number of clusterdecisions %d exceeds the max limitation %d", len(clusterDecisions), maxNumOfClusterDecisions)
 	}
 
 	existPlacementDecision, err := c.placementDecisionLister.PlacementDecisions(placementDecision.Namespace).Get(placementDecisionName)
@@ -601,14 +620,14 @@ func (c *schedulingController) createOrUpdatePlacementDecision(
 		existPlacementDecision, err = c.clusterClient.ClusterV1beta1().PlacementDecisions(
 			placement.Namespace).Create(ctx, placementDecision, metav1.CreateOptions{})
 		if err != nil {
-			return err
+			return false, err
 		}
 		c.eventsRecorder.Eventf(
 			placement, existPlacementDecision, corev1.EventTypeNormal,
 			"DecisionCreate", "DecisionCreated",
 			"Decision %s is created with placement %s in namespace %s", existPlacementDecision.Name, placement.Name, placement.Namespace)
 	case err != nil:
-		return err
+		return false, err
 	}
 
 	// update the status and labels of the placementdecision if decisions change
@@ -625,11 +644,11 @@ func (c *schedulingController) createOrUpdatePlacementDecision(
 	if updated {
 		// Record events when status is updated
 		c.recordDecisionEvents(placement, existPlacementDecision, clusterScores, status)
-		return err
+		return true, err
 	}
 	// Do not record events when label is updated
 	_, err = placementDecisionPatcher.PatchLabelAnnotations(ctx, newPlacementDecision, newPlacementDecision.ObjectMeta, existPlacementDecision.ObjectMeta)
-	return err
+	return false, err
 }
 
 // recordDecisionEvents records DecisionUpdate and ScoreUpdate events for placement decision
@@ -711,6 +730,7 @@ func filterClustersBySelector(
 	groupSelector clusterapiv1beta1.GroupClusterSelector,
 	clusters []*clusterapiv1.ManagedCluster,
 	clusterNames sets.Set[string],
+	scores PrioritizerScore,
 ) ([]clusterapiv1beta1.ClusterDecision, *framework.Status) {
 	var matched []clusterapiv1beta1.ClusterDecision
 	// set CEL env to nil since placement decision groups do not support CEL expressions.
@@ -735,6 +755,7 @@ func filterClustersBySelector(
 
 		matched = append(matched, clusterapiv1beta1.ClusterDecision{
 			ClusterName: cluster.Name,
+			Score:       scores[cluster.Name],
 		})
 		clusterNames.Delete(cluster.Name)
 	}
@@ -743,13 +764,16 @@ func filterClustersBySelector(
 }
 
 // divideDecisionGroups divide the matched clusters to the groups and ensuring that each group has the specified length.
-func divideDecisionGroups(groupName string, matched []clusterapiv1beta1.ClusterDecision, groupLength int) []clusterDecisionGroup {
+func divideDecisionGroups(groupName string, matched []clusterapiv1beta1.ClusterDecision, groupLength int, sortBy clusterapiv1beta1.PlacementSortByType) []clusterDecisionGroup {
 	var groups []clusterDecisionGroup
 
-	// sort the matched cluster decisions by name before divide
-	sort.SliceStable(matched, func(i, j int) bool {
-		return matched[i].ClusterName < matched[j].ClusterName
-	})
+	// sort the matched cluster decisions before divide
+	switch sortBy {
+	case clusterapiv1beta1.PlacementSortByScore:
+		slices.SortStableFunc(matched, compareClusterDecisionScore)
+	default:
+		slices.SortStableFunc(matched, compareClusterDecisionName)
+	}
 
 	for len(matched) > 0 {
 		groupClusters := matched
@@ -768,4 +792,76 @@ func divideDecisionGroups(groupName string, matched []clusterapiv1beta1.ClusterD
 	}
 
 	return groups
+}
+
+func compareClusterDecisionName(a, b clusterapiv1beta1.ClusterDecision) int {
+	return strings.Compare(a.ClusterName, b.ClusterName)
+}
+
+func compareClusterDecisionScore(a, b clusterapiv1beta1.ClusterDecision) int {
+	// Swap a <-> b when comparing score for descending sort order
+	if cmp := cmp.Compare(b.Score, a.Score); cmp != 0 {
+		return cmp
+	}
+	// Secondary sort on names in ascending order
+	return compareClusterDecisionName(a, b)
+}
+
+// shouldSkipScoreUpdate checks if the placement is currently rate limited on score changes, and if there are any differences between
+// decisions other than changes in score. A change to the sort order of decisions when placement has `SortBy: Score` is subject to the same rate limit.
+func shouldSkipScoreUpdate(placement *clusterapiv1beta1.Placement, newDecisions, existingDecisions []*clusterapiv1beta1.PlacementDecision) (bool, error) {
+	if placement.Spec.ScoreRateLimit == "" || placement.Status.LastScoreUpdateTime == nil {
+		return false, nil
+	}
+	if len(newDecisions) != len(existingDecisions) {
+		return false, nil
+	}
+
+	rateLimit, err := time.ParseDuration(placement.Spec.ScoreRateLimit)
+	if err != nil {
+		return false, err
+	}
+	if rateLimit <= 0 || time.Since(placement.Status.LastScoreUpdateTime.Time) > rateLimit {
+		// Greater than rate limit since last update, no need to check scores
+		return false, nil
+	}
+
+	existingClusterDecisions := map[string]clusterapiv1beta1.ClusterDecision{}
+	for _, pd := range existingDecisions {
+		for _, cd := range pd.Status.Decisions {
+			// ClusterDecisions are keyed by cluster name and decision group so that changes to groupings
+			// will always ignore rate limiting
+			key := clusterDecisionKey(pd, cd.ClusterName)
+			existingClusterDecisions[key] = cd
+		}
+	}
+
+	for _, pd := range newDecisions {
+		for _, cd := range pd.Status.Decisions {
+			key := clusterDecisionKey(pd, cd.ClusterName)
+			if existingCD, ok := existingClusterDecisions[key]; ok {
+				// Check if anything besides score has changed
+				existingCD.Score = cd.Score
+				if !equality.Semantic.DeepEqual(cd, existingCD) {
+					return false, nil
+				}
+			} else {
+				// Cluster decision was removed
+				return false, nil
+			}
+			delete(existingClusterDecisions, key)
+		}
+	}
+
+	if len(existingClusterDecisions) > 0 {
+		// Cluster was added
+		return false, nil
+	}
+	return true, nil
+}
+
+func clusterDecisionKey(placementDecision *clusterapiv1beta1.PlacementDecision, clusterName string) string {
+	decisionGroup := placementDecision.Labels[clusterapiv1beta1.DecisionGroupNameLabel]
+	decisionGroupIdx := placementDecision.Labels[clusterapiv1beta1.DecisionGroupIndexLabel]
+	return strings.Join([]string{decisionGroup, decisionGroupIdx, clusterName}, ":")
 }

--- a/pkg/placement/controllers/scheduling/scheduling_controller_event_test.go
+++ b/pkg/placement/controllers/scheduling/scheduling_controller_event_test.go
@@ -135,7 +135,7 @@ func TestCreateOrUpdatePlacementDecision_EventRecording(t *testing.T) {
 				},
 			}
 
-			err := ctrl.createOrUpdatePlacementDecision(context.TODO(), placement, placementDecision, c.clusterScores, c.status)
+			_, err := ctrl.createOrUpdatePlacementDecision(context.TODO(), placement, placementDecision, c.clusterScores, c.status)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/placement/controllers/scheduling/scheduling_controller_test.go
+++ b/pkg/placement/controllers/scheduling/scheduling_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -962,12 +963,14 @@ func TestBind(t *testing.T) {
 		initObjs        []runtime.Object
 		placement       *clusterapiv1beta1.Placement
 		clusters        []*clusterapiv1.ManagedCluster
+		scores          PrioritizerScore
 		validateActions func(t *testing.T, actions []clienttesting.Action)
 	}{
 		{
 			name:      "create single placementdecision",
 			placement: testinghelpers.NewPlacement(placementNamespace, placementName).Build(),
 			clusters:  newClusters(10),
+			scores:    newPrioritizerScore(newSelectedClusters(10), 0, 1, 2, 3),
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				testingcommon.AssertActions(t, actions, "create")
 				actual := actions[0].(clienttesting.CreateActionImpl).Object
@@ -975,7 +978,9 @@ func TestBind(t *testing.T) {
 				if !ok {
 					t.Errorf("expected PlacementDecision was updated")
 				}
-				assertClustersSelected(t, placementDecision.Status.Decisions, newSelectedClusters(10)...)
+				clusters := newSelectedClusters(10)
+				assertClustersSelected(t, placementDecision.Status.Decisions, clusters...)
+				assertClusterScores(t, placementDecision.Status.Decisions, newPrioritizerScore(clusters, 0, 1, 2, 3))
 				if placementDecision.Labels[clusterapiv1beta1.DecisionGroupIndexLabel] != "0" {
 					t.Errorf("unexpected PlacementDecision labels %v", placementDecision.Labels)
 				}
@@ -988,6 +993,7 @@ func TestBind(t *testing.T) {
 			name:      "create multiple placementdecisions",
 			placement: testinghelpers.NewPlacement(placementNamespace, placementName).Build(),
 			clusters:  newClusters(101),
+			scores:    newPrioritizerScore(newSelectedClusters(101), 5, 10),
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
 				testingcommon.AssertActions(t, actions, "create", "create")
 				selectedClusters := newSelectedClusters(101)
@@ -997,6 +1003,7 @@ func TestBind(t *testing.T) {
 					t.Errorf("expected PlacementDecision was updated")
 				}
 				assertClustersSelected(t, placementDecision.Status.Decisions, selectedClusters[0:100]...)
+				assertClusterScores(t, placementDecision.Status.Decisions, newPrioritizerScore(selectedClusters[0:100], 5, 10))
 				if placementDecision.Labels[clusterapiv1beta1.DecisionGroupIndexLabel] != "0" {
 					t.Errorf("unexpected PlacementDecision labels %v", placementDecision.Labels)
 				}
@@ -1007,6 +1014,7 @@ func TestBind(t *testing.T) {
 					t.Errorf("expected PlacementDecision was updated")
 				}
 				assertClustersSelected(t, placementDecision.Status.Decisions, selectedClusters[100:]...)
+				assertClusterScores(t, placementDecision.Status.Decisions, newPrioritizerScore(selectedClusters[100:], 5, 10))
 				if placementDecision.Labels[clusterapiv1beta1.DecisionGroupIndexLabel] != "0" {
 					t.Errorf("unexpected PlacementDecision labels %v", placementDecision.Labels)
 				}
@@ -1348,6 +1356,115 @@ func TestBind(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "decisions not patched with score update before rate limit",
+			placement: testinghelpers.NewPlacement(placementNamespace, placementName).
+				WithScoreRateLimit("5m").
+				WithLastSoreUpdateTime(metav1.Now()).
+				Build(),
+			clusters: newClusters(2),
+			scores:   newPrioritizerScore(newSelectedClusters(2), 1, 2),
+			initObjs: []runtime.Object{
+				testinghelpers.NewPlacementDecision(placementNamespace, testinghelpers.PlacementDecisionName(placementName, 1)).
+					WithLabel(clusterapiv1beta1.PlacementLabel, placementName).
+					WithLabel(clusterapiv1beta1.DecisionGroupIndexLabel, "0").
+					WithScores(newPrioritizerScore(newSelectedClusters(2), 1)).
+					WithDecisions(newSelectedClusters(2)...).Build(),
+			},
+			validateActions: testingcommon.AssertNoActions,
+		},
+		{
+			name: "decisions patched with score update after rate limit",
+			placement: testinghelpers.NewPlacement(placementNamespace, placementName).
+				WithScoreRateLimit("5m").
+				WithLastSoreUpdateTime(metav1.Time{Time: time.Now().Add(-6 * time.Minute)}).
+				Build(),
+			clusters: newClusters(2),
+			scores:   newPrioritizerScore(newSelectedClusters(2), 1, 2),
+			initObjs: []runtime.Object{
+				testinghelpers.NewPlacementDecision(placementNamespace, testinghelpers.PlacementDecisionName(placementName, 1)).
+					WithLabel(clusterapiv1beta1.PlacementLabel, placementName).
+					WithLabel(clusterapiv1beta1.DecisionGroupIndexLabel, "0").
+					WithScores(newPrioritizerScore(newSelectedClusters(2), 1)).
+					WithDecisions(newSelectedClusters(2)...).Build(),
+			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "patch")
+				selectedClusters := newSelectedClusters(2)
+				placementDecision := &clusterapiv1beta1.PlacementDecision{}
+				patchData := actions[0].(clienttesting.PatchActionImpl).Patch
+				err := json.Unmarshal(patchData, placementDecision)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assertClustersSelected(t, placementDecision.Status.Decisions, selectedClusters...)
+				assertClusterScores(t, placementDecision.Status.Decisions, newPrioritizerScore(selectedClusters, 1, 2))
+			},
+		},
+		{
+			name: "decisions patched with cluster update before rate limit",
+			placement: testinghelpers.NewPlacement(placementNamespace, placementName).
+				WithScoreRateLimit("5m").
+				WithLastSoreUpdateTime(metav1.Now()).
+				Build(),
+			clusters: newClusters(3),
+			scores:   newPrioritizerScore(newSelectedClusters(3), 1, 2, 3),
+			initObjs: []runtime.Object{
+				testinghelpers.NewPlacementDecision(placementNamespace, testinghelpers.PlacementDecisionName(placementName, 1)).
+					WithLabel(clusterapiv1beta1.PlacementLabel, placementName).
+					WithLabel(clusterapiv1beta1.DecisionGroupIndexLabel, "0").
+					WithScores(newPrioritizerScore(newSelectedClusters(2), 1)).
+					WithDecisions(newSelectedClusters(2)...).Build(),
+			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "patch")
+				selectedClusters := newSelectedClusters(3)
+				placementDecision := &clusterapiv1beta1.PlacementDecision{}
+				patchData := actions[0].(clienttesting.PatchActionImpl).Patch
+				err := json.Unmarshal(patchData, placementDecision)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assertClustersSelected(t, placementDecision.Status.Decisions, selectedClusters...)
+				assertClusterScores(t, placementDecision.Status.Decisions, newPrioritizerScore(selectedClusters, 1, 2, 3))
+			},
+		},
+		{
+			name: "decisions patched with decision group update before rate limit",
+			placement: testinghelpers.NewPlacement(placementNamespace, placementName).
+				WithScoreRateLimit("5m").
+				WithLastSoreUpdateTime(metav1.Now()).
+				WithGroupStrategy(clusterapiv1beta1.GroupStrategy{
+					DecisionGroups: []clusterapiv1beta1.DecisionGroup{
+						{GroupName: "newgroup"},
+					},
+				}).
+				Build(),
+			clusters: newClusters(2),
+			scores:   newPrioritizerScore(newSelectedClusters(2), 1, 2),
+			initObjs: []runtime.Object{
+				testinghelpers.NewPlacementDecision(placementNamespace, testinghelpers.PlacementDecisionName(placementName, 1)).
+					WithLabel(clusterapiv1beta1.PlacementLabel, placementName).
+					WithLabel(clusterapiv1beta1.DecisionGroupIndexLabel, "0").
+					WithScores(newPrioritizerScore(newSelectedClusters(2), 1)).
+					WithDecisions(newSelectedClusters(2)...).Build(),
+			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "patch")
+				selectedClusters := newSelectedClusters(2)
+				placementDecision := &clusterapiv1beta1.PlacementDecision{}
+				patchData := actions[0].(clienttesting.PatchActionImpl).Patch
+				err := json.Unmarshal(patchData, placementDecision)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assertClustersSelected(t, placementDecision.Status.Decisions, selectedClusters...)
+				assertClusterScores(t, placementDecision.Status.Decisions, newPrioritizerScore(selectedClusters, 1, 2))
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -1382,8 +1499,8 @@ func TestBind(t *testing.T) {
 				metricsRecorder:         metrics.NewScheduleMetrics(clock.RealClock{}),
 			}
 
-			decisions, _, _ := ctrl.generatePlacementDecisionsAndStatus(c.placement, c.clusters)
-			err := ctrl.bind(
+			decisions, _, _ := ctrl.generatePlacementDecisionsAndStatus(c.placement, c.clusters, c.scores)
+			_, err := ctrl.bind(
 				context.TODO(),
 				c.placement,
 				decisions,
@@ -1411,6 +1528,15 @@ func assertClustersSelected(t *testing.T, decisons []clusterapiv1beta1.ClusterDe
 	}
 }
 
+func assertClusterScores(t *testing.T, decisions []clusterapiv1beta1.ClusterDecision, scores PrioritizerScore) {
+	t.Helper()
+	for _, decision := range decisions {
+		if score, ok := scores[decision.ClusterName]; ok && decision.Score != score {
+			t.Errorf("expected cluster %s score %d, but got %d", decision.ClusterName, score, decision.Score)
+		}
+	}
+}
+
 func newClusters(num int) (clusters []*clusterapiv1.ManagedCluster) {
 	for i := 0; i < num; i++ {
 		ClusterName := fmt.Sprintf("cluster%d", i+1)
@@ -1430,6 +1556,19 @@ func newSelectedClusters(num int) (clusters []string) {
 	})
 
 	return clusters
+}
+
+func newPrioritizerScore(clusters []string, scores ...int64) PrioritizerScore {
+	prioritizerScores := PrioritizerScore{}
+	for i, cluster := range clusters {
+		score := int64(0)
+		if len(scores) > 0 {
+			score = scores[i%len(scores)]
+		}
+		prioritizerScores[cluster] = score
+	}
+
+	return prioritizerScores
 }
 
 // newTestSchedulingController creates a test scheduling controller with the given objects.

--- a/pkg/placement/helpers/testing/builders.go
+++ b/pkg/placement/helpers/testing/builders.go
@@ -107,6 +107,21 @@ func (b *PlacementBuilder) WithDeletionTimestamp() *PlacementBuilder {
 	return b
 }
 
+func (b *PlacementBuilder) WithSortBy(sortBy clusterapiv1beta1.PlacementSortByType) *PlacementBuilder {
+	b.placement.Spec.SortBy = sortBy
+	return b
+}
+
+func (b *PlacementBuilder) WithScoreRateLimit(scoreRateLimit string) *PlacementBuilder {
+	b.placement.Spec.ScoreRateLimit = scoreRateLimit
+	return b
+}
+
+func (b *PlacementBuilder) WithLastSoreUpdateTime(lastScoreUpdateTime metav1.Time) *PlacementBuilder {
+	b.placement.Status.LastScoreUpdateTime = &lastScoreUpdateTime
+	return b
+}
+
 func (b *PlacementBuilder) AddPredicate(
 	labelSelector *metav1.LabelSelector,
 	claimSelector *clusterapiv1beta1.ClusterClaimSelector,
@@ -199,6 +214,7 @@ func NewClusterPredicate(
 
 type PlacementDecisionBuilder struct {
 	placementDecision *clusterapiv1beta1.PlacementDecision
+	scores            map[string]int64
 }
 
 func NewPlacementDecision(namespace, name string) *PlacementDecisionBuilder {
@@ -235,11 +251,25 @@ func (b *PlacementDecisionBuilder) WithDeletionTimestamp() *PlacementDecisionBui
 	return b
 }
 
+func (b *PlacementDecisionBuilder) WithScores(scores map[string]int64) *PlacementDecisionBuilder {
+	b.scores = scores
+
+	if b.placementDecision != nil {
+		for i, decision := range b.placementDecision.Status.Decisions {
+			if score, ok := b.scores[decision.ClusterName]; ok {
+				b.placementDecision.Status.Decisions[i].Score = score
+			}
+		}
+	}
+	return b
+}
+
 func (b *PlacementDecisionBuilder) WithDecisions(clusterNames ...string) *PlacementDecisionBuilder {
 	var decisions []clusterapiv1beta1.ClusterDecision
 	for _, clusterName := range clusterNames {
 		decisions = append(decisions, clusterapiv1beta1.ClusterDecision{
 			ClusterName: clusterName,
+			Score:       b.scores[clusterName],
 		})
 	}
 	b.placementDecision.Status.Decisions = decisions


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Add Score for each ClusterDecision on PlacementDecisions so that consumers of the placement API can use it to make their own scheduling decisions (e.g. weighted cluster selection by score). Additionally support sorting the decisions by score (desc).

To reduce API pressure, updates to PlacementDecisions that would only affect the scores of the selected clusters are rate limited by default to once every minute. A change that modifies anything other than score will override the rate limit, and the latest scores will be reflected in the update along with the other changes.

## Related issue(s)

[Placement Score Visibility Enhancement](https://github.com/open-cluster-management-io/enhancements/blob/main/enhancements/sig-architecture/225-placement-score-visibility/README.md)
Depends on https://github.com/open-cluster-management-io/api/pull/428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add addon webhook configuration for Default and Hosted deployments (custom address, ports, and bind settings; Hosted requires address).
  * Introduce placement scoring and sorting (by Score or ClusterName), with rate-limited score updates and last-score timestamps.
  * Surface per-cluster placement scores in placement decisions.

* **Chores**
  * Updated manifest timestamps.
  * Added temporary dependency replace directive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->