### PR TITLE
✨ Apply resource in manifestwork ordered by kind

### DIFF
--- a/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler.go
+++ b/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
@@ -31,6 +33,67 @@ type applyResult struct {
 	Error  error
 
 	resourceMeta workapiv1.ManifestResourceMeta
+}
+
+// resourceApplyOrder defines the priority rank for applying resources by kind.
+// Lower rank means applied first. Resources of the same rank preserve their spec order
+// (stable sort). Kinds not listed here are applied after all listed kinds (rank 1000),
+// preserving their relative spec order; nil/unparseable manifests sort last (rank 1001).
+//
+// Rank 0: Cluster-scoped foundations — no dependencies on other resources
+// Rank 1: RBAC — needed before workloads that reference service accounts
+// Rank 2: Namespace-scoped policies and identity — must exist before workloads
+// Rank 3: Config and storage — referenced by workloads as volumes or env
+// Rank 4: Networking — services, ingress, etc.
+// Rank 5: Workloads — pods, deployments, jobs, etc.
+// Rank 6: Post-workload — webhooks and API aggregation that may depend on running workloads
+var resourceApplyOrder = map[string]int{
+	// Rank 0: cluster-scoped, no deps
+	"PriorityClass":            0,
+	"Namespace":                0,
+	"CustomResourceDefinition": 0,
+	"StorageClass":             0,
+	"PersistentVolume":         0,
+	"PodSecurityPolicy":        0,
+
+	// Rank 1: RBAC
+	"ClusterRole":        1,
+	"ClusterRoleBinding": 1,
+	"Role":               1,
+	"RoleBinding":        1,
+
+	// Rank 2: namespace-scoped policies and identity
+	"NetworkPolicy":       2,
+	"ResourceQuota":       2,
+	"LimitRange":          2,
+	"PodDisruptionBudget": 2,
+	"ServiceAccount":      2,
+
+	// Rank 3: config and storage
+	"Secret":                3,
+	"ConfigMap":             3,
+	"PersistentVolumeClaim": 3,
+
+	// Rank 4: networking
+	"Service": 4,
+
+	// Rank 5: workloads
+	"DaemonSet":               5,
+	"Pod":                     5,
+	"ReplicationController":   5,
+	"ReplicaSet":              5,
+	"Deployment":              5,
+	"HorizontalPodAutoscaler": 5,
+	"StatefulSet":             5,
+	"Job":                     5,
+	"CronJob":                 5,
+
+	// Rank 6: post-workload
+	"APIService":                       6,
+	"MutatingWebhookConfiguration":     6,
+	"ValidatingWebhookConfiguration":   6,
+	"ValidatingAdmissionPolicy":        6,
+	"ValidatingAdmissionPolicyBinding": 6,
 }
 
 type manifestworkReconciler struct {
@@ -131,6 +194,49 @@ func (m *manifestworkReconciler) reconcile(
 	return manifestWork, appliedManifestWork, resourceResults, err
 }
 
+// orderedManifest holds a pre-parsed manifest together with its original position in the spec.
+// Manifests are sorted by resource kind for apply ordering, while specIndex preserves the
+// original position for ordinal tracking and status updates.
+type orderedManifest struct {
+	specIndex    int
+	obj          *unstructured.Unstructured
+	gvr          schema.GroupVersionResource
+	resourceMeta workapiv1.ManifestResourceMeta
+	err          error
+}
+
+func (m *manifestworkReconciler) parseAndSortManifests(manifests []workapiv1.Manifest) []orderedManifest {
+	ordered := make([]orderedManifest, len(manifests))
+	for i, manifest := range manifests {
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(manifest.Raw); err != nil {
+			ordered[i] = orderedManifest{specIndex: i, resourceMeta: workapiv1.ManifestResourceMeta{
+				Ordinal: int32(i), //nolint:gosec
+			}, err: err}
+			continue
+		}
+
+		resMeta, gvr, err := helper.BuildResourceMeta(i, obj, m.restMapper)
+		ordered[i] = orderedManifest{specIndex: i, obj: obj, gvr: gvr, resourceMeta: resMeta, err: err}
+	}
+
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return kindOrder(ordered[i].obj) < kindOrder(ordered[j].obj)
+	})
+
+	return ordered
+}
+
+func kindOrder(obj *unstructured.Unstructured) int {
+	if obj == nil {
+		return 1001
+	}
+	if order, ok := resourceApplyOrder[obj.GetKind()]; ok {
+		return order
+	}
+	return 1000
+}
+
 func (m *manifestworkReconciler) applyManifests(
 	ctx context.Context,
 	manifests []workapiv1.Manifest,
@@ -140,14 +246,17 @@ func (m *manifestworkReconciler) applyManifests(
 	owner metav1.OwnerReference,
 	existingResults []applyResult) []applyResult {
 
-	for index, manifest := range manifests {
-		switch {
-		case existingResults[index].Result == nil:
-			// Apply if there is no result.
-			existingResults[index] = m.applyOneManifest(ctx, index, manifest, workSpec, workStatus, recorder, owner)
-		case apierrors.IsConflict(existingResults[index].Error):
-			// Apply if there is a resource conflict error.
-			existingResults[index] = m.applyOneManifest(ctx, index, manifest, workSpec, workStatus, recorder, owner)
+	ordered := m.parseAndSortManifests(manifests)
+
+	for _, om := range ordered {
+		needsApply := existingResults[om.specIndex].Result == nil || apierrors.IsConflict(existingResults[om.specIndex].Error)
+		if !needsApply {
+			continue
+		}
+		if om.err != nil {
+			existingResults[om.specIndex] = applyResult{Error: om.err, resourceMeta: om.resourceMeta}
+		} else {
+			existingResults[om.specIndex] = m.applyOneManifest(ctx, om, workSpec, workStatus, recorder, owner)
 		}
 	}
 
@@ -156,49 +265,34 @@ func (m *manifestworkReconciler) applyManifests(
 
 func (m *manifestworkReconciler) applyOneManifest(
 	ctx context.Context,
-	index int,
-	manifest workapiv1.Manifest,
+	om orderedManifest,
 	workSpec workapiv1.ManifestWorkSpec,
 	workStatus workapiv1.ManifestWorkStatus,
 	recorder events.Recorder,
 	owner metav1.OwnerReference) applyResult {
 	logger := klog.FromContext(ctx)
-	result := applyResult{}
-
-	// parse the required and set resource meta
-	required := &unstructured.Unstructured{}
-	if err := required.UnmarshalJSON(manifest.Raw); err != nil {
-		result.Error = err
-		return result
-	}
+	result := applyResult{resourceMeta: om.resourceMeta}
 
 	// ignore the required object UID to avoid UID precondition failed error
-	if len(required.GetUID()) != 0 {
-		logger.Info("Ignore the UID for the manifest index", "uid", required.GetUID(), "index", index)
-		required.SetUID("")
-	}
-
-	resMeta, gvr, err := helper.BuildResourceMeta(index, required, m.restMapper)
-	result.resourceMeta = resMeta
-	if err != nil {
-		result.Error = err
-		return result
+	if len(om.obj.GetUID()) != 0 {
+		logger.Info("Ignore the UID for the manifest index", "uid", om.obj.GetUID(), "index", om.specIndex)
+		om.obj.SetUID("")
 	}
 
 	// manifests with the Complete condition are not updated
-	manifestCondition := helper.FindManifestCondition(resMeta, workStatus.ResourceStatus.Manifests)
+	manifestCondition := helper.FindManifestCondition(om.resourceMeta, workStatus.ResourceStatus.Manifests)
 	if manifestCondition != nil {
 		if meta.IsStatusConditionTrue(manifestCondition.Conditions, workapiv1.ManifestComplete) {
-			result.Result = required
+			result.Result = om.obj
 			return result
 		}
 	}
 
 	// check if the resource to be applied should be owned by the manifest work
-	ownedByTheWork := helper.OwnedByTheWork(gvr, resMeta.Namespace, resMeta.Name, workSpec.DeleteOption)
+	ownedByTheWork := helper.OwnedByTheWork(om.gvr, om.resourceMeta.Namespace, om.resourceMeta.Name, workSpec.DeleteOption)
 
 	// check the Executor subject permission before applying
-	err = m.validator.Validate(ctx, workSpec.Executor, gvr, resMeta.Namespace, resMeta.Name, ownedByTheWork, required)
+	err := m.validator.Validate(ctx, workSpec.Executor, om.gvr, om.resourceMeta.Namespace, om.resourceMeta.Name, ownedByTheWork, om.obj)
 	if err != nil {
 		result.Error = err
 		return result
@@ -208,7 +302,7 @@ func (m *manifestworkReconciler) applyOneManifest(
 	requiredOwner := manageOwnerRef(ownedByTheWork, owner)
 
 	// find update strategy option.
-	option := helper.FindManifestConfiguration(resMeta, workSpec.ManifestConfigs)
+	option := helper.FindManifestConfiguration(om.resourceMeta, workSpec.ManifestConfigs)
 	// strategy is updated by default
 	strategy := workapiv1.UpdateStrategy{Type: workapiv1.UpdateStrategyTypeUpdate}
 	if option != nil && option.UpdateStrategy != nil {
@@ -216,7 +310,7 @@ func (m *manifestworkReconciler) applyOneManifest(
 	}
 
 	applier := m.appliers.GetApplier(strategy.Type)
-	result.Result, result.Error = applier.Apply(ctx, gvr, required, requiredOwner, option, recorder)
+	result.Result, result.Error = applier.Apply(ctx, om.gvr, om.obj, requiredOwner, option, recorder)
 
 	return result
 }

--- a/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler_test.go
+++ b/pkg/work/spoke/controllers/manifestcontroller/manifestwork_reconciler_test.go
@@ -1201,3 +1201,220 @@ func TestOnUpdateFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestKindOrder(t *testing.T) {
+	cases := []struct {
+		name     string
+		obj      *unstructured.Unstructured
+		expected int
+	}{
+		{
+			name:     "nil object",
+			obj:      nil,
+			expected: 1001,
+		},
+		{
+			name:     "Namespace",
+			obj:      testingcommon.NewUnstructured("v1", "Namespace", "", "test"),
+			expected: 0,
+		},
+		{
+			name:     "ServiceAccount",
+			obj:      testingcommon.NewUnstructured("v1", "ServiceAccount", "ns1", "test"),
+			expected: 2,
+		},
+		{
+			name:     "Deployment",
+			obj:      testingcommon.NewUnstructured("apps/v1", "Deployment", "ns1", "test"),
+			expected: 5,
+		},
+		{
+			name:     "unknown kind",
+			obj:      testingcommon.NewUnstructured("v1", "SomeCustomResource", "ns1", "test"),
+			expected: 1000,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := kindOrder(c.obj)
+			if actual != c.expected {
+				t.Errorf("expected %d, got %d", c.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseAndSortManifests(t *testing.T) {
+	toRawManifest := func(obj *unstructured.Unstructured) workapiv1.Manifest {
+		raw, _ := obj.MarshalJSON()
+		return workapiv1.Manifest{RawExtension: runtime.RawExtension{Raw: raw}}
+	}
+
+	cases := []struct {
+		name              string
+		manifests         []workapiv1.Manifest
+		expectedSpecOrder []int
+		expectedKinds     []string
+	}{
+		{
+			name: "single manifest unchanged",
+			manifests: []workapiv1.Manifest{
+				toRawManifest(testingcommon.NewUnstructured("v1", "Secret", "ns1", "s1")),
+			},
+			expectedSpecOrder: []int{0},
+			expectedKinds:     []string{"Secret"},
+		},
+		{
+			name: "same kind preserves spec order",
+			manifests: []workapiv1.Manifest{
+				toRawManifest(testingcommon.NewUnstructured("v1", "Secret", "ns1", "s1")),
+				toRawManifest(testingcommon.NewUnstructured("v1", "Secret", "ns2", "s2")),
+			},
+			expectedSpecOrder: []int{0, 1},
+			expectedKinds:     []string{"Secret", "Secret"},
+		},
+		{
+			name: "deployment sorted after service account",
+			manifests: []workapiv1.Manifest{
+				toRawManifest(testingcommon.NewUnstructured("apps/v1", "Deployment", "ns1", "deploy")),
+				toRawManifest(testingcommon.NewUnstructured("v1", "ServiceAccount", "ns1", "sa")),
+			},
+			expectedSpecOrder: []int{1, 0},
+			expectedKinds:     []string{"ServiceAccount", "Deployment"},
+		},
+		{
+			name: "full dependency chain sorted correctly",
+			manifests: []workapiv1.Manifest{
+				toRawManifest(testingcommon.NewUnstructured("apps/v1", "Deployment", "ns1", "deploy")),
+				toRawManifest(testingcommon.NewUnstructured("v1", "ConfigMap", "ns1", "cm")),
+				toRawManifest(testingcommon.NewUnstructured("v1", "Namespace", "", "ns1")),
+				toRawManifest(testingcommon.NewUnstructured("v1", "ServiceAccount", "ns1", "sa")),
+				toRawManifest(testingcommon.NewUnstructured("v1", "Secret", "ns1", "secret")),
+			},
+			expectedSpecOrder: []int{2, 3, 1, 4, 0},
+			expectedKinds:     []string{"Namespace", "ServiceAccount", "ConfigMap", "Secret", "Deployment"},
+		},
+		{
+			name: "unknown kinds sorted after known kinds",
+			manifests: []workapiv1.Manifest{
+				toRawManifest(testingcommon.NewUnstructured("v1", "CustomThing", "ns1", "ct")),
+				toRawManifest(testingcommon.NewUnstructured("v1", "Secret", "ns1", "s1")),
+			},
+			expectedSpecOrder: []int{1, 0},
+			expectedKinds:     []string{"Secret", "CustomThing"},
+		},
+		{
+			name: "stable sort preserves relative order for equal priority",
+			manifests: []workapiv1.Manifest{
+				toRawManifest(testingcommon.NewUnstructured("v1", "Secret", "ns1", "s1")),
+				toRawManifest(testingcommon.NewUnstructured("apps/v1", "Deployment", "ns1", "d1")),
+				toRawManifest(testingcommon.NewUnstructured("v1", "Secret", "ns2", "s2")),
+				toRawManifest(testingcommon.NewUnstructured("apps/v1", "Deployment", "ns2", "d2")),
+			},
+			expectedSpecOrder: []int{0, 2, 1, 3},
+			expectedKinds:     []string{"Secret", "Secret", "Deployment", "Deployment"},
+		},
+		{
+			name:              "empty manifests",
+			manifests:         []workapiv1.Manifest{},
+			expectedSpecOrder: []int{},
+			expectedKinds:     []string{},
+		},
+		{
+			name: "invalid manifest JSON",
+			manifests: []workapiv1.Manifest{
+				{RawExtension: runtime.RawExtension{Raw: []byte("not-json")}},
+				toRawManifest(testingcommon.NewUnstructured("v1", "Secret", "ns1", "s1")),
+			},
+			expectedSpecOrder: []int{1, 0},
+			expectedKinds:     []string{"Secret", ""},
+		},
+	}
+
+	reconciler := &manifestworkReconciler{restMapper: spoketesting.NewFakeRestMapper()}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ordered := reconciler.parseAndSortManifests(c.manifests)
+			if len(ordered) != len(c.expectedSpecOrder) {
+				t.Fatalf("expected %d items, got %d", len(c.expectedSpecOrder), len(ordered))
+			}
+
+			for i, om := range ordered {
+				if om.specIndex != c.expectedSpecOrder[i] {
+					t.Errorf("index %d: expected specIndex %d, got %d", i, c.expectedSpecOrder[i], om.specIndex)
+				}
+
+				kind := ""
+				if om.obj != nil {
+					kind = om.obj.GetKind()
+				}
+				if kind != c.expectedKinds[i] {
+					t.Errorf("index %d: expected kind %q, got %q", i, c.expectedKinds[i], kind)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyManifestsInDependencyOrder(t *testing.T) {
+	// Verify that when a ManifestWork contains a Deployment (spec index 0) and a
+	// Secret (spec index 1), the Secret is sorted ahead of the Deployment, but
+	// results are stored at the original spec indices.
+	tc := newTestCase("dependency order: sa before deployment").
+		withWorkManifest(
+			testingcommon.NewUnstructured("apps/v1", "Deployment", "ns1", "deploy"),
+			testingcommon.NewUnstructured("v1", "Secret", "ns1", "secret"),
+		).
+		withExpectedWorkAction("patch").
+		withAppliedWorkAction("create").
+		withExpectedKubeAction("get", "create").
+		withExpectedDynamicAction("get", "create").
+		withExpectedManifestCondition(
+			expectedCondition(workapiv1.ManifestApplied, metav1.ConditionTrue),
+			expectedCondition(workapiv1.ManifestApplied, metav1.ConditionTrue),
+		).
+		withExpectedWorkCondition(expectedCondition(workapiv1.WorkApplied, metav1.ConditionTrue))
+
+	work, workKey := tc.newManifestWork()
+	controller := newController(t, work, nil, spoketesting.NewFakeRestMapper()).
+		withKubeObject().
+		withUnstructuredObject()
+
+	syncContext := testingcommon.NewFakeSyncContext(t, workKey)
+	err := controller.toController().sync(context.TODO(), syncContext, work.Name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tc.validate(t, controller.dynamicClient, controller.workClient, controller.kubeClient)
+
+	// Verify the ordinals in manifest conditions match original spec indices
+	for _, action := range controller.workClient.Actions() {
+		if action.GetResource().Resource != "manifestworks" {
+			continue
+		}
+		patchAction, ok := action.(clienttesting.PatchActionImpl)
+		if !ok {
+			continue
+		}
+		patchedWork := &workapiv1.ManifestWork{}
+		if err := json.Unmarshal(patchAction.Patch, patchedWork); err != nil {
+			t.Fatal(err)
+		}
+		for _, mc := range patchedWork.Status.ResourceStatus.Manifests {
+			switch mc.ResourceMeta.Kind {
+			case "Deployment":
+				if mc.ResourceMeta.Ordinal != 0 {
+					t.Errorf("Deployment should have ordinal 0 (spec index), got %d", mc.ResourceMeta.Ordinal)
+				}
+			case "Secret":
+				if mc.ResourceMeta.Ordinal != 1 {
+					t.Errorf("Secret should have ordinal 1 (spec index), got %d", mc.ResourceMeta.Ordinal)
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/addon-framework/issues/374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Manifests are now pre-parsed and applied in a deterministic, kind-prioritized order so resource dependencies are handled consistently, while per-manifest status entries remain aligned to their original spec positions.

* **Tests**
  * Added unit and integration tests validating ordering semantics, stable tie-breaking, handling of unknown/invalid kinds, and preservation of per-manifest status indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->