### PR TITLE
:bug: Add cluster.local FQDN to PlacementDebugServer cert SANs

### DIFF
--- a/pkg/operator/operators/clustermanager/controllers/certrotationcontroller/certrotation_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/certrotationcontroller/certrotation_controller.go
@@ -303,7 +303,13 @@ func (c certRotationController) syncOne(ctx context.Context, clustermanager *ope
 
 	if helpers.PlacementDebugServerEnabled(clustermanager) {
 		placementServiceName := fmt.Sprintf("%s-placement", clustermanager.Name)
-		hostNames := []string{fmt.Sprintf("%s.%s.svc", placementServiceName, clustermanagerNamespace)}
+		hostNames := []string{
+			fmt.Sprintf("%s.%s.svc", placementServiceName, clustermanagerNamespace),
+			// TODO(cluster-domain): cluster.local is the default but can be customized
+			// via kubelet --cluster-domain. Consider making this configurable on the
+			// ClusterManager CR and updating all service cert SANs to use it.
+			fmt.Sprintf("%s.%s.svc.cluster.local", placementServiceName, clustermanagerNamespace),
+		}
 
 		if _, ok := cmRotations.targetRotations[helpers.PlacementDebugServingCertSecret]; !ok {
 			c.rotationMap[clustermanagerName].targetRotations[helpers.PlacementDebugServingCertSecret] = certrotation.TargetRotation{


### PR DESCRIPTION
## Summary

- Adds `.svc.cluster.local` FQDN to PlacementDebugServer serving certificate Subject Alternative Names, alongside the existing `.svc` short name

## Context

PR #1494 introduced CertRotationController support for PlacementDebugServer TLS. The generated serving cert only includes the short `.svc` hostname as a SAN:

```
DNS:cluster-manager-placement.open-cluster-management-hub.svc
```

Any client connecting via the fully-qualified Kubernetes DNS name (`cluster-manager-placement.open-cluster-management-hub.svc.cluster.local`) gets a TLS hostname verification failure:

```
Hostname/IP does not match certificate's altnames:
  Host: cluster-manager-placement.open-cluster-management-hub.svc.cluster.local
  is not in the cert's altnames:
    DNS:cluster-manager-placement.open-cluster-management-hub.svc
```

Both `.svc` and `.svc.cluster.local` are valid in-cluster DNS forms for Kubernetes Services. Omitting the FQDN forces consumers to either skip TLS verification or use only the short form, neither of which is desirable.

## Test plan

- [x] E2E tested on a live cluster: in-cluster client successfully connects to the debug server over TLS using the full FQDN with certificate verification enabled
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced debug serving certificate hostname handling to accept both standard and fully qualified in-cluster service DNS formats (e.g., service.namespace.svc and service.namespace.svc.cluster.local).
  * This improves certificate validation for in-cluster debug endpoints and reduces connection issues when fully qualified names are used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/ocm/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->