### PR TITLE
🌱 Register hub as local-cluster in local dev setup

### DIFF
--- a/solutions/setup-dev-environment/README.md
+++ b/solutions/setup-dev-environment/README.md
@@ -1,6 +1,6 @@
 # Setup dev environment by kind
 
-This scripts is to setup an OCM developer environment in your local machine with 3 kind clusters. The script will bootstrap 3 kind clusters on your local machine: hub, cluster1, and cluster2. The hub is used as the control plane of the OCM, and the other two clusters are registered on the hub as the managed clusters.
+This script sets up an OCM developer environment on your local machine with three kind clusters: hub, cluster1, and cluster2. The hub is used as the control plane of the OCM and is also registered as a managed cluster named local-cluster. The other two clusters are registered on the hub as managed clusters.
 
 ## Prerequisite
 
@@ -16,12 +16,13 @@ sudo chmod +x /usr/local/bin/clusteradm
 
 ## Setup the clusters
 
-Run `./local-up.sh`, you will see two clusters registered on the hub cluster.
+Run `./local-up.sh`, you will see three clusters registered on the hub cluster.
 
-```
-NAME       HUB ACCEPTED   MANAGED CLUSTER URLS      JOINED   AVAILABLE   AGE
-cluster1   true           https://127.0.0.1:45325   True     True        116s
-cluster2   true           https://127.0.0.1:45325   True     True        98s
+```text
+NAME            HUB ACCEPTED   MANAGED CLUSTER URLS      JOINED   AVAILABLE   AGE
+cluster1        true           https://127.0.0.1:45325   True     True        116s
+cluster2        true           https://127.0.0.1:45325   True     True        98s
+local-cluster   true           https://127.0.0.1:45325   True     True        78s
 ```
 
 <details>
@@ -61,4 +62,4 @@ $ ./local-up.sh
 ```
 
 
-</details> 
+</details>

--- a/solutions/setup-dev-environment/local-up.sh
+++ b/solutions/setup-dev-environment/local-up.sh
@@ -4,9 +4,10 @@ cd $(dirname ${BASH_SOURCE})
 
 set -e
 
-hub=${CLUSTER1:-hub}
+hub=${HUB:-hub}
 c1=${CLUSTER1:-cluster1}
 c2=${CLUSTER2:-cluster2}
+local_cluster=local-cluster
 
 hubctx="kind-${hub}"
 c1ctx="kind-${c1}"
@@ -26,7 +27,13 @@ $(echo ${joincmd} --force-internal-endpoint-lookup --wait --context ${c1ctx} | s
 echo -e "Join cluster2 to hub\n"
 $(echo ${joincmd} --force-internal-endpoint-lookup --wait --context ${c2ctx} | sed "s/<cluster_name>/$c2/g")
 
-echo -e "Accept join of cluster1 and cluster2\n"
-clusteradm accept --context ${hubctx} --clusters ${c1},${c2} --wait
+echo -e "Join hub to itself as ${local_cluster}\n"
+$(echo ${joincmd} --force-internal-endpoint-lookup --wait --context ${hubctx} | sed "s/<cluster_name>/${local_cluster}/g")
+
+managed_clusters="${c1},${c2},${local_cluster}"
+echo -e "Accept join of ${managed_clusters}\n"
+clusteradm accept --context ${hubctx} --clusters ${managed_clusters} --wait
+
+kubectl label managedcluster "${local_cluster}" local-cluster=true --overwrite --context ${hubctx}
 
 kubectl get managedclusters --all-namespaces --context ${hubctx}


### PR DESCRIPTION
## Summary

Register the hub cluster as a managed cluster named `local-cluster` in the local kind development environment.

Having a default self-managed hub cluster gives local development a simple place to try hub-side patterns. One example is the policy addon approach from #307, where a policy runs on the hub/local cluster and creates resources in managed cluster namespaces based on `PlacementDecision`s. It should also make it easier to explore other approaches that depend on a standard `local-cluster` identity.

The README is also updated to show the three expected managed clusters.

## Related issue(s)

Related to #307, especially https://github.com/open-cluster-management-io/ocm/issues/307#issuecomment-1794037873.

## Testing

```console
$ bash -n solutions/setup-dev-environment/local-up.sh
```

```console
$ kubectl get managedclusters --context kind-hub
NAME            HUB ACCEPTED   MANAGED CLUSTER URLS                  JOINED   AVAILABLE   AGE
cluster1        true           https://cluster1-control-plane:6443   True     True        46m
cluster2        true           https://cluster2-control-plane:6443   True     True        45m
local-cluster   true           https://hub-control-plane:6443        True     True        45m
```

<img width="1514" height="194" alt="CleanShot 2026-05-08 at 17 12 11@2x" src="https://github.com/user-attachments/assets/994b24e5-711b-460a-a54c-55f526f556f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev setup now boots three local clusters (hub, cluster1, cluster2) and automatically registers the hub as a managed cluster (appearing as "local-cluster") alongside others.

* **Documentation**
  * Clarified bootstrap instructions and expanded example output to show all three clusters on the hub after setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->