### PR TITLE
:seedling: chore: pin `addon-examples` image for tests

### DIFF
--- a/hack/e2e_flaky_error_test.sh
+++ b/hack/e2e_flaky_error_test.sh
@@ -34,8 +34,9 @@ do
     kind load docker-image --name=e2e quay.io/open-cluster-management/addon-manager:$IMAGE_TAG
 
     # This is for addon-manager test: /workspaces/OCM/test/e2e/manifests/addon/addon_template.yaml
-    docker pull quay.io/open-cluster-management/addon-examples:latest
-    kind load docker-image --name=e2e quay.io/open-cluster-management/addon-examples:latest
+    ADDON_EXAMPLE_IMAGE_TAG=$(go list -m -mod=readonly -f '{{ .Version }}' open-cluster-management.io/addon-framework | cut -d'-' -f1)
+    docker pull "quay.io/open-cluster-management/addon-examples:${ADDON_EXAMPLE_IMAGE_TAG}"
+    kind load docker-image --name=e2e "quay.io/open-cluster-management/addon-examples:${ADDON_EXAMPLE_IMAGE_TAG}"
 
     kind get kubeconfig --name=e2e > .kubeconfig
 
@@ -51,7 +52,7 @@ do
     else
         echo "Test $i failed"
         timestamp=$(date +"%Y%m%d-%H%M%S")
-        output_file="_output/flaky-error-test/e2e_test_$timestamp_${i}.output"
+        output_file="_output/flaky-error-test/e2e_test_${timestamp}_${i}.output"
         echo "$test_output" > "$output_file"
         echo "Exiting due to failure."
         exit 1

--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -11,6 +11,7 @@ KLUSTERLET_DEPLOY_MODE?=Default
 REGISTRATION_DRIVER?=csr
 MANAGED_CLUSTER_NAME?=cluster1
 KLUSTERLET_NAME?=klusterlet
+ADDON_EXAMPLE_IMAGE_TAG?=$(shell go list -m -mod=readonly -f '{{ .Version }}' open-cluster-management.io/addon-framework | cut -d'-' -f1)
 
 SED_CMD:=sed
 ifeq ($(GOHOSTOS),darwin)
@@ -79,6 +80,7 @@ run-e2e:
 	-expected-image-tag=$(IMAGE_TAG) \
 	-klusterlet-deploy-mode=$(KLUSTERLET_DEPLOY_MODE) \
 	-registration-driver=$(REGISTRATION_DRIVER) \
+	-addon-example-image-tag=$(ADDON_EXAMPLE_IMAGE_TAG) \
 	${ARGS}
 
 clean-hub: clean-hub-cr clean-hub-operator

