### PR TITLE
✨ Add imagePullSecrets support to cluster-manager helm chart

### DIFF
--- a/deploy/cluster-manager/chart/cluster-manager/templates/_helpers.tpl
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/_helpers.tpl
@@ -3,7 +3,8 @@
      the full list is still applied to operator pods via clusterManager.imagePullSecrets. */}}
 {{- define "clusterManager.imagePullSecretName" -}}
 {{- if .Values.images.imagePullSecrets -}}
-{{- (index .Values.images.imagePullSecrets 0).name -}}
+{{- $name := (index .Values.images.imagePullSecrets 0).name | default "" -}}
+{{- required "images.imagePullSecrets[0].name must be set when imagePullSecrets is provided" $name -}}
 {{- else -}}
 open-cluster-management-image-pull-credentials
 {{- end -}}

--- a/deploy/cluster-manager/chart/cluster-manager/templates/_helpers.tpl
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/_helpers.tpl
@@ -1,3 +1,23 @@
+{{/* Name of the image pull secret synced to hub namespaces and passed to the operator.
+     When imagePullSecrets lists multiple secrets, only the first name is used here;
+     the full list is still applied to operator pods via clusterManager.imagePullSecrets. */}}
+{{- define "clusterManager.imagePullSecretName" -}}
+{{- if .Values.images.imagePullSecrets -}}
+{{- (index .Values.images.imagePullSecrets 0).name -}}
+{{- else -}}
+open-cluster-management-image-pull-credentials
+{{- end -}}
+{{- end }}
+
+{{/* Image pull secrets for operator pods and service account. */}}
+{{- define "clusterManager.imagePullSecrets" -}}
+{{- if .Values.images.imagePullSecrets -}}
+{{ .Values.images.imagePullSecrets | toYaml }}
+{{- else -}}
+- name: {{ include "clusterManager.imagePullSecretName" . }}
+{{- end -}}
+{{- end }}
+
 {{/* Create secret to access docker registry */}}
 {{- define "imagePullSecret" }}
 {{- with .Values.images }}

--- a/deploy/cluster-manager/chart/cluster-manager/templates/cluster_role.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/cluster_role.yaml
@@ -34,7 +34,7 @@ rules:
     - "addon-webhook-sa-kubeconfig"
     - "external-hub-kubeconfig"
     - "work-driver-config"
-    - "open-cluster-management-image-pull-credentials"
+    - {{ include "clusterManager.imagePullSecretName" . | quote }}
     - "grpc-server-serving-cert"
     - "placement-debug-serving-cert"
     - "cluster-import-config"

