### PR TITLE
:seedling: refactor cluster kubeapiserver health check with failure threshold

### DIFF
--- a/pkg/registration/spoke/managedcluster/available_reconcile.go
+++ b/pkg/registration/spoke/managedcluster/available_reconcile.go
@@ -1,0 +1,90 @@
+package managedcluster
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
+)
+
+// failureThreshold is the duration that health check failures must persist
+// before marking the cluster as unavailable. This prevents transient API server blips
+// from flipping the Available condition.
+var failureThreshold = 20 * time.Second
+
+// healthCheckRetryInterval is the interval for fast requeue when a transient failure is
+// detected, allowing sustained failures to be confirmed quickly.
+var healthCheckRetryInterval = 5 * time.Second
+
+type availableReconcile struct {
+	managedClusterDiscoveryClient discovery.DiscoveryInterface
+	firstFailureTime              time.Time
+}
+
+func (r *availableReconcile) reconcile(ctx context.Context, syncCtx factory.SyncContext, cluster *clusterv1.ManagedCluster) (*clusterv1.ManagedCluster, reconcileState, error) {
+	condition := r.checkKubeAPIServerStatus(ctx)
+
+	if condition.Status == metav1.ConditionTrue {
+		r.firstFailureTime = time.Time{}
+		meta.SetStatusCondition(&cluster.Status.Conditions, condition)
+		return cluster, reconcileContinue, nil
+	}
+
+	now := time.Now()
+	if r.firstFailureTime.IsZero() {
+		r.firstFailureTime = now
+	}
+
+	if now.Sub(r.firstFailureTime) >= failureThreshold {
+		meta.SetStatusCondition(&cluster.Status.Conditions, condition)
+		return cluster, reconcileStop, nil
+	}
+
+	// Transient failure: keep the existing condition unchanged, but requeue quickly
+	// to confirm whether the failure is sustained.
+	syncCtx.Queue().AddAfter("", healthCheckRetryInterval)
+	return cluster, reconcileStop, nil
+}
+
+// checkKubeAPIServerStatus uses the livez api to check the status of kube apiserver with healthz as fallback
+func (r *availableReconcile) checkKubeAPIServerStatus(ctx context.Context) metav1.Condition {
+	statusCode := 0
+	condition := metav1.Condition{Type: clusterv1.ManagedClusterConditionAvailable}
+	result := r.managedClusterDiscoveryClient.RESTClient().Get().AbsPath("/livez").Do(ctx).StatusCode(&statusCode)
+	if statusCode == http.StatusOK {
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = "ManagedClusterAvailable"
+		condition.Message = "Managed cluster is available"
+		return condition
+	}
+
+	// for backward compatible, the livez endpoint is supported from Kubernetes 1.16, so if the livez is not found or
+	// forbidden, the healthz endpoint will be used.
+	if statusCode == http.StatusNotFound || statusCode == http.StatusForbidden {
+		result = r.managedClusterDiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do(ctx).StatusCode(&statusCode)
+		if statusCode == http.StatusOK {
+			condition.Status = metav1.ConditionTrue
+			condition.Reason = "ManagedClusterAvailable"
+			condition.Message = "Managed cluster is available"
+			return condition
+		}
+	}
+
+	condition.Status = metav1.ConditionFalse
+	condition.Reason = "ManagedClusterKubeAPIServerUnavailable"
+	body, err := result.Raw()
+	if err == nil {
+		condition.Message = fmt.Sprintf("The kube-apiserver is not ok, status code: %d, %v", statusCode, string(body))
+		return condition
+	}
+
+	condition.Message = fmt.Sprintf("The kube-apiserver is not ok, status code: %d, %v", statusCode, err)
+	return condition
+}

