### PR TITLE
:sparkles:  support networkpolicy in hub ns

### DIFF
--- a/deploy/cluster-manager/chart/cluster-manager/templates/cluster_role.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/cluster_role.yaml
@@ -165,6 +165,10 @@ rules:
 - apiGroups: [ "cluster.x-k8s.io" ]
   resources: [ "clusters" ]
   verbs: ["get", "list", "watch"]
+# Allow the registration-operator to manage network policies
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["create", "get", "list", "update", "patch", "delete"]
 # for grpc-sever, the grpc-server need join permission for bootstrapping a managed cluster
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclustersets/join"]

--- a/deploy/cluster-manager/config/rbac/cluster_role.yaml
+++ b/deploy/cluster-manager/config/rbac/cluster_role.yaml
@@ -167,6 +167,10 @@ rules:
 - apiGroups: [ "cluster.x-k8s.io" ]
   resources: [ "clusters" ]
   verbs: ["get", "list", "watch"]
+# Allow the registration-operator to manage network policies
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["create", "get", "list", "update", "patch", "delete"]
 # for grpc-sever, the grpc-server need join permission for bootstrapping a managed cluster
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclustersets/join"]

--- a/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
@@ -551,6 +551,17 @@ spec:
           - list
           - watch
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+        - apiGroups:
           - cluster.open-cluster-management.io
           resources:
           - managedclustersets/join

--- a/manifests/cluster-manager/hub/network-policy/allow-apiserver-egress.yaml
+++ b/manifests/cluster-manager/hub/network-policy/allow-apiserver-egress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apiserver-egress
+  namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
+spec:
+  podSelector:
+    matchLabels:
+      open-cluster-management.io/created-by-clustermanager: {{ .ClusterManagerName }}
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443

--- a/manifests/cluster-manager/hub/network-policy/default-deny-all.yaml
+++ b/manifests/cluster-manager/hub/network-policy/default-deny-all.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{ .ClusterManagerNamespace }}
+  labels:
+    {{ if gt (len .Labels) 0 }}
+    {{ range $key, $value := .Labels }}
+    "{{ $key }}": "{{ $value }}"
+    {{ end }}
+    {{ end }}
+spec:
+  podSelector:
+    matchLabels:
+      open-cluster-management.io/created-by-clustermanager: {{ .ClusterManagerName }}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -50,6 +50,7 @@ type HubConfig struct {
 	GRPCServerImage                   string
 	GRPCAutoApprovedUsers             string
 	GRPCEndpointType                  string
+	NetworkPolicyEnabled              bool
 	// TLS configuration injected into all managed hub component deployments
 	TLSMinVersion   string
 	TLSCipherSuites string

--- a/pkg/cmd/hub/operator.go
+++ b/pkg/cmd/hub/operator.go
@@ -30,6 +30,8 @@ func NewHubOperatorCmd() *cobra.Command {
 		"Number of deployment replicas, operator will automatically determine replicas if not set")
 	flags.BoolVar(&cmOptions.EnableSyncLabels, "enable-sync-labels", false,
 		"If set, will sync the labels of ClusterManager CR to all hub resources")
+	flags.BoolVar(&cmOptions.EnableNetworkPolicy, "enable-network-policy", false,
+		"If set, will create NetworkPolicy resources in the hub namespace to restrict pod network access")
 	opts.AddFlags(flags)
 	return cmd
 }

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -17,6 +17,7 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -147,6 +148,8 @@ func CleanUpStaticObject(
 		err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, t.Name, metav1.DeleteOptions{})
 	case *admissionv1.MutatingWebhookConfiguration:
 		err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, t.Name, metav1.DeleteOptions{})