--- a/test/e2e/addon_token_auth_test.go
+++ b/test/e2e/addon_token_auth_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 var _ = ginkgo.Describe("Template addon with token-based authentication", ginkgo.Ordered, ginkgo.Label("addon-manager", "addon-token-auth"), func() {
+	addonExampleImage := addonExampleImageRepo + ":" + addonExampleImageTag
 	addOnName := "hello-template"
 	addonInstallNamespace := "test-addon-template-token"
 	var signerSecretNamespace string
@@ -224,6 +225,7 @@ var _ = ginkgo.Describe("Template addon with token-based authentication", ginkgo
 			defaultAddonTemplateReaderManifestsFunc(manifests.AddonManifestFiles, map[string]interface{}{
 				"Namespace":                   universalClusterName,
 				"AddonInstallNamespace":       addonInstallNamespace,
+				"AddonExampleImage":           addonExampleImage,
 				"CustomSignerName":            customSignerName,
 				"AddonManagerNamespace":       templateagent.AddonManagerNamespace(),
 				"CustomSignerSecretName":      customSignerSecretName,
@@ -325,6 +327,7 @@ var _ = ginkgo.Describe("Template addon with token-based authentication", ginkgo
 			defaultAddonTemplateReaderManifestsFunc(manifests.AddonManifestFiles, map[string]interface{}{
 				"Namespace":                   universalClusterName,
 				"AddonInstallNamespace":       addonInstallNamespace,
+				"AddonExampleImage":           addonExampleImage,
 				"CustomSignerName":            customSignerName,
 				"AddonManagerNamespace":       templateagent.AddonManagerNamespace(),
 				"CustomSignerSecretName":      customSignerSecretName,

--- a/test/e2e/addonmanagement_test.go
+++ b/test/e2e/addonmanagement_test.go
@@ -39,8 +39,8 @@ const (
 	namespaceOverrideConfigName              = "namespace-override-config"
 	proxyDeploymentConfigName                = "proxy-deploy-config"
 	resourceRequirementsDeploymentConfigName = "resource-requirements-deploy-config"
-	originalImageValue                       = "quay.io/open-cluster-management/addon-examples:latest"
-	overrideImageValue                       = "quay.io/ocm/addon-examples:latest"
+	addonExampleImageRepo                    = "quay.io/open-cluster-management/addon-examples"
+	overrideImageRepo                        = "quay.io/ocm/addon-examples"
 	customSignerName                         = "example.com/signer-name"
 	// #nosec G101
 	customSignerSecretName = "addon-signer-secret"
@@ -74,6 +74,7 @@ var (
 )
 
 var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-manager"), func() {
+	addonExampleImage := addonExampleImageRepo + ":" + addonExampleImageTag
 	addOnName := "hello-template"
 	addonInstallNamespace := "test-addon-template"
 
@@ -120,6 +121,7 @@ var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-
 			defaultAddonTemplateReaderManifestsFunc(manifests.AddonManifestFiles, map[string]interface{}{
 				"Namespace":                   universalClusterName,
 				"AddonInstallNamespace":       addonInstallNamespace,
+				"AddonExampleImage":           addonExampleImage,
 				"CustomSignerName":            customSignerName,
 				"AddonManagerNamespace":       templateagent.AddonManagerNamespace(),
 				"CustomSignerSecretName":      customSignerSecretName,
@@ -177,6 +179,7 @@ var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-
 			defaultAddonTemplateReaderManifestsFunc(manifests.AddonManifestFiles, map[string]interface{}{
 				"Namespace":                   universalClusterName,
 				"AddonInstallNamespace":       addonInstallNamespace,
+				"AddonExampleImage":           addonExampleImage,
 				"CustomSignerName":            customSignerName,
 				"AddonManagerNamespace":       templateagent.AddonManagerNamespace(),
 				"CustomSignerSecretName":      customSignerSecretName,
@@ -433,7 +436,7 @@ var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-
 				return fmt.Errorf("expect one container, but %v", containers)
 			}
 
-			if containers[0].Image != overrideImageValue {
+			if containers[0].Image != overrideImageRepo+":"+addonExampleImageTag {
 				return fmt.Errorf("unexpected image %s", containers[0].Image)
 			}
 
@@ -487,7 +490,7 @@ var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-
 				return fmt.Errorf("expect one container, but %v", containers)
 			}
 
-			if containers[0].Image != originalImageValue {
+			if containers[0].Image != addonExampleImage {
 				return fmt.Errorf("unexpected image %s", containers[0].Image)
 			}
 
@@ -640,7 +643,7 @@ var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-
 				return fmt.Errorf("expect one container, but %v", containers)
 			}
 
-			if containers[0].Image != overrideImageValue {
+			if containers[0].Image != overrideImageRepo+":"+addonExampleImageTag {
 				return fmt.Errorf("unexpected image %s", containers[0].Image)
 			}
 
@@ -677,7 +680,7 @@ var _ = ginkgo.Describe("Addon management", ginkgo.Ordered, ginkgo.Label("addon-
 				return fmt.Errorf("expect one container, but %v", containers)
 			}
 
-			if containers[0].Image != originalImageValue {
+			if containers[0].Image != addonExampleImage {
 				return fmt.Errorf("unexpected image %s", containers[0].Image)
 			}
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -34,10 +34,11 @@ var (
 	nilExecutorValidating bool
 
 	// images
-	registrationImage string
-	workImage         string
-	singletonImage    string
-	images            framework.Images
+	registrationImage    string
+	workImage            string
+	singletonImage       string
+	addonExampleImageTag string
+	images               framework.Images
 
 	// expected image tag for validation
 	expectedImageTag string
@@ -70,6 +71,7 @@ func init() {
 	flag.StringVar(&singletonImage, "singleton-image", "", "The image of the klusterlet agent")
 	flag.StringVar(&expectedImageTag, "expected-image-tag", "", "The expected image tag for all OCM components (e.g., 'e2e')")
 	flag.StringVar(&registrationDriver, "registration-driver", "csr", "The registration driver (csr or grpc)")
+	flag.StringVar(&addonExampleImageTag, "addon-example-image-tag", "latest", "The tag of the addon example image")
 }
 
 var hub *framework.Hub

--- a/test/e2e/manifests/addon/addon_template.yaml
+++ b/test/e2e/manifests/addon/addon_template.yaml
@@ -40,7 +40,7 @@ spec:
                   serviceAccountName: hello-template-agent-sa
                   containers:
                     - name: helloworld-agent
-                      image: quay.io/open-cluster-management/addon-examples:latest
+                      image: << AddonExampleImage >>
                       imagePullPolicy: IfNotPresent
                       args:
                         - "/helloworld_helm"
@@ -72,7 +72,7 @@ spec:
                   serviceAccountName: hello-template-agent-sa
                   containers:
                     - name: helloworld-agent
-                      image: quay.io/open-cluster-management/addon-examples:latest
+                      image: << AddonExampleImage >>
                       imagePullPolicy: IfNotPresent
                       args:
                         - "/helloworld_helm"
@@ -124,7 +124,7 @@ spec:
                   restartPolicy: Never
                   containers:
                   - name: hello-template-agent
-                    image: quay.io/open-cluster-management/addon-examples:latest
+                    image: << AddonExampleImage >>
                     imagePullPolicy: IfNotPresent
                     args:
                       - "/helloworld_helm"


### PR DESCRIPTION
## Summary

Pin the `addon-examples` image for tests to the version specified in the `go.mod` file. This way, the `addon-framework` library can be updated independently from the `OCM` repo and changes here addressed when the dependency is updated.

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E tests accept a configurable addon example image tag via a new CLI flag.
  * Manifests and test flows use a templated image placeholder so the selected tag is pulled and loaded into the local test cluster.
  * Failed-test output filenames now include timestamp and attempt index for clearer artifact tracing.

* **Chores**
  * Image tag defaults are derived from the repository/module version instead of always using "latest".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/ocm/pull/1529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->