--- a/pkg/registration/spoke/managedcluster/available_reconcile_test.go
+++ b/pkg/registration/spoke/managedcluster/available_reconcile_test.go
@@ -1,0 +1,278 @@
+package managedcluster
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+
+	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
+	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
+)
+
+func newHealthCheckServer(t *testing.T, livezStatus *atomic.Int32, healthzStatus *atomic.Int32, responseMsg string) (*httptest.Server, *discovery.DiscoveryClient) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/livez":
+			status := int(livezStatus.Load())
+			w.WriteHeader(status)
+			if status != http.StatusOK {
+				if _, err := w.Write([]byte(responseMsg)); err != nil {
+					t.Fatal(err)
+				}
+			}
+		case "/healthz":
+			status := int(healthzStatus.Load())
+			w.WriteHeader(status)
+			if status != http.StatusOK {
+				if _, err := w.Write([]byte(responseMsg)); err != nil {
+					t.Fatal(err)
+				}
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(&rest.Config{Host: apiServer.URL})
+	return apiServer, discoveryClient
+}
+
+func newAtomicStatus(status int) *atomic.Int32 {
+	v := &atomic.Int32{}
+	v.Store(int32(status))
+	return v
+}
+
+func TestAvailableReconcile(t *testing.T) {
+	cases := []struct {
+		name              string
+		livezStatus       int
+		healthzStatus     int
+		responseMsg       string
+		expectedStatus    metav1.ConditionStatus
+		expectedReason    string
+		expectedState     reconcileState
+		expectedMsgPrefix string
+	}{
+		{
+			name:           "kube-apiserver is healthy via livez",
+			livezStatus:    http.StatusOK,
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: "ManagedClusterAvailable",
+			expectedState:  reconcileContinue,
+		},
+		{
+			name:           "livez not found, fallback to healthz which is ok",
+			livezStatus:    http.StatusNotFound,
+			healthzStatus:  http.StatusOK,
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: "ManagedClusterAvailable",
+			expectedState:  reconcileContinue,
+		},
+		{
+			name:           "livez forbidden, fallback to healthz which is ok",
+			livezStatus:    http.StatusForbidden,
+			healthzStatus:  http.StatusOK,
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: "ManagedClusterAvailable",
+			expectedState:  reconcileContinue,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			livez := newAtomicStatus(c.livezStatus)
+			healthz := newAtomicStatus(c.healthzStatus)
+			apiServer, discoveryClient := newHealthCheckServer(t, livez, healthz, c.responseMsg)
+			defer apiServer.Close()
+
+			reconciler := &availableReconcile{
+				managedClusterDiscoveryClient: discoveryClient,
+			}
+
+			cluster := testinghelpers.NewAcceptedManagedCluster()
+			updatedCluster, state, err := reconciler.reconcile(context.TODO(), testingcommon.NewFakeSyncContext(t, ""), cluster)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if state != c.expectedState {
+				t.Errorf("expected state %v, got %v", c.expectedState, state)
+			}
+
+			condition := meta.FindStatusCondition(updatedCluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+			if condition == nil {
+				t.Fatalf("expected Available condition to be set")
+			}
+			if condition.Status != c.expectedStatus {
+				t.Errorf("expected condition status %v, got %v", c.expectedStatus, condition.Status)
+			}
+			if condition.Reason != c.expectedReason {
+				t.Errorf("expected condition reason %q, got %q", c.expectedReason, condition.Reason)
+			}
+		})
+	}
+}
+
+func TestAvailableReconcileFailureThreshold(t *testing.T) {
+	livez := newAtomicStatus(http.StatusInternalServerError)
+	healthz := newAtomicStatus(0)
+	apiServer, discoveryClient := newHealthCheckServer(t, livez, healthz, "internal server error")
+	defer apiServer.Close()
+
+	// Use short durations for testing
+	origThreshold := failureThreshold
+	origInterval := healthCheckRetryInterval
+	failureThreshold = 100 * time.Millisecond
+	healthCheckRetryInterval = 50 * time.Millisecond
+	defer func() {
+		failureThreshold = origThreshold
+		healthCheckRetryInterval = origInterval
+	}()
+
+	reconciler := &availableReconcile{
+		managedClusterDiscoveryClient: discoveryClient,
+	}
+
+	// Set an initial Available=True condition to verify it's preserved during transient failures.
+	cluster := testinghelpers.NewAcceptedManagedCluster()
+	cluster.Status.Conditions = append(cluster.Status.Conditions, metav1.Condition{
+		Type:    clusterv1.ManagedClusterConditionAvailable,
+		Status:  metav1.ConditionTrue,
+		Reason:  "ManagedClusterAvailable",
+		Message: "Managed cluster is available",
+	})
+
+	// First failure: condition should remain True (within threshold), and a fast requeue should be triggered
+	syncCtx := testingcommon.NewFakeSyncContext(t, "")
+	updatedCluster, state, err := reconciler.reconcile(context.TODO(), syncCtx, cluster.DeepCopy())
+	if err != nil {
+		t.Fatalf("first failure: unexpected error: %v", err)
+	}
+	if state != reconcileStop {
+		t.Errorf("first failure: expected reconcileStop, got %v", state)
+	}
+	condition := meta.FindStatusCondition(updatedCluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+	if condition == nil {
+		t.Fatalf("first failure: expected Available condition")
+	}
+	if condition.Status != metav1.ConditionTrue {
+		t.Errorf("first failure: expected condition to remain True, got %v", condition.Status)
+	}
+
+	// Simulate failure persisting beyond threshold
+	reconciler.firstFailureTime = time.Now().Add(-failureThreshold)
+	syncCtx = testingcommon.NewFakeSyncContext(t, "")
+	updatedCluster, state, err = reconciler.reconcile(context.TODO(), syncCtx, cluster.DeepCopy())
+	if err != nil {
+		t.Fatalf("threshold failure: unexpected error: %v", err)
+	}
+	if state != reconcileStop {
+		t.Errorf("threshold failure: expected reconcileStop, got %v", state)
+	}
+	condition = meta.FindStatusCondition(updatedCluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+	if condition == nil {
+		t.Fatalf("threshold failure: expected Available condition")
+	}
+	if condition.Status != metav1.ConditionFalse {
+		t.Errorf("threshold failure: expected condition False after threshold exceeded, got %v", condition.Status)
+	}
+	if condition.Reason != "ManagedClusterKubeAPIServerUnavailable" {
+		t.Errorf("threshold failure: expected reason ManagedClusterKubeAPIServerUnavailable, got %q", condition.Reason)
+	}
+}
+
+func TestAvailableReconcileFailureReset(t *testing.T) {
+	livez := newAtomicStatus(http.StatusInternalServerError)
+	healthz := newAtomicStatus(0)
+	apiServer, discoveryClient := newHealthCheckServer(t, livez, healthz, "internal server error")
+	defer apiServer.Close()
+
+	reconciler := &availableReconcile{
+		managedClusterDiscoveryClient: discoveryClient,
+	}
+
+	cluster := testinghelpers.NewAcceptedManagedCluster()
+	cluster.Status.Conditions = append(cluster.Status.Conditions, metav1.Condition{
+		Type:    clusterv1.ManagedClusterConditionAvailable,
+		Status:  metav1.ConditionTrue,
+		Reason:  "ManagedClusterAvailable",
+		Message: "Managed cluster is available",
+	})
+
+	// First failure: sets firstFailureTime
+	reconciler.reconcile(context.TODO(), testingcommon.NewFakeSyncContext(t, ""), cluster.DeepCopy())
+	if reconciler.firstFailureTime.IsZero() {
+		t.Fatal("expected firstFailureTime to be set after failure")
+	}
+
+	// Recovery: API server becomes healthy, firstFailureTime should reset
+	livez.Store(int32(http.StatusOK))
+	updatedCluster, state, err := reconciler.reconcile(context.TODO(), testingcommon.NewFakeSyncContext(t, ""), cluster.DeepCopy())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != reconcileContinue {
+		t.Errorf("expected reconcileContinue after recovery, got %v", state)
+	}
+	if !reconciler.firstFailureTime.IsZero() {
+		t.Error("expected firstFailureTime to be reset after recovery")
+	}
+	condition := meta.FindStatusCondition(updatedCluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+	if condition == nil || condition.Status != metav1.ConditionTrue {
+		t.Errorf("expected condition True after recovery")
+	}
+
+	// Fail again: should start fresh, not carry over previous failure time
+	livez.Store(int32(http.StatusInternalServerError))
+	reconciler.reconcile(context.TODO(), testingcommon.NewFakeSyncContext(t, ""), cluster.DeepCopy())
+
+	// The failure just started, so even with many rapid calls it should not flip to False
+	for i := 0; i < 10; i++ {
+		updatedCluster, _, _ = reconciler.reconcile(context.TODO(), testingcommon.NewFakeSyncContext(t, ""), cluster.DeepCopy())
+	}
+	condition = meta.FindStatusCondition(updatedCluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+	if condition.Status != metav1.ConditionTrue {
+		t.Errorf("expected condition to remain True during fresh failure window, got %v", condition.Status)
+	}
+}
+
+func TestAvailableReconcileBurstEvents(t *testing.T) {
+	livez := newAtomicStatus(http.StatusInternalServerError)
+	healthz := newAtomicStatus(0)
+	apiServer, discoveryClient := newHealthCheckServer(t, livez, healthz, "internal server error")
+	defer apiServer.Close()
+
+	reconciler := &availableReconcile{
+		managedClusterDiscoveryClient: discoveryClient,
+	}
+
+	cluster := testinghelpers.NewAcceptedManagedCluster()
+	cluster.Status.Conditions = append(cluster.Status.Conditions, metav1.Condition{
+		Type:    clusterv1.ManagedClusterConditionAvailable,
+		Status:  metav1.ConditionTrue,
+		Reason:  "ManagedClusterAvailable",
+		Message: "Managed cluster is available",
+	})
+
+	// Simulate a burst of watch events (node + cluster + namespace) firing together.
+	// All calls happen instantly, well within failureThreshold, so condition must stay True.
+	for i := 0; i < 20; i++ {
+		reconciler.reconcile(context.TODO(), testingcommon.NewFakeSyncContext(t, ""), cluster.DeepCopy())
+	}
+
+	updatedCluster, _, _ := reconciler.reconcile(context.TODO(), testingcommon.NewFakeSyncContext(t, ""), cluster.DeepCopy())
+	condition := meta.FindStatusCondition(updatedCluster.Status.Conditions, clusterv1.ManagedClusterConditionAvailable)
+	if condition.Status != metav1.ConditionTrue {
+		t.Errorf("expected condition to remain True during burst, got %v", condition.Status)
+	}
+}

--- a/pkg/registration/spoke/managedcluster/resource_reconcile.go
+++ b/pkg/registration/spoke/managedcluster/resource_reconcile.go
@@ -3,11 +3,8 @@ package managedcluster
 import (
 	"context"
 	"fmt"
-	"net/http"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/discovery"
 	corev1lister "k8s.io/client-go/listers/core/v1"
@@ -22,72 +19,29 @@ type resoureReconcile struct {
 }
 
 func (r *resoureReconcile) reconcile(ctx context.Context, _ factory.SyncContext, cluster *clusterv1.ManagedCluster) (*clusterv1.ManagedCluster, reconcileState, error) {
-	// check the kube-apiserver health on managed cluster.
-	condition := r.checkKubeAPIServerStatus(ctx)
-
-	// the managed cluster kube-apiserver is health, update its version and resources if necessary.
-	if condition.Status == metav1.ConditionTrue {
-		clusterVersion, err := r.getClusterVersion()
-		if err != nil {
-			return cluster, reconcileStop, fmt.Errorf("unable to get server version of managed cluster %q: %w", cluster.Name, err)
-		}
-
-		capacity, allocatable, err := r.getClusterResources()
-		if err != nil {
-			return cluster, reconcileStop, fmt.Errorf("unable to get capacity and allocatable of managed cluster %q: %w", cluster.Name, err)
-		}
-
-		// we allow other components update the cluster capacity, so we need merge the capacity to this updated, if
-		// one current capacity entry does not exist in this updated capacity, we add it back.
-		for key, val := range cluster.Status.Capacity {
-			if _, ok := capacity[key]; !ok {
-				capacity[key] = val
-			}
-		}
-
-		cluster.Status.Capacity = capacity
-		cluster.Status.Allocatable = allocatable
-		cluster.Status.Version = *clusterVersion
+	clusterVersion, err := r.getClusterVersion()
+	if err != nil {
+		return cluster, reconcileStop, fmt.Errorf("unable to get server version of managed cluster %q: %w", cluster.Name, err)
 	}
 
-	meta.SetStatusCondition(&cluster.Status.Conditions, condition)
+	capacity, allocatable, err := r.getClusterResources()
+	if err != nil {
+		return cluster, reconcileStop, fmt.Errorf("unable to get capacity and allocatable of managed cluster %q: %w", cluster.Name, err)
+	}
+
+	// we allow other components update the cluster capacity, so we need merge the capacity to this updated, if
+	// one current capacity entry does not exist in this updated capacity, we add it back.
+	for key, val := range cluster.Status.Capacity {
+		if _, ok := capacity[key]; !ok {
+			capacity[key] = val
+		}
+	}
+
+	cluster.Status.Capacity = capacity
+	cluster.Status.Allocatable = allocatable
+	cluster.Status.Version = *clusterVersion
+
 	return cluster, reconcileContinue, nil
-}
-
-// using readyz api to check the status of kube apiserver
-func (r *resoureReconcile) checkKubeAPIServerStatus(ctx context.Context) metav1.Condition {
-	statusCode := 0
-	condition := metav1.Condition{Type: clusterv1.ManagedClusterConditionAvailable}
-	result := r.managedClusterDiscoveryClient.RESTClient().Get().AbsPath("/livez").Do(ctx).StatusCode(&statusCode)
-	if statusCode == http.StatusOK {
-		condition.Status = metav1.ConditionTrue
-		condition.Reason = "ManagedClusterAvailable"
-		condition.Message = "Managed cluster is available"
-		return condition
-	}
-
-	// for backward compatible, the livez endpoint is supported from Kubernetes 1.16, so if the livez is not found or
-	// forbidden, the healthz endpoint will be used.
-	if statusCode == http.StatusNotFound || statusCode == http.StatusForbidden {
-		result = r.managedClusterDiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do(ctx).StatusCode(&statusCode)
-		if statusCode == http.StatusOK {
-			condition.Status = metav1.ConditionTrue
-			condition.Reason = "ManagedClusterAvailable"
-			condition.Message = "Managed cluster is available"
-			return condition
-		}
-	}
-
-	condition.Status = metav1.ConditionFalse
-	condition.Reason = "ManagedClusterKubeAPIServerUnavailable"
-	body, err := result.Raw()
-	if err == nil {
-		condition.Message = fmt.Sprintf("The kube-apiserver is not ok, status code: %d, %v", statusCode, string(body))
-		return condition
-	}
-
-	condition.Message = fmt.Sprintf("The kube-apiserver is not ok, status code: %d, %v", statusCode, err)
-	return condition
 }
 
 func (r *resoureReconcile) getClusterVersion() (*clusterv1.ManagedClusterVersion, error) {

--- a/pkg/registration/spoke/managedcluster/resource_reconcile_test.go
+++ b/pkg/registration/spoke/managedcluster/resource_reconcile_test.go
@@ -97,46 +97,6 @@ func TestHealthCheck(t *testing.T) {
 				"managedcluster.cluster.open-cluster-management.io \"testmanagedcluster\" not found",
 		},
 		{
-			name:        "kube-apiserver is not health",
-			clusters:    []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
-			httpStatus:  http.StatusInternalServerError,
-			responseMsg: "internal server error",
-			validateActions: func(t *testing.T, clusterClient *clusterfake.Clientset, hubClient *kubefake.Clientset) {
-				expectedCondition := metav1.Condition{
-					Type:    clusterv1.ManagedClusterConditionAvailable,
-					Status:  metav1.ConditionFalse,
-					Reason:  "ManagedClusterKubeAPIServerUnavailable",
-					Message: "The kube-apiserver is not ok, status code: 500, an error on the server (\"internal server error\") has prevented the request from succeeding",
-				}
-				actions := clusterClient.Actions()
-				testingcommon.AssertActions(t, actions, "patch")
-				patch := actions[0].(clienttesting.PatchAction).GetPatch()
-				managedCluster := &clusterv1.ManagedCluster{}
-				err := json.Unmarshal(patch, managedCluster)
-				if err != nil {
-					t.Fatal(err)
-				}
-				testingcommon.AssertCondition(t, managedCluster.Status.Conditions, expectedCondition)
-
-				if len(hubClient.Actions()) != 1 {
-					t.Errorf("Expected 1 event created in the sync loop, actual %d",
-						len(hubClient.Actions()))
-				}
-				actionEvent := hubClient.Actions()[0]
-				if actionEvent.GetResource().Resource != "events" {
-					t.Errorf("Expected event created, actual %s", actionEvent.GetResource())
-				}
-				if actionEvent.GetNamespace() != testinghelpers.TestManagedClusterName {
-					t.Errorf("Expected event created in namespace %s, actual %s",
-						testinghelpers.TestManagedClusterName, actionEvent.GetNamespace())
-				}
-				if actionEvent.GetVerb() != "create" {
-					t.Errorf("Expected event created, actual %s", actionEvent.GetVerb())
-				}
-
-			},
-		},
-		{
 			name:     "kube-apiserver is ok",
 			clusters: []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
 			nodes: []runtime.Object{
@@ -189,52 +149,6 @@ func TestHealthCheck(t *testing.T) {
 				if actionEvent.GetVerb() != "create" {
 					t.Errorf("Expected event created, actual %s", actionEvent.GetVerb())
 				}
-			},
-		},
-		{
-			name:       "there is no livez endpoint",
-			clusters:   []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
-			nodes:      []runtime.Object{},
-			httpStatus: http.StatusNotFound,
-			validateActions: func(t *testing.T, clusterClient *clusterfake.Clientset, hubClient *kubefake.Clientset) {
-				expectedCondition := metav1.Condition{
-					Type:    clusterv1.ManagedClusterConditionAvailable,
-					Status:  metav1.ConditionTrue,
-					Reason:  "ManagedClusterAvailable",
-					Message: "Managed cluster is available",
-				}
-				actions := clusterClient.Actions()
-				testingcommon.AssertActions(t, actions, "patch")
-				patch := actions[0].(clienttesting.PatchAction).GetPatch()
-				managedCluster := &clusterv1.ManagedCluster{}
-				err := json.Unmarshal(patch, managedCluster)
-				if err != nil {
-					t.Fatal(err)
-				}
-				testingcommon.AssertCondition(t, managedCluster.Status.Conditions, expectedCondition)
-			},
-		},
-		{
-			name:       "livez is forbidden",
-			clusters:   []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
-			nodes:      []runtime.Object{},
-			httpStatus: http.StatusForbidden,
-			validateActions: func(t *testing.T, clusterClient *clusterfake.Clientset, hubClient *kubefake.Clientset) {
-				expectedCondition := metav1.Condition{
-					Type:    clusterv1.ManagedClusterConditionAvailable,
-					Status:  metav1.ConditionTrue,
-					Reason:  "ManagedClusterAvailable",
-					Message: "Managed cluster is available",
-				}
-				actions := clusterClient.Actions()
-				testingcommon.AssertActions(t, actions, "patch")
-				patch := actions[0].(clienttesting.PatchAction).GetPatch()
-				managedCluster := &clusterv1.ManagedCluster{}
-				err := json.Unmarshal(patch, managedCluster)
-				if err != nil {
-					t.Fatal(err)
-				}
-				testingcommon.AssertCondition(t, managedCluster.Status.Conditions, expectedCondition)
 			},
 		},
 		{

--- a/pkg/registration/spoke/managedcluster/status_controller.go
+++ b/pkg/registration/spoke/managedcluster/status_controller.go
@@ -115,6 +115,10 @@ func newManagedClusterStatusController(
 			hubClusterClient.ClusterV1().ManagedClusters()),
 		reconcilers: []statusReconcile{
 			&joiningReconcile{},
+			// availableReconcile must run before resource and claim reconcilers because it checks
+			// kube-apiserver health. If the API server is unavailable, it returns reconcileStop to
+			// skip resource/claim gathering which would fail against an unreachable API server.
+			&availableReconcile{managedClusterDiscoveryClient: managedClusterDiscoveryClient},
 			&resoureReconcile{managedClusterDiscoveryClient: managedClusterDiscoveryClient, nodeLister: nodeInformer.Lister()},
 			&claimReconcile{claimLister: claimInformer.Lister(),
 				maxCustomClusterClaims:       maxCustomClusterClaims,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API-server health probing (livez with healthz fallback) to determine managed-cluster availability.

* **Behavior Changes**
  * Availability flips to Unavailable only after a sustained failure window (failure threshold); transient failures trigger fast retries (~5s) and do not immediately flip status.
  * Availability check now runs earlier in reconciliation and can short-circuit a sync cycle; status/capacity/version updates proceed independently (availability no longer blocks routine status/capacity/version updates).

* **Tests**
  * Added unit tests for health checks, thresholds, retries, recovery, and burst scenarios; adjusted existing health-check test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->