+	case *networkingv1.NetworkPolicy:
+		err = client.NetworkingV1().NetworkPolicies(t.Namespace).Delete(ctx, t.Name, metav1.DeleteOptions{})
 	default:
 		err = fmt.Errorf("unhandled type %T", object)
 	}

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -67,6 +67,7 @@ type clusterManagerController struct {
 	deploymentReplicas            int32
 	operatorNamespace             string
 	enableSyncLabels              bool
+	enableNetworkPolicy           bool
 	tlsMinVersion                 string
 	tlsCipherSuites               string
 }
@@ -96,6 +97,7 @@ func NewClusterManagerController(
 	deploymentReplicas int32,
 	operatorNamespace string,
 	enableSyncLabels bool,
+	enableNetworkPolicy bool,
 	tlsMinVersion string,
 	tlsCipherSuites string,
 ) factory.Controller {
@@ -115,6 +117,7 @@ func NewClusterManagerController(
 		deploymentReplicas:            deploymentReplicas,
 		operatorNamespace:             operatorNamespace,
 		enableSyncLabels:              enableSyncLabels,
+		enableNetworkPolicy:           enableNetworkPolicy,
 		tlsMinVersion:                 tlsMinVersion,
 		tlsCipherSuites:               tlsCipherSuites,
 	}
@@ -250,6 +253,8 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 	// Set TLS config for all managed hub component deployments
 	config.TLSMinVersion = n.tlsMinVersion
 	config.TLSCipherSuites = n.tlsCipherSuites
+
+	config.NetworkPolicyEnabled = n.enableNetworkPolicy
 
 	// Update finalizer at first
 	if clusterManager.DeletionTimestamp.IsZero() {

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_hub_reconcile.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_hub_reconcile.go
@@ -87,6 +87,11 @@ var (
 		"cluster-manager/hub/grpc-server/serviceaccount.yaml",
 		"cluster-manager/hub/grpc-server/service.yaml",
 	}
+
+	networkPolicyFiles = []string{
+		"cluster-manager/hub/network-policy/default-deny-all.yaml",
+		"cluster-manager/hub/network-policy/allow-apiserver-egress.yaml",
+	}
 )
 
 type hubReconcile struct {
@@ -116,6 +121,14 @@ func (c *hubReconcile) reconcile(ctx context.Context, cm *operatorapiv1.ClusterM
 	// Remove grpc server related resources if grpc auth is disabled
 	if !config.GRPCAuthEnabled {
 		_, _, err := cleanResources(ctx, c.hubKubeClient, cm, config, grpcServerResourceFiles...)
+		if err != nil {
+			return cm, reconcileStop, err
+		}
+	}
+
+	// Remove network policy resources if network policy is disabled
+	if !config.NetworkPolicyEnabled {
+		_, _, err := cleanResources(ctx, c.hubKubeClient, cm, config, networkPolicyFiles...)
 		if err != nil {
 			return cm, reconcileStop, err
 		}
@@ -179,6 +192,10 @@ func getHubResources(mode operatorapiv1.InstallMode, config manifests.HubConfig)
 
 	if config.GRPCAuthEnabled {
 		hubResources = append(hubResources, grpcServerResourceFiles...)
+	}
+
+	if config.NetworkPolicyEnabled {
+		hubResources = append(hubResources, networkPolicyFiles...)
 	}
 
 	// the hubHostedWebhookServiceFiles are only used in hosted mode

--- a/pkg/operator/operators/clustermanager/options.go
+++ b/pkg/operator/operators/clustermanager/options.go
@@ -30,6 +30,7 @@ type Options struct {
 	ControlPlaneNodeLabelSelector string
 	DeploymentReplicas            int32
 	EnableSyncLabels              bool
+	EnableNetworkPolicy           bool
 }
 
 // RunClusterManagerOperator starts a new cluster manager operator
@@ -120,6 +121,7 @@ func (o *Options) RunClusterManagerOperator(ctx context.Context, controllerConte
 		o.DeploymentReplicas,
 		controllerContext.OperatorNamespace,
 		o.EnableSyncLabels,
+		o.EnableNetworkPolicy,
 		tlsMinVersion,
 		tlsCipherSuites,
 	)

--- a/test/integration/operator/clustermanager_test.go
+++ b/test/integration/operator/clustermanager_test.go
@@ -35,6 +35,10 @@ const (
 )
 
 func startHubOperator(ctx context.Context, mode operatorapiv1.InstallMode) {
+	startHubOperatorWithOptions(ctx, mode, func(_ *clustermanager.Options) {})
+}
+
+func startHubOperatorWithOptions(ctx context.Context, mode operatorapiv1.InstallMode, configure func(*clustermanager.Options)) {
 	certrotation.SigningCertValidity = time.Second * 30
 	certrotation.TargetCertValidity = time.Second * 10
 	certrotation.ResyncInterval = time.Second * 1
@@ -49,6 +53,7 @@ func startHubOperator(ctx context.Context, mode operatorapiv1.InstallMode) {
 
 	o := &clustermanager.Options{}
 	o.EnableSyncLabels = true
+	configure(o)
 	err := o.RunClusterManagerOperator(ctx, &controllercmd.ControllerContext{
 		KubeConfig:        config,
 		EventRecorder:     util.NewIntegrationTestEventRecorder("integration"),
@@ -1732,5 +1737,66 @@ var _ = ginkgo.Describe("ClusterManager TLS Profile", func() {
 			return fmt.Errorf("deployment %s: --tls-min-version=VersionTLS13 not found in args %v",
 				hubGRPCServerDeployment, actual.Spec.Template.Spec.Containers[0].Args)
 		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+	})
+})
+
+var _ = ginkgo.Describe("ClusterManager NetworkPolicy", ginkgo.Ordered, func() {
+	var cancel context.CancelFunc
+
+	ginkgo.BeforeEach(func() {
+		var ctx context.Context
+		ctx, cancel = context.WithCancel(context.Background())
+		go startHubOperatorWithOptions(ctx, operatorapiv1.InstallModeDefault, func(o *clustermanager.Options) {
+			o.EnableNetworkPolicy = true
+		})
+	})
+	ginkgo.AfterEach(func() {
+		if cancel != nil {
+			cancel()
+		}
+		err := kubeClient.AppsV1().Deployments(hubNamespace).DeleteCollection(
+			context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should create network policies when enabled", func() {
+		gomega.Eventually(func() error {
+			if _, err := kubeClient.NetworkingV1().NetworkPolicies(hubNamespace).Get(
+				context.Background(), "default-deny-all", metav1.GetOptions{}); err != nil {
+				return err
+			}
+			return nil
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+		gomega.Eventually(func() error {
+			if _, err := kubeClient.NetworkingV1().NetworkPolicies(hubNamespace).Get(
+				context.Background(), "allow-apiserver-egress", metav1.GetOptions{}); err != nil {
+				return err
+			}
+			return nil
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+	})
+
+	ginkgo.It("should not create network policies when disabled", func() {
+		if cancel != nil {
+			cancel()
+		}
+		var ctx context.Context
+		ctx, cancel = context.WithCancel(context.Background())
+		go startHubOperator(ctx, operatorapiv1.InstallModeDefault)
+
+		gomega.Eventually(func() error {
+			if _, err := kubeClient.CoreV1().Namespaces().Get(
+				context.Background(), hubNamespace, metav1.GetOptions{}); err != nil {
+				return err
+			}
+			return nil
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeNil())
+
+		gomega.Consistently(func() bool {
+			_, err := kubeClient.NetworkingV1().NetworkPolicies(hubNamespace).Get(
+				context.Background(), "default-deny-all", metav1.GetOptions{})
+			return errors.IsNotFound(err)
+		}, 5, eventuallyInterval).Should(gomega.BeTrue())
 	})
 })


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable network policy support to restrict cluster network traffic with default deny-all policies and selective egress permissions for DNS, HTTPS, and Kubernetes API server communication.

* **Tests**
  * Added integration tests for network policy configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->