### PR TITLE
:book: OWNERS updated to add rokej

### DIFF
--- a/pkg/operator/OWNERS
+++ b/pkg/operator/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - zhujian7
 - zhiweiyin318
 - dongbeiqing91
+- rokej
 
 reviewers:
 - zhujian7
@@ -9,3 +10,4 @@ reviewers:
 - xuezhaojun
 - dongbeiqing91
 - haowells
+- rokej


### PR DESCRIPTION

## Summary

With the agreement from @mikeshng and @qiujian16, I have updated the ocm operator's OWNERS file to include myself as a maintainer.

## Related issue(s)

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project ownership and approval permissions for the operator component by adding an additional approver and reviewer. This is an internal administrative update with no user-facing or functional changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/ocm/pull/1537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->