### PR TITLE
:bug: Fix cluster-manager RBAC: add secrets list/watch to unrestricted rule

### DIFF
--- a/deploy/cluster-manager/chart/cluster-manager/templates/cluster_role.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/cluster_role.yaml
@@ -40,7 +40,7 @@ rules:
     - "cluster-import-config"
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create"]
+  verbs: ["create", "list", "watch"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["create", "get", "list", "update", "watch", "patch", "delete"]

--- a/deploy/cluster-manager/config/rbac/cluster_role.yaml
+++ b/deploy/cluster-manager/config/rbac/cluster_role.yaml
@@ -42,7 +42,7 @@ rules:
     - "cluster-import-config"
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create"]
+  verbs: ["create", "list", "watch"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["create", "get", "list", "update", "watch", "patch", "delete"]

--- a/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
@@ -163,6 +163,7 @@ spec:
           - work-driver-config
           - open-cluster-management-image-pull-credentials
           - grpc-server-serving-cert
+          - placement-debug-serving-cert
           - cluster-import-config
           resources:
           - secrets
@@ -179,6 +180,8 @@ spec:
           - secrets
           verbs:
           - create
+          - list
+          - watch
         - apiGroups:
           - coordination.k8s.io
           resources:


### PR DESCRIPTION
## Summary

Fix cluster-manager RBAC: add secrets list/watch to unrestricted rule

## Related issue(s)

https://github.com/open-cluster-management-io/ocm/pull/1494

Fixes https://github.com/open-cluster-management-io/ocm/issues/1534

FYI @Randy424 not sure why this was not picked up from your testing. Please ensure future testing include deployment testing. CC @rokej 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cluster-manager role-based access control permissions across Kubernetes manifests to support improved monitoring, debugging, and management of cluster operations and secrets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/ocm/pull/1535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->