--- a/deploy/cluster-manager/chart/cluster-manager/templates/image_pull_secret.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/image_pull_secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: open-cluster-management-image-pull-credentials
+  name: {{ include "clusterManager.imagePullSecretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: cluster-manager

--- a/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/operator.yaml
@@ -29,6 +29,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      imagePullSecrets: {{- include "clusterManager.imagePullSecrets" . | nindent 8 }}
       serviceAccountName: cluster-manager
       containers:
       - name: registration-operator
@@ -37,6 +38,7 @@ spec:
         args:
           - "/registration-operator"
           - "hub"
+          - --image-pull-secret-name={{ include "clusterManager.imagePullSecretName" . }}
           {{- if .Values.enableSyncLabels }}
           - --enable-sync-labels
           {{- end }}

--- a/deploy/cluster-manager/chart/cluster-manager/templates/service_account.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/templates/service_account.yaml
@@ -3,5 +3,4 @@ kind: ServiceAccount
 metadata:
   name: cluster-manager
   namespace: {{ .Release.Namespace }}
-imagePullSecrets:
-  - name: open-cluster-management-image-pull-credentials
+imagePullSecrets: {{- include "clusterManager.imagePullSecrets" . | nindent 2 }}

--- a/deploy/cluster-manager/chart/cluster-manager/values.yaml
+++ b/deploy/cluster-manager/chart/cluster-manager/values.yaml
@@ -17,13 +17,22 @@ images:
   # The image tag is the appVersion by default, can be replaced by this version.
   tag: ""
   imagePullPolicy: IfNotPresent
-  # The image pull secret name is open-cluster-management-image-pull-credentials.
-  # Please set the userName/password or the dockerConfigJson if you use a private image registry.
+  # imagePullSecrets references existing secrets in the release namespace for pulling images.
+  # All entries are applied to the operator service account and deployment.
+  # The first entry's name is also used to sync the secret to hub components
+  # (registration, work, placement, addon-manager) and for operator RBAC.
+  # Example:
+  # imagePullSecrets:
+  #   - name: my-registry-secret
+  imagePullSecrets: []
+  # The image pull secret name is open-cluster-management-image-pull-credentials by default.
+  # Please set the userName/password or the dockerConfigJson if you use a private image registry
+  # and want the chart to create the pull secret.
   # The registry will be set in the generated credential if you set userName/password.
   # Suggest to use dockerConfigJson if you set overrides here.
-  # For example: 
+  # For example:
   # --set-file images.imageCredentials.dockerConfigJson=<your dockerConfigJson file> ,
-  # or set the json context in values.yaml file 
+  # or set the json context in values.yaml file
   # dockerConfigJson: |
   #   {
   #     "auths": {
@@ -34,8 +43,9 @@ images:
   #   }
   # }
   #
-  # The image pull secret is fixed into the serviceAccount, you can also set
-  # `createImageCredentials` to `false` and create the pull secret manually.
+  # To use an existing pull secret without embedding credentials in values, set
+  # `createImageCredentials` to `false` and either leave `imagePullSecrets` empty
+  # (default name) or set it to reference your existing secret.
   imageCredentials:
     createImageCredentials: false
     userName: ""

--- a/deploy/cluster-manager/config/operator/operator.yaml
+++ b/deploy/cluster-manager/config/operator/operator.yaml
@@ -40,6 +40,8 @@ spec:
             weight: 30
       securityContext:
         runAsNonRoot: true
+      imagePullSecrets:
+        - name: open-cluster-management-image-pull-credentials
       serviceAccountName: cluster-manager
       containers:
       - name: registration-operator
@@ -48,6 +50,7 @@ spec:
         args:
           - "/registration-operator"
           - "hub"
+          - --image-pull-secret-name=open-cluster-management-image-pull-credentials
         env:
         - name: POD_NAME
           valueFrom:

--- a/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
+++ b/deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
@@ -598,6 +598,7 @@ spec:
               - args:
                 - /registration-operator
                 - hub
+                - --image-pull-secret-name=open-cluster-management-image-pull-credentials
                 env:
                 - name: POD_NAME
                   valueFrom:
@@ -636,6 +637,8 @@ spec:
                 volumeMounts:
                 - mountPath: /tmp
                   name: tmpdir
+              imagePullSecrets:
+              - name: open-cluster-management-image-pull-credentials
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: cluster-manager

--- a/manifests/cluster-manager/hub/registration/clusterrole.yaml
+++ b/manifests/cluster-manager/hub/registration/clusterrole.yaml
@@ -121,7 +121,7 @@ rules:
   resources: ["secrets"]
   verbs: ["get"]
   resourceNames:
-    - "open-cluster-management-image-pull-credentials"
+    - "{{ .ImagePullSecretName }}"
     - "cluster-import-config"
 {{end}}
 {{if .ClusterProfileEnabled}}

--- a/manifests/cluster-manager/management/registration/deployment.yaml
+++ b/manifests/cluster-manager/management/registration/deployment.yaml
@@ -70,6 +70,7 @@ spec:
           {{if .ClusterImporterEnabled}}
           - "--agent-image={{ .AgentImage }}"
           - "--bootstrap-serviceaccount={{ .OperatorNamespace }}/agent-registration-bootstrap"
+          - "--image-pull-secret-name={{ .ImagePullSecretName }}"
           {{if .ImporterRenderers}}
           - "--import-renderers={{ .ImporterRenderers }}"
           {{end}}

--- a/manifests/config.go
+++ b/manifests/config.go
@@ -34,6 +34,7 @@ type HubConfig struct {
 	WorkDriver                     string
 	AutoApproveUsers               string
 	ImagePullSecret                string
+	ImagePullSecretName            string
 	// ResourceRequirementResourceType is the resource requirement resource type for the cluster manager managed containers.
 	ResourceRequirementResourceType operatorapiv1.ResourceQosClass
 	// ResourceRequirements is the resource requirements for the cluster manager managed containers.

--- a/pkg/cmd/hub/operator.go
+++ b/pkg/cmd/hub/operator.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/utils/clock"
 
 	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	"open-cluster-management.io/ocm/pkg/operator/helpers"
 	"open-cluster-management.io/ocm/pkg/operator/operators/clustermanager"
 	"open-cluster-management.io/ocm/pkg/version"
 )
@@ -30,6 +31,8 @@ func NewHubOperatorCmd() *cobra.Command {
 		"Number of deployment replicas, operator will automatically determine replicas if not set")
 	flags.BoolVar(&cmOptions.EnableSyncLabels, "enable-sync-labels", false,
 		"If set, will sync the labels of ClusterManager CR to all hub resources")
+	flags.StringVar(&cmOptions.ImagePullSecretName, "image-pull-secret-name", helpers.ImagePullSecret,
+		"The name of the image pull secret in the operator namespace to sync to hub components")
 	opts.AddFlags(flags)
 	return cmd
 }

--- a/pkg/cmd/hub/operator_test.go
+++ b/pkg/cmd/hub/operator_test.go
@@ -43,6 +43,7 @@ func TestHubOperatorFlags(t *testing.T) {
 		"control-plane-node-label-selector": "string",
 		"deployment-replicas":               "int32",
 		"enable-sync-labels":                "bool",
+		"image-pull-secret-name":            "string",
 	}
 
 	for flagName, flagType := range expectedFlags {
@@ -82,6 +83,7 @@ func TestHubOperatorFlagDefaults(t *testing.T) {
 		{"control-plane-node-label-selector", "node-role.kubernetes.io/master="},
 		{"deployment-replicas", "0"},
 		{"enable-sync-labels", "false"},
+		{"image-pull-secret-name", "open-cluster-management-image-pull-credentials"},
 	}
 
 	for _, test := range tests {

--- a/pkg/operator/helpers/chart/config.go
+++ b/pkg/operator/helpers/chart/config.go
@@ -95,6 +95,8 @@ type ImagesConfig struct {
 	Tag string `json:"tag,omitempty"`
 	// ImagePullPolicy is the image pull policy of operator image. Default is IfNotPresent.
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// ImagePullSecrets references existing secrets for pulling images.
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// The image pull secret name is open-cluster-management-image-pull-credentials.
 	// Please set the userName and password if you use a private image registry.
 	ImageCredentials ImageCredentials `json:"imageCredentials,omitempty"`

--- a/pkg/operator/helpers/chart/render_test.go
+++ b/pkg/operator/helpers/chart/render_test.go
@@ -112,6 +112,18 @@ func TestClusterManagerConfig(t *testing.T) {
 			expectedObjCnt: 6,
 		},
 		{
+			name:      "use existing imagePullSecrets",
+			namespace: "ocm",
+			chartConfig: func() *ClusterManagerChartConfig {
+				config := NewDefaultClusterManagerChartConfig()
+				config.Images.ImagePullSecrets = []corev1.LocalObjectReference{
+					{Name: "my-existing-secret"},
+				}
+				return config
+			},
+			expectedObjCnt: 5,
+		},
+		{
 			name:      "create namespace",
 			namespace: "multicluster-engine",
 			chartConfig: func() *ClusterManagerChartConfig {

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -818,6 +818,14 @@ func GetOperatorNamespace() string {
 	return operatorNamespace
 }
 
+// NormalizeImagePullSecretName returns the default image pull secret name when name is empty.
+func NormalizeImagePullSecretName(name string) string {
+	if name == "" {
+		return ImagePullSecret
+	}
+	return name
+}
+
 // filterLabels removes reserved label keys from the input map
 func filterLabels(labels map[string]string) map[string]string {
 	filtered := map[string]string{}

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -820,10 +820,11 @@ func GetOperatorNamespace() string {
 
 // NormalizeImagePullSecretName returns the default image pull secret name when name is empty.
 func NormalizeImagePullSecretName(name string) string {
-	if name == "" {
+	normalized := strings.TrimSpace(name)
+	if normalized == "" {
 		return ImagePullSecret
 	}
-	return name
+	return normalized
 }
 
 // filterLabels removes reserved label keys from the input map

--- a/pkg/operator/helpers/helpers_test.go
+++ b/pkg/operator/helpers/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -2402,5 +2403,49 @@ func TestGRPCServerEndpointType(t *testing.T) {
 				t.Errorf("expected endpoint type %s, but got %s", tc.expectedType, endpointType)
 			}
 		})
+	}
+}
+
+func TestNormalizeImagePullSecretName(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "default when empty",
+			expected: ImagePullSecret,
+		},
+		{
+			name:     "custom secret name",
+			input:    "my-registry-secret",
+			expected: "my-registry-secret",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizeImagePullSecretName(c.input); got != c.expected {
+				t.Fatalf("expected %q, got %q", c.expected, got)
+			}
+		})
+	}
+}
+
+func TestRegistrationClusterRoleImagePullSecretName(t *testing.T) {
+	template, err := manifests.ClusterManagerManifestFiles.ReadFile("cluster-manager/hub/registration/clusterrole.yaml")
+	if err != nil {
+		t.Fatalf("failed to read manifest: %v", err)
+	}
+
+	objData := assets.MustCreateAssetFromTemplate("cluster-manager/hub/registration/clusterrole.yaml", template, manifests.HubConfig{
+		ClusterManagerName:     "test",
+		ClusterImporterEnabled: true,
+		ImagePullSecretName:    "my-registry-secret",
+		Replica:                1,
+	}).Data
+
+	if !strings.Contains(string(objData), "my-registry-secret") {
+		t.Fatalf("expected clusterrole to reference custom image pull secret, got:\n%s", string(objData))
 	}
 }

--- a/pkg/operator/helpers/helpers_test.go
+++ b/pkg/operator/helpers/helpers_test.go
@@ -2417,8 +2417,18 @@ func TestNormalizeImagePullSecretName(t *testing.T) {
 			expected: ImagePullSecret,
 		},
 		{
+			name:     "default when whitespace only",
+			input:    "   ",
+			expected: ImagePullSecret,
+		},
+		{
 			name:     "custom secret name",
 			input:    "my-registry-secret",
+			expected: "my-registry-secret",
+		},
+		{
+			name:     "trim whitespace from secret name",
+			input:    " my-registry-secret ",
 			expected: "my-registry-secret",
 		},
 	}

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller.go
@@ -67,6 +67,7 @@ type clusterManagerController struct {
 	deploymentReplicas            int32
 	operatorNamespace             string
 	enableSyncLabels              bool
+	imagePullSecretName           string
 	tlsMinVersion                 string
 	tlsCipherSuites               string
 }
@@ -96,6 +97,7 @@ func NewClusterManagerController(
 	deploymentReplicas int32,
 	operatorNamespace string,
 	enableSyncLabels bool,
+	imagePullSecretName string,
 	tlsMinVersion string,
 	tlsCipherSuites string,
 ) factory.Controller {
@@ -115,6 +117,7 @@ func NewClusterManagerController(
 		deploymentReplicas:            deploymentReplicas,
 		operatorNamespace:             operatorNamespace,
 		enableSyncLabels:              enableSyncLabels,
+		imagePullSecretName:           imagePullSecretName,
 		tlsMinVersion:                 tlsMinVersion,
 		tlsCipherSuites:               tlsCipherSuites,
 	}
@@ -169,6 +172,7 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 		ClusterManagerName:              clusterManager.Name,
 		ClusterManagerNamespace:         clusterManagerNamespace,
 		OperatorNamespace:               n.operatorNamespace,
+		ImagePullSecretName:             n.imagePullSecretName,
 		RegistrationImage:               clusterManager.Spec.RegistrationImagePullSpec,
 		WorkImage:                       clusterManager.Spec.WorkImagePullSpec,
 		PlacementImage:                  clusterManager.Spec.PlacementImagePullSpec,
@@ -278,7 +282,8 @@ func (n *clusterManagerController) sync(ctx context.Context, controllerContext f
 		&crdReconcile{cache: n.cache, recorder: controllerContext.Recorder(), hubAPIExtensionClient: hubApiExtensionClient,
 			hubMigrationClient: hubMigrationClient, skipRemoveCRDs: n.skipRemoveCRDs},
 		&secretReconcile{cache: n.cache, recorder: controllerContext.Recorder(), operatorKubeClient: n.operatorKubeClient,
-			hubKubeClient: hubClient, operatorNamespace: n.operatorNamespace, enableSyncLabels: n.enableSyncLabels},
+			hubKubeClient: hubClient, operatorNamespace: n.operatorNamespace, imagePullSecretName: n.imagePullSecretName,
+			enableSyncLabels: n.enableSyncLabels},
 		&hubReconcile{cache: n.cache, recorder: controllerContext.Recorder(), hubKubeClient: hubClient},
 		&runtimeReconcile{cache: n.cache, recorder: controllerContext.Recorder(), hubKubeConfig: hubKubeConfig, hubKubeClient: hubClient,
 			kubeClient: managementClient, ensureSAKubeconfigs: n.ensureSAKubeconfigs},
@@ -551,7 +556,7 @@ func cleanResources(ctx context.Context, kubeClient kubernetes.Interface, cm *op
 }
 
 func (n *clusterManagerController) getImagePullSecret(ctx context.Context) (string, error) {
-	_, err := n.operatorKubeClient.CoreV1().Secrets(n.operatorNamespace).Get(ctx, helpers.ImagePullSecret, metav1.GetOptions{})
+	_, err := n.operatorKubeClient.CoreV1().Secrets(n.operatorNamespace).Get(ctx, n.imagePullSecretName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return "", nil
 	}
@@ -559,7 +564,7 @@ func (n *clusterManagerController) getImagePullSecret(ctx context.Context) (stri
 		return "", err
 	}
 
-	return helpers.ImagePullSecret, nil
+	return n.imagePullSecretName, nil
 }
 
 func getIdentityCreatorRoleAndTags(cm operatorapiv1.ClusterManager) string {

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_controller_test.go
@@ -110,6 +110,7 @@ func newTestControllerWithoutCaBundle(t *testing.T, clustermanager *operatorapiv
 		clusterManagerLister: operatorInformers.Operator().V1().ClusterManagers().Lister(),
 		configMapLister:      kubeInfomers.Core().V1().ConfigMaps().Lister(),
 		cache:                resourceapply.NewResourceCache(),
+		imagePullSecretName:  helpers.ImagePullSecret,
 	}
 
 	store := operatorInformers.Operator().V1().ClusterManagers().Informer().GetStore()
@@ -142,6 +143,7 @@ func newTestController(t *testing.T, clustermanager *operatorapiv1.ClusterManage
 		clusterManagerLister: operatorInformers.Operator().V1().ClusterManagers().Lister(),
 		configMapLister:      kubeInfomers.Core().V1().ConfigMaps().Lister(),
 		cache:                resourceapply.NewResourceCache(),
+		imagePullSecretName:  helpers.ImagePullSecret,
 	}
 
 	store := operatorInformers.Operator().V1().ClusterManagers().Informer().GetStore()
@@ -495,6 +497,7 @@ func TestSyncSecret(t *testing.T) {
 	tests := []struct {
 		name                                    string
 		clusterManager                          func() *operatorapiv1.ClusterManager
+		imagePullSecretName                     string
 		imagePullSecret, workDriverConfigSecret *corev1.Secret
 	}{
 		{
@@ -527,6 +530,14 @@ func TestSyncSecret(t *testing.T) {
 			imagePullSecret: newSecret(helpers.ImagePullSecret, operatorNamespace),
 		},
 		{
+			name: "sync custom imagePullSecret",
+			clusterManager: func() *operatorapiv1.ClusterManager {
+				return newClusterManager("testhub")
+			},
+			imagePullSecretName: "my-registry-secret",
+			imagePullSecret:     newSecret("my-registry-secret", operatorNamespace),
+		},
+		{
 			name: "sync workDriverConfigSecret",
 			clusterManager: func() *operatorapiv1.ClusterManager {
 				clusterManager := newClusterManager("testhub")
@@ -552,6 +563,10 @@ func TestSyncSecret(t *testing.T) {
 		cm := c.clusterManager()
 		tc := newTestController(t, cm)
 		tc.clusterManagerController.operatorNamespace = operatorNamespace
+		if c.imagePullSecretName != "" {
+			tc.clusterManagerController.imagePullSecretName = c.imagePullSecretName
+		}
+		expectedImagePullSecretName := tc.clusterManagerController.imagePullSecretName
 		clusterManagerNamespace := helpers.ClusterManagerNamespace(cm.Name, cm.Spec.DeployOption.Mode)
 		setup(t, tc, nil)
 
@@ -588,9 +603,9 @@ func TestSyncSecret(t *testing.T) {
 			}
 		}
 
-		_, err = tc.hubKubeClient.CoreV1().Secrets(clusterManagerNamespace).Get(ctx, helpers.ImagePullSecret, metav1.GetOptions{})
+		_, err = tc.hubKubeClient.CoreV1().Secrets(clusterManagerNamespace).Get(ctx, expectedImagePullSecretName, metav1.GetOptions{})
 		if c.imagePullSecret == nil && !errors.IsNotFound(err) {
-			t.Fatalf("excpected no secret %v but got: %v", helpers.ImagePullSecret, err)
+			t.Fatalf("excpected no secret %v but got: %v", expectedImagePullSecretName, err)
 		}
 		if c.imagePullSecret != nil && err != nil {
 			t.Fatalf("Failed to get synced image pull secret: %v", err)
@@ -609,7 +624,7 @@ func TestSyncSecret(t *testing.T) {
 				t.Fatalf("Expected image pull secret in deployment. %v", deployment.Name)
 			}
 
-			if c.imagePullSecret != nil && deployment.Spec.Template.Spec.ImagePullSecrets[0].Name != helpers.ImagePullSecret {
+			if c.imagePullSecret != nil && deployment.Spec.Template.Spec.ImagePullSecrets[0].Name != expectedImagePullSecretName {
 				t.Fatalf("Expected correct image pull secret name in deployment. %v", deployment.Name)
 			}
 		}
@@ -1055,6 +1070,76 @@ func TestGRPCServiceLoadBalancerType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestImagePullSecretNameOnHubResources(t *testing.T) {
+	clusterManager := newClusterManager("testhub")
+	clusterManager.Spec.RegistrationConfiguration = &operatorapiv1.RegistrationHubConfiguration{
+		FeatureGates: []operatorapiv1.FeatureGate{
+			{Feature: string(ocmfeature.ClusterImporter), Mode: operatorapiv1.FeatureGateModeTypeEnable},
+		},
+	}
+
+	tc := newTestController(t, clusterManager)
+	tc.clusterManagerController.operatorNamespace = helpers.DefaultComponentNamespace
+	tc.clusterManagerController.imagePullSecretName = "my-registry-secret"
+	clusterManagerNamespace := helpers.ClusterManagerNamespace(clusterManager.Name, clusterManager.Spec.DeployOption.Mode)
+	setup(t, tc, setDeployment(clusterManager.Name, clusterManagerNamespace))
+
+	if _, err := tc.managementKubeClient.CoreV1().Secrets(helpers.DefaultComponentNamespace).Create(
+		ctx, newSecret("my-registry-secret", helpers.DefaultComponentNamespace), metav1.CreateOptions{},
+	); err != nil {
+		t.Fatalf("failed to create image pull secret: %v", err)
+	}
+
+	syncContext := testingcommon.NewFakeSyncContext(t, "testhub")
+	if err := tc.clusterManagerController.sync(ctx, syncContext, "testhub"); err != nil {
+		t.Fatalf("expected no error when sync, %v", err)
+	}
+
+	clusterRoleName := "open-cluster-management:testhub-registration:controller"
+	clusterRole, err := tc.hubKubeClient.RbacV1().ClusterRoles().Get(ctx, clusterRoleName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get registration clusterrole: %v", err)
+	}
+
+	registrationDeploymentName := clusterManager.Name + "-registration-controller"
+	var imagePullSecretNameArg string
+	kubeActions := append(tc.hubKubeClient.Actions(), tc.managementKubeClient.Actions()...)
+	for _, action := range kubeActions {
+		if action.GetVerb() != createVerb && action.GetVerb() != "update" {
+			continue
+		}
+		var deployment *appsv1.Deployment
+		if action.GetVerb() == createVerb {
+			deployment, _ = action.(clienttesting.CreateActionImpl).Object.(*appsv1.Deployment)
+		} else {
+			deployment, _ = action.(clienttesting.UpdateActionImpl).Object.(*appsv1.Deployment)
+		}
+		if deployment == nil || deployment.Name != registrationDeploymentName || deployment.Namespace != clusterManagerNamespace {
+			continue
+		}
+		for _, arg := range deployment.Spec.Template.Spec.Containers[0].Args {
+			if after, ok := strings.CutPrefix(arg, "--image-pull-secret-name="); ok {
+				imagePullSecretNameArg = after
+				break
+			}
+		}
+		break
+	}
+	if imagePullSecretNameArg != "my-registry-secret" {
+		t.Fatalf("expected registration deployment to pass --image-pull-secret-name=my-registry-secret, got %q", imagePullSecretNameArg)
+	}
+
+	for _, rule := range clusterRole.Rules {
+		for _, resourceName := range rule.ResourceNames {
+			if resourceName == "my-registry-secret" {
+				return
+			}
+		}
+	}
+
+	t.Fatalf("expected registration clusterrole %q to reference my-registry-secret", clusterRoleName)
 }
 
 // TestImporterRenderersConfiguration tests that importer renderers are correctly rendered in the registration deployment

--- a/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_secret_reconcile.go
+++ b/pkg/operator/operators/clustermanager/controllers/clustermanagercontroller/clustermanager_secret_reconcile.go
@@ -18,30 +18,30 @@ import (
 	"open-cluster-management.io/ocm/pkg/operator/helpers"
 )
 
-var (
-	// secretNames is the slice of secrets to be synced from operator namespace to the clusterManager namespace
-	secretNames = []string{helpers.ImagePullSecret, helpers.WorkDriverConfigSecret}
-)
-
 type secretReconcile struct {
-	operatorKubeClient kubernetes.Interface
-	hubKubeClient      kubernetes.Interface
-	operatorNamespace  string
-	cache              resourceapply.ResourceCache
-	recorder           events.Recorder
-	enableSyncLabels   bool
+	operatorKubeClient  kubernetes.Interface
+	hubKubeClient       kubernetes.Interface
+	operatorNamespace   string
+	imagePullSecretName string
+	cache               resourceapply.ResourceCache
+	recorder            events.Recorder
+	enableSyncLabels    bool
+}
+
+func (c *secretReconcile) secretNames(config manifests.HubConfig) []string {
+	names := []string{c.imagePullSecretName}
+	isWorkDriver := config.CloudEventsDriverEnabled && config.WorkDriver != string(operatorapiv1.WorkDriverTypeKube)
+	if isWorkDriver {
+		names = append(names, helpers.WorkDriverConfigSecret)
+	}
+	return names
 }
 
 func (c *secretReconcile) reconcile(ctx context.Context, cm *operatorapiv1.ClusterManager,
 	config manifests.HubConfig) (*operatorapiv1.ClusterManager, reconcileState, error) {
 	var syncedErrs []error
-	isWorkDriver := config.CloudEventsDriverEnabled && config.WorkDriver != string(operatorapiv1.WorkDriverTypeKube)
 
-	for _, secretName := range secretNames {
-		if secretName == helpers.WorkDriverConfigSecret && !isWorkDriver {
-			continue
-		}
-
+	for _, secretName := range c.secretNames(config) {
 		// sync the secret to target namespace
 		// will delete the secret in the target ns if the secret is not found in the source ns
 		if _, _, err := helpers.SyncSecret(
@@ -74,7 +74,7 @@ func (c *secretReconcile) reconcile(ctx context.Context, cm *operatorapiv1.Clust
 
 func (c *secretReconcile) clean(ctx context.Context, cm *operatorapiv1.ClusterManager,
 	config manifests.HubConfig) (*operatorapiv1.ClusterManager, reconcileState, error) {
-	for _, secretName := range secretNames {
+	for _, secretName := range []string{c.imagePullSecretName, helpers.WorkDriverConfigSecret} {
 		if err := c.hubKubeClient.CoreV1().Secrets(config.ClusterManagerNamespace).Delete(ctx,
 			secretName, metav1.DeleteOptions{}); err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/operator/operators/clustermanager/options.go
+++ b/pkg/operator/operators/clustermanager/options.go
@@ -30,6 +30,7 @@ type Options struct {
 	ControlPlaneNodeLabelSelector string
 	DeploymentReplicas            int32
 	EnableSyncLabels              bool
+	ImagePullSecretName           string
 }
 
 // RunClusterManagerOperator starts a new cluster manager operator
@@ -122,6 +123,7 @@ func (o *Options) RunClusterManagerOperator(ctx context.Context, controllerConte
 		o.DeploymentReplicas,
 		controllerContext.OperatorNamespace,
 		o.EnableSyncLabels,
+		imagePullSecretNameFromOptions(o),
 		tlsMinVersion,
 		tlsCipherSuites,
 	)
@@ -165,4 +167,8 @@ func (o *Options) RunClusterManagerOperator(ctx context.Context, controllerConte
 
 	<-ctx.Done()
 	return nil
+}
+
+func imagePullSecretNameFromOptions(o *Options) string {
+	return helpers.NormalizeImagePullSecretName(o.ImagePullSecretName)
 }

--- a/pkg/operator/operators/clustermanager/options_test.go
+++ b/pkg/operator/operators/clustermanager/options_test.go
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("start cluster manager", func() {
 		// start hub controller
 		go func() {
 			defer ginkgo.GinkgoRecover()
-			o := &Options{}
+			o := &Options{ImagePullSecretName: "my-registry-secret"}
 			err := o.RunClusterManagerOperator(ctx, &controllercmd.ControllerContext{
 				KubeConfig:        cfg,
 				EventRecorder:     util.NewIntegrationTestEventRecorder("integration"),

--- a/pkg/operator/operators/clustermanager/options_unit_test.go
+++ b/pkg/operator/operators/clustermanager/options_unit_test.go
@@ -1,0 +1,34 @@
+package clustermanager
+
+import (
+	"testing"
+
+	"open-cluster-management.io/ocm/pkg/operator/helpers"
+)
+
+func TestImagePullSecretNameFromOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		options  Options
+		expected string
+	}{
+		{
+			name:     "default when unset",
+			options:  Options{},
+			expected: helpers.ImagePullSecret,
+		},
+		{
+			name:     "custom secret name",
+			options:  Options{ImagePullSecretName: "my-registry-secret"},
+			expected: "my-registry-secret",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := imagePullSecretNameFromOptions(&c.options); got != c.expected {
+				t.Fatalf("expected %q, got %q", c.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/registration/hub/importer/options/options.go
+++ b/pkg/registration/hub/importer/options/options.go
@@ -6,14 +6,16 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
 
+	"open-cluster-management.io/ocm/pkg/operator/helpers"
 	"open-cluster-management.io/ocm/pkg/registration/hub/importer"
 )
 
 type Options struct {
-	APIServerURL      string
-	AgentImage        string
-	BootstrapSA       string
-	ImporterRenderers []string
+	APIServerURL        string
+	AgentImage          string
+	BootstrapSA         string
+	ImagePullSecretName string
+	ImporterRenderers   []string
 }
 
 const (
@@ -25,8 +27,9 @@ const (
 
 func New() *Options {
 	return &Options{
-		BootstrapSA:       "open-cluster-management/agent-registration-bootstrap",
-		ImporterRenderers: []string{RenderFromConfigSecret},
+		BootstrapSA:         "open-cluster-management/agent-registration-bootstrap",
+		ImagePullSecretName: helpers.ImagePullSecret,
+		ImporterRenderers:   []string{RenderFromConfigSecret},
 	}
 }
 
@@ -42,16 +45,19 @@ func (m *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&m.ImporterRenderers, "import-renderers", m.ImporterRenderers,
 		"Ordered list of import renderers applied sequentially to render klusterlet manifests. "+
 			"Allowed: render-auto, render-from-config-secret. Later renderers may override earlier values.")
+	fs.StringVar(&m.ImagePullSecretName, "image-pull-secret-name", m.ImagePullSecretName,
+		"Name of the image pull secret in the operator namespace used by the cluster importer.")
 }
 
 func GetImporterRenderers(options *Options, kubeClient kubernetes.Interface,
 	operatorNamespace string) ([]importer.KlusterletConfigRenderer, error) {
+	imagePullSecretName := helpers.NormalizeImagePullSecretName(options.ImagePullSecretName)
 	var renderers []importer.KlusterletConfigRenderer
 	if len(options.ImporterRenderers) == 0 {
 		renderers = append(renderers,
 			importer.RenderBootstrapHubKubeConfig(kubeClient, options.APIServerURL, options.BootstrapSA),
 			importer.RenderImage(options.AgentImage),
-			importer.RenderImagePullSecret(kubeClient, operatorNamespace),
+			importer.RenderImagePullSecret(kubeClient, operatorNamespace, imagePullSecretName),
 		)
 		return renderers, nil
 	}
@@ -62,7 +68,7 @@ func GetImporterRenderers(options *Options, kubeClient kubernetes.Interface,
 			renderers = append(renderers,
 				importer.RenderBootstrapHubKubeConfig(kubeClient, options.APIServerURL, options.BootstrapSA),
 				importer.RenderImage(options.AgentImage),
-				importer.RenderImagePullSecret(kubeClient, operatorNamespace),
+				importer.RenderImagePullSecret(kubeClient, operatorNamespace, imagePullSecretName),
 			)
 		case RenderFromConfigSecret:
 			renderers = append(renderers,

--- a/pkg/registration/hub/importer/renderers.go
+++ b/pkg/registration/hub/importer/renderers.go
@@ -20,8 +20,6 @@ import (
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
 )
 
-const imagePullSecretName = "open-cluster-management-image-pull-credentials"
-
 func RenderBootstrapHubKubeConfig(
 	kubeClient kubernetes.Interface, apiServerURL, bootstrapSA string) KlusterletConfigRenderer {
 	return func(ctx context.Context, _ *v1.ManagedCluster, config *chart.KlusterletChartConfig) (*chart.KlusterletChartConfig, error) {
@@ -114,9 +112,9 @@ func RenderImage(image string) KlusterletConfigRenderer {
 	}
 }
 
-func RenderImagePullSecret(kubeClient kubernetes.Interface, namespace string) KlusterletConfigRenderer {
+func RenderImagePullSecret(kubeClient kubernetes.Interface, namespace, secretName string) KlusterletConfigRenderer {
 	return func(ctx context.Context, _ *v1.ManagedCluster, config *chart.KlusterletChartConfig) (*chart.KlusterletChartConfig, error) {
-		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, imagePullSecretName, metav1.GetOptions{})
+		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 		switch {
 		case errors.IsNotFound(err):
 			return config, nil

--- a/pkg/registration/hub/importer/renderers_test.go
+++ b/pkg/registration/hub/importer/renderers_test.go
@@ -16,6 +16,7 @@ import (
 
 	v1 "open-cluster-management.io/api/cluster/v1"
 
+	"open-cluster-management.io/ocm/pkg/operator/helpers"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
 )
 
@@ -136,20 +137,23 @@ func TestRenderImage(t *testing.T) {
 
 func TestRenderImagePullSecret(t *testing.T) {
 	cases := []struct {
-		name     string
-		secrets  []runtime.Object
-		expected string
+		name       string
+		secretName string
+		secrets    []runtime.Object
+		expected   string
 	}{
 		{
-			name:    "not image secret",
-			secrets: []runtime.Object{},
+			name:       "not image secret",
+			secretName: helpers.ImagePullSecret,
+			secrets:    []runtime.Object{},
 		},
 		{
-			name: "secret has not correct key",
+			name:       "secret has not correct key",
+			secretName: helpers.ImagePullSecret,
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      imagePullSecretName,
+						Name:      helpers.ImagePullSecret,
 						Namespace: "test",
 					},
 					Data: map[string][]byte{
@@ -159,11 +163,12 @@ func TestRenderImagePullSecret(t *testing.T) {
 			},
 		},
 		{
-			name: "secrets has correct key",
+			name:       "secrets has correct key",
+			secretName: helpers.ImagePullSecret,
 			secrets: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      imagePullSecretName,
+						Name:      helpers.ImagePullSecret,
 						Namespace: "test",
 					},
 					Data: map[string][]byte{
@@ -173,13 +178,29 @@ func TestRenderImagePullSecret(t *testing.T) {
 			},
 			expected: "test",
 		},
+		{
+			name:       "custom secret name",
+			secretName: "my-registry-secret",
+			secrets: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-registry-secret",
+						Namespace: "test",
+					},
+					Data: map[string][]byte{
+						corev1.DockerConfigJsonKey: []byte("custom"),
+					},
+				},
+			},
+			expected: "custom",
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			client := kubefake.NewClientset(c.secrets...)
 			config := &chart.KlusterletChartConfig{}
-			render := RenderImagePullSecret(client, "test")
+			render := RenderImagePullSecret(client, "test", c.secretName)
 			config, err := render(context.TODO(), nil, config)
 			if err != nil {
 				t.Fatalf("failed to render image: %v", err)


### PR DESCRIPTION
Allow referencing existing pull secrets via images.imagePullSecrets instead of embedding credentials in values.
Document that the operator syncs the default secret name to hub components.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR adds the imagePullSecrets pod attribute to the operator pod. I've seen that then the operator uses that secret, with that specific name, to sync other deployments and items.

The goal is that people can also provide their imagePullSecret and then refer it like:

```yaml
images:
  imagePullSecrets:
    - name: open-cluster-management-image-pull-credentials  # MUST be this exact name!!!!!!
  imageCredentials:
    createImageCredentials: false
```


## Related issue(s)

https://github.com/open-cluster-management-io/ocm/issues/1538

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--image-pull-secret-name` CLI flag to configure which Kubernetes image pull secret is used for hub/registration syncing.
  * Added Helm/config support for `imagePullSecrets` to reference existing pull secrets.
* **Documentation**
  * Updated chart values guidance for using existing image pull credentials (including default secret name behavior).
* **Bug Fixes**
  * Ensured the configured image pull secret name is consistently applied across deployments and RBAC.
* **Tests**
  * Expanded coverage for custom and existing image pull secret name scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->