### PR TITLE
:sparkles: feat: add "random" placement prioritizer

### DIFF
--- a/pkg/placement/controllers/scheduling/schedule.go
+++ b/pkg/placement/controllers/scheduling/schedule.go
@@ -25,6 +25,7 @@ import (
 	"open-cluster-management.io/ocm/pkg/placement/plugins/addon"
 	"open-cluster-management.io/ocm/pkg/placement/plugins/balance"
 	"open-cluster-management.io/ocm/pkg/placement/plugins/predicate"
+	"open-cluster-management.io/ocm/pkg/placement/plugins/random"
 	"open-cluster-management.io/ocm/pkg/placement/plugins/resource"
 	"open-cluster-management.io/ocm/pkg/placement/plugins/steady"
 	"open-cluster-management.io/ocm/pkg/placement/plugins/tainttoleration"
@@ -35,6 +36,7 @@ const (
 	PrioritizerSteady                    string = "Steady"
 	PrioritizerResourceAllocatableCPU    string = "ResourceAllocatableCPU"
 	PrioritizerResourceAllocatableMemory string = "ResourceAllocatableMemory"
+	PrioritizerRandom                    string = "Random"
 )
 
 // PrioritizerScore defines the score for each cluster
@@ -404,6 +406,8 @@ func getPrioritizers(weights map[clusterapiv1beta1.ScoreCoordinate]int32, handle
 				result[k] = steady.New(handle)
 			case PrioritizerResourceAllocatableCPU, PrioritizerResourceAllocatableMemory:
 				result[k] = resource.NewResourcePrioritizerBuilder(handle).WithPrioritizerName(k.BuiltIn).Build()
+			case PrioritizerRandom:
+				result[k] = random.New(handle)
 			default:
 				msg := fmt.Sprintf("unexpected built-in prioritizer: %s", k.BuiltIn)
 				return nil, framework.NewStatus("", framework.Misconfigured, msg)

--- a/pkg/placement/controllers/scheduling/schedule.go
+++ b/pkg/placement/controllers/scheduling/schedule.go
@@ -3,6 +3,7 @@ package scheduling
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -146,7 +147,7 @@ func (s *schedulerHandler) MetricsRecorder() *metrics.ScheduleMetrics {
 }
 
 // Initialize the default prioritizer weight.
-// Balane and Steady weight 1, others weight 0.
+// Balance and Steady weight 1, others weight 0.
 // The default weight can be replaced by each placement's PrioritizerConfigs.
 var defaultPrioritizerConfig = map[clusterapiv1beta1.ScoreCoordinate]int32{
 	{
@@ -356,13 +357,13 @@ func setRequeueAfter(requeueAfter, newRequeueAfter *time.Duration) *time.Duratio
 func getWeights(defaultWeight map[clusterapiv1beta1.ScoreCoordinate]int32,
 	placement *clusterapiv1beta1.Placement) (map[clusterapiv1beta1.ScoreCoordinate]int32, *framework.Status) {
 	mode := placement.Spec.PrioritizerPolicy.Mode
-	switch {
-	case mode == clusterapiv1beta1.PrioritizerPolicyModeExact:
+	switch mode {
+	case clusterapiv1beta1.PrioritizerPolicyModeExact:
 		return mergeWeights(nil, placement.Spec.PrioritizerPolicy.Configurations)
-	case mode == clusterapiv1beta1.PrioritizerPolicyModeAdditive || mode == "":
+	case clusterapiv1beta1.PrioritizerPolicyModeAdditive, "":
 		return mergeWeights(defaultWeight, placement.Spec.PrioritizerPolicy.Configurations)
 	default:
-		msg := fmt.Sprintf("incorrect prioritizer policy mode: %s", mode)
+		msg := fmt.Sprintf("unexpected prioritizer policy mode: %s", mode)
 		return nil, framework.NewStatus("", framework.Misconfigured, msg)
 	}
 }
@@ -373,9 +374,7 @@ func mergeWeights(defaultWeight map[clusterapiv1beta1.ScoreCoordinate]int32,
 	weights := make(map[clusterapiv1beta1.ScoreCoordinate]int32)
 	status := framework.NewStatus("", framework.Success, "")
 	// copy the default weight
-	for sc, w := range defaultWeight {
-		weights[sc] = w
-	}
+	maps.Copy(weights, defaultWeight)
 
 	// override default weight
 	for _, c := range customizedWeight {
@@ -398,15 +397,15 @@ func getPrioritizers(weights map[clusterapiv1beta1.ScoreCoordinate]int32, handle
 			continue
 		}
 		if k.Type == clusterapiv1beta1.ScoreCoordinateTypeBuiltIn {
-			switch {
-			case k.BuiltIn == PrioritizerBalance:
+			switch k.BuiltIn {
+			case PrioritizerBalance:
 				result[k] = balance.New(handle)
-			case k.BuiltIn == PrioritizerSteady:
+			case PrioritizerSteady:
 				result[k] = steady.New(handle)
-			case k.BuiltIn == PrioritizerResourceAllocatableCPU || k.BuiltIn == PrioritizerResourceAllocatableMemory:
+			case PrioritizerResourceAllocatableCPU, PrioritizerResourceAllocatableMemory:
 				result[k] = resource.NewResourcePrioritizerBuilder(handle).WithPrioritizerName(k.BuiltIn).Build()
 			default:
-				msg := fmt.Sprintf("incorrect builtin prioritizer: %s", k.BuiltIn)
+				msg := fmt.Sprintf("unexpected built-in prioritizer: %s", k.BuiltIn)
 				return nil, framework.NewStatus("", framework.Misconfigured, msg)
 			}
 		} else {

--- a/pkg/placement/plugins/addon/addon.go
+++ b/pkg/placement/plugins/addon/addon.go
@@ -15,11 +15,10 @@ import (
 )
 
 const (
-	placementLabel = clusterapiv1beta1.PlacementLabel
-	description    = `
-	Customize prioritizer get cluster scores from AddOnPlacementScores with sepcific
-	resource name and score name. The clusters which doesn't have corresponding
-	AddOnPlacementScores resource or has expired score is given score 0.
+	description = `
+	Add-on prioritizer gets cluster scores from AddOnPlacementScores with a specific
+	resource name and score name. The clusters that don't have corresponding
+	AddOnPlacementScores resource or have expired scores are given a score of 0.
 	`
 )
 

--- a/pkg/placement/plugins/balance/balance.go
+++ b/pkg/placement/plugins/balance/balance.go
@@ -16,8 +16,8 @@ import (
 const (
 	placementLabel = "cluster.open-cluster-management.io/placement"
 	description    = `
-	Balance prioritizer balance the number of decisions among the clusters. The cluster
-	with the highest number of decision is given the lowest score, while the empty cluster is given
+	Balance prioritizer balances the number of decisions among the clusters. The cluster
+	with the highest number of decisions is given the lowest score, while the empty cluster is given
 	the highest score.
 	`
 )
@@ -35,7 +35,7 @@ func New(handle plugins.Handle) *Balance {
 }
 
 func (b *Balance) Name() string {
-	return reflect.TypeOf(*b).Name()
+	return reflect.TypeFor[Balance]().Name()
 }
 
 func (b *Balance) Description() string {
@@ -77,8 +77,8 @@ func (b *Balance) Score(ctx context.Context, placement *clusterapiv1beta1.Placem
 		if count, ok := decisionCount[clusterName]; ok {
 			usage := float64(count) / float64(maxCount)
 
-			// Negate the usage and subtracted by 0.5, then we double it and muliply by maxCount,
-			// which normalize the score to value between 100 and -100
+			// Negate the usage and subtracted by 0.5, then we double it and multiply by maxCount,
+			// which normalizes the score to a value between 100 and -100
 			scores[clusterName] = 2 * int64(float64(plugins.MaxClusterScore)*(0.5-usage))
 		}
 	}

--- a/pkg/placement/plugins/predicate/predicate.go
+++ b/pkg/placement/plugins/predicate/predicate.go
@@ -16,7 +16,7 @@ import (
 
 var _ plugins.Filter = &Predicate{}
 
-const description = "Predicate filter filters the clusters based on predicate defined in placement"
+const description = "Predicate filters the clusters based on predicates defined in the placement."
 
 type Predicate struct {
 	handle plugins.Handle
@@ -27,7 +27,7 @@ func New(handle plugins.Handle) *Predicate {
 }
 
 func (p *Predicate) Name() string {
-	return reflect.TypeOf(*p).Name()
+	return reflect.TypeFor[Predicate]().Name()
 }
 
 func (p *Predicate) Description() string {

--- a/pkg/placement/plugins/random/random.go
+++ b/pkg/placement/plugins/random/random.go
@@ -1,0 +1,60 @@
+package random
+
+import (
+	"context"
+	"math/rand"
+	"reflect"
+
+	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
+	clusterapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+
+	"open-cluster-management.io/ocm/pkg/placement/controllers/framework"
+	"open-cluster-management.io/ocm/pkg/placement/plugins"
+)
+
+const (
+	description = `
+	Random prioritizer assigns random scores to clusters, providing random cluster 
+	selection without consideration of cluster resources or existing decisions.
+	`
+)
+
+var _ plugins.Prioritizer = &Random{}
+
+type Random struct {
+	handle plugins.Handle
+}
+
+func New(handle plugins.Handle) *Random {
+	return &Random{
+		handle: handle,
+	}
+}
+
+func (r *Random) Name() string {
+	return reflect.TypeFor[Random]().Name()
+}
+
+func (r *Random) Description() string {
+	return description
+}
+
+func (r *Random) Score(ctx context.Context, placement *clusterapiv1beta1.Placement,
+	clusters []*clusterapiv1.ManagedCluster) (plugins.PluginScoreResult, *framework.Status) {
+	scores := map[string]int64{}
+
+	scoreRange := plugins.MaxClusterScore - plugins.MinClusterScore + 1
+
+	for _, cluster := range clusters {
+		// Generate a random score between MinClusterScore (-100) and MaxClusterScore (100)
+		scores[cluster.Name] = rand.Int63n(scoreRange) + plugins.MinClusterScore
+	}
+
+	return plugins.PluginScoreResult{
+		Scores: scores,
+	}, framework.NewStatus(r.Name(), framework.Success, "")
+}
+
+func (r *Random) RequeueAfter(ctx context.Context, placement *clusterapiv1beta1.Placement) (plugins.PluginRequeueResult, *framework.Status) {
+	return plugins.PluginRequeueResult{}, framework.NewStatus(r.Name(), framework.Success, "")
+}

--- a/pkg/placement/plugins/random/random_test.go
+++ b/pkg/placement/plugins/random/random_test.go
@@ -1,0 +1,125 @@
+package random
+
+import (
+	"testing"
+
+	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
+	clusterapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+
+	testinghelpers "open-cluster-management.io/ocm/pkg/placement/helpers/testing"
+	"open-cluster-management.io/ocm/pkg/placement/plugins"
+)
+
+func TestScoreClusterWithRandom(t *testing.T) {
+	cases := []struct {
+		name      string
+		placement *clusterapiv1beta1.Placement
+		clusters  []*clusterapiv1.ManagedCluster
+	}{
+		{
+			name:      "no clusters",
+			placement: testinghelpers.NewPlacement("test", "test").Build(),
+			clusters:  []*clusterapiv1.ManagedCluster{},
+		},
+		{
+			name:      "single cluster",
+			placement: testinghelpers.NewPlacement("test", "test").Build(),
+			clusters: []*clusterapiv1.ManagedCluster{
+				testinghelpers.NewManagedCluster("cluster1").Build(),
+			},
+		},
+		{
+			name:      "multiple clusters",
+			placement: testinghelpers.NewPlacement("test", "test").Build(),
+			clusters: []*clusterapiv1.ManagedCluster{
+				testinghelpers.NewManagedCluster("cluster1").Build(),
+				testinghelpers.NewManagedCluster("cluster2").Build(),
+				testinghelpers.NewManagedCluster("cluster3").Build(),
+				testinghelpers.NewManagedCluster("cluster4").Build(),
+				testinghelpers.NewManagedCluster("cluster5").Build(),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			random := &Random{
+				handle: testinghelpers.NewFakePluginHandle(t, nil),
+			}
+
+			scoreResult, status := random.Score(t.Context(), c.placement, c.clusters)
+			if err := status.AsError(); err != nil {
+				t.Errorf("Expected no error, but got %v", err)
+			}
+
+			scores := scoreResult.Scores
+			// Verify all clusters received a score
+			if len(scores) != len(c.clusters) {
+				t.Errorf("Expected %d scores, but got %d", len(c.clusters), len(scores))
+			}
+
+			// Verify all scores are within valid range
+			for _, cluster := range c.clusters {
+				score, exists := scores[cluster.Name]
+				if !exists {
+					t.Errorf("Cluster %s did not receive a score", cluster.Name)
+					continue
+				}
+
+				if score < plugins.MinClusterScore || score > plugins.MaxClusterScore {
+					t.Errorf("Cluster %s score %d is outside valid range [%d, %d]",
+						cluster.Name, score, plugins.MinClusterScore, plugins.MaxClusterScore)
+				}
+			}
+		})
+	}
+}
+
+func TestScoreDistribution(t *testing.T) {
+	// Run multiple iterations to verify randomness
+	placement := testinghelpers.NewPlacement("test", "test").Build()
+	clusters := []*clusterapiv1.ManagedCluster{
+		testinghelpers.NewManagedCluster("cluster1").Build(),
+		testinghelpers.NewManagedCluster("cluster2").Build(),
+		testinghelpers.NewManagedCluster("cluster3").Build(),
+	}
+
+	random := &Random{
+		handle: testinghelpers.NewFakePluginHandle(t, nil),
+	}
+
+	allScoresIdentical := true
+	var previousScores map[string]int64
+
+	for i := range 10 {
+		scoreResult, status := random.Score(t.Context(), placement, clusters)
+		scores := scoreResult.Scores
+		err := status.AsError()
+
+		if err != nil {
+			t.Errorf("Expected no error on iteration %d, but got %v", i, err)
+		}
+
+		// Check if scores differ from previous iteration
+		if i > 0 && allScoresIdentical {
+			scoresMatch := true
+			for clusterName, score := range scores {
+				if previousScore, exists := previousScores[clusterName]; !exists || score != previousScore {
+					scoresMatch = false
+					break
+				}
+			}
+			if !scoresMatch {
+				allScoresIdentical = false
+			}
+		}
+
+		previousScores = scores
+	}
+
+	// With random scores, it's highly unlikely all iterations produce identical scores
+	// Note: This test has a very low probability of false failure
+	if allScoresIdentical && len(clusters) > 0 {
+		t.Errorf("all score iterations produced identical results")
+	}
+}

--- a/pkg/placement/plugins/resource/resource.go
+++ b/pkg/placement/plugins/resource/resource.go
@@ -16,9 +16,9 @@ import (
 const (
 	placementLabel = clusterapiv1beta1.PlacementLabel
 	description    = `
-	ResourceAllocatableCPU and ResourceAllocatableMemory prioritizer makes the scheduling
+	ResourceAllocatableCPU and ResourceAllocatableMemory prioritizers make the scheduling
 	decisions based on the resource allocatable of managed clusters.
-	The clusters that has the most allocatable are given the highest score,
+	The clusters that have the most allocatable are given the highest score,
 	while the least is given the lowest score.
 	`
 )

--- a/pkg/placement/plugins/steady/steady.go
+++ b/pkg/placement/plugins/steady/steady.go
@@ -18,7 +18,7 @@ import (
 const (
 	placementLabel = "cluster.open-cluster-management.io/placement"
 	description    = `
-	Steady prioritizer ensure the existing decision is stabilized. The clusters that existing decisions
+	Steady prioritizer ensures the existing decisions are stabilized. The clusters that existing decisions
 	choose are given the highest score while the clusters with no existing decisions are given the lowest
 	score.
 	`
@@ -37,7 +37,7 @@ func New(handle plugins.Handle) *Steady {
 }
 
 func (s *Steady) Name() string {
-	return reflect.TypeOf(*s).Name()
+	return reflect.TypeFor[Steady]().Name()
 }
 
 func (s *Steady) Description() string {
@@ -69,7 +69,7 @@ func (s *Steady) Score(
 		)
 	}
 
-	existingDecisions := sets.String{}
+	existingDecisions := sets.New[string]()
 	for _, decision := range decisions {
 		for _, d := range decision.Status.Decisions {
 			existingDecisions.Insert(d.ClusterName)

--- a/pkg/placement/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/placement/plugins/tainttoleration/taint_toleration.go
@@ -24,7 +24,7 @@ var TolerationClock = clock.Clock(clock.RealClock{})
 
 const (
 	placementLabel = "cluster.open-cluster-management.io/placement"
-	description    = "TaintToleration is a plugin that checks if a placement tolerates a managed cluster's taints"
+	description    = "TaintToleration filters the clusters based on whether the placement tolerates the managed cluster's taints."
 )
 
 type TaintToleration struct {
@@ -38,7 +38,7 @@ func New(handle plugins.Handle) *TaintToleration {
 }
 
 func (p *TaintToleration) Name() string {
-	return reflect.TypeOf(*p).Name()
+	return reflect.TypeFor[TaintToleration]().Name()
 }
 
 func (pl *TaintToleration) Description() string {


### PR DESCRIPTION
## Summary

feat: add "random" placement prioritizer

## Related issue(s)

- https://github.com/open-cluster-management-io/ocm/issues/1507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Random prioritizer plugin to produce per-cluster placement scores.

* **Bug Fixes**
  * Corrected grammar and clarity in multiple placement plugin descriptions.
  * Updated misconfiguration error wording for clearer guidance.

* **Improvements**
  * Consistent implementation updates across placement plugins for reliability.
  * Added tests covering the new Random prioritizer's scoring and distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->