### PR TITLE
:seedling: add v1beta1 integration tests for addon API - preserve v1alpha1 tests

### DIFF
--- a/test/integration/addon/addon_configs_alpha_test.go
+++ b/test/integration/addon/addon_configs_alpha_test.go
@@ -10,13 +10,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 )
 
-var _ = ginkgo.Describe("AddConfigs Beta", func() {
+var _ = ginkgo.Describe("AddConfigs Alpha", func() {
 	var managedClusterName string
 	var configDefaultNamespace string
 	var configDefaultName string
@@ -45,7 +45,7 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// prepare ClusterManagementAddon
-		_, err = createClusterManagementAddOnBeta(testAddOnConfigsImpl.name, configDefaultNamespace, configDefaultName)
+		_, err = createClusterManagementAddOnAlpha(testAddOnConfigsImpl.name, configDefaultNamespace, configDefaultName)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		assertClusterManagementAddOnAnnotations(testAddOnConfigsImpl.name)
@@ -55,14 +55,14 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 		_, err = hubKubeClient.CoreV1().Namespaces().Create(context.Background(), configDefaultNS, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		addOnDefaultConfig := &addonapiv1beta1.AddOnDeploymentConfig{
+		addOnDefaultConfig := &addonapiv1alpha1.AddOnDeploymentConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configDefaultName,
 				Namespace: configDefaultNamespace,
 			},
-			Spec: addOnDefaultConfigSpecBeta,
+			Spec: addOnDefaultConfigSpecAlpha,
 		}
-		_, err = hubAddonClient.AddonV1beta1().AddOnDeploymentConfigs(configDefaultNamespace).Create(
+		_, err = hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(configDefaultNamespace).Create(
 			context.Background(), addOnDefaultConfig, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
@@ -74,47 +74,53 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		err = hubKubeClient.CoreV1().Namespaces().Delete(context.Background(), configDefaultNamespace, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Delete(context.Background(), testAddOnConfigsImpl.name, metav1.DeleteOptions{})
+		err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Delete(context.Background(), testAddOnConfigsImpl.name, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		delete(testAddOnConfigsImpl.registrations, managedClusterName)
 	})
 
 	ginkgo.It("Should use default config", func() {
-		addon := &addonapiv1beta1.ManagedClusterAddOn{
+		addon := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testAddOnConfigsImpl.name,
 				Namespace: managedClusterName,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{},
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: "test",
+			},
 		}
-		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// check cma status
-		assertClusterManagementAddOnDefaultConfigReferencesBeta(testAddOnConfigsImpl.name, addonapiv1beta1.DefaultConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertClusterManagementAddOnDefaultConfigReferencesAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.DefaultConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: configDefaultNamespace,
 					Name:      configDefaultName,
 				},
 				SpecHash: addOnDefaultConfigSpecHash,
 			},
 		})
-		assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name)
+		assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name)
 
 		// check mca status
-		assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, managedClusterName, addonapiv1beta1.ConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, managedClusterName, addonapiv1alpha1.ConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: configDefaultNamespace,
+				Name:      configDefaultName,
+			},
 			LastObservedGeneration: 1,
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: configDefaultNamespace,
 					Name:      configDefaultName,
 				},
@@ -124,19 +130,23 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 	})
 
 	ginkgo.It("Should override default config by install strategy", func() {
-		cma, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), testAddOnConfigsImpl.name, metav1.GetOptions{})
+		cma, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), testAddOnConfigsImpl.name, metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		cma.Spec.InstallStrategy = addonapiv1beta1.InstallStrategy{
-			Type: addonapiv1beta1.AddonInstallStrategyPlacements,
-			Placements: []addonapiv1beta1.PlacementStrategy{
+		cma.Spec.InstallStrategy = addonapiv1alpha1.InstallStrategy{
+			Type: addonapiv1alpha1.AddonInstallStrategyPlacements,
+			Placements: []addonapiv1alpha1.PlacementStrategy{
 				{
-					PlacementRef: addonapiv1beta1.PlacementRef{Name: "test-placement", Namespace: configDefaultNamespace},
-					Configs: []addonapiv1beta1.AddOnConfig{
+					PlacementRef: addonapiv1alpha1.PlacementRef{Name: "test-placement", Namespace: configDefaultNamespace},
+					Configs: []addonapiv1alpha1.AddOnConfig{
 						{
-							ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+							ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 								Group:    addOnDeploymentConfigGVR.Group,
 								Resource: addOnDeploymentConfigGVR.Resource,
+							},
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
+								Namespace: configDefaultNamespace,
+								Name:      "another-config",
 							},
 						},
 					},
@@ -146,7 +156,7 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 				},
 			},
 		}
-		patchClusterManagementAddOnBeta(context.Background(), cma)
+		patchClusterManagementAddOnAlpha(context.Background(), cma)
 
 		placement := &clusterv1beta1.Placement{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: configDefaultNamespace}}
 		_, err = hubClusterClient.ClusterV1beta1().Placements(configDefaultNamespace).Create(context.Background(), placement, metav1.CreateOptions{})
@@ -172,29 +182,29 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// check cma status
-		assertClusterManagementAddOnDefaultConfigReferencesBeta(testAddOnConfigsImpl.name, addonapiv1beta1.DefaultConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertClusterManagementAddOnDefaultConfigReferencesAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.DefaultConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: configDefaultNamespace,
 					Name:      configDefaultName,
 				},
 				SpecHash: addOnDefaultConfigSpecHash,
 			},
 		})
-		assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name, addonapiv1beta1.InstallProgression{
-			PlacementRef: addonapiv1beta1.PlacementRef{Name: "test-placement", Namespace: configDefaultNamespace},
-			ConfigReferences: []addonapiv1beta1.InstallConfigReference{
+		assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+			PlacementRef: addonapiv1alpha1.PlacementRef{Name: "test-placement", Namespace: configDefaultNamespace},
+			ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
 				{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-						ConfigReferent: addonapiv1beta1.ConfigReferent{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
 							Namespace: configDefaultNamespace,
 							Name:      "another-config",
 						},
@@ -205,14 +215,18 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 		})
 
 		// check mca status
-		assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, managedClusterName, addonapiv1beta1.ConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, managedClusterName, addonapiv1alpha1.ConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: configDefaultNamespace,
+				Name:      "another-config",
+			},
 			LastObservedGeneration: 0,
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: configDefaultNamespace,
 					Name:      "another-config",
 				},
@@ -222,70 +236,79 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 	})
 
 	ginkgo.It("Should override default config", func() {
-		addOnConfig := &addonapiv1beta1.AddOnDeploymentConfig{
+		addOnConfig := &addonapiv1alpha1.AddOnDeploymentConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "addon-config",
 				Namespace: managedClusterName,
 			},
-			Spec: addOnTest1ConfigSpecBeta,
+			Spec: addOnTest1ConfigSpecAlpha,
 		}
-		_, err = hubAddonClient.AddonV1beta1().AddOnDeploymentConfigs(managedClusterName).Create(context.Background(), addOnConfig, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(managedClusterName).Create(context.Background(), addOnConfig, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		addon := &addonapiv1beta1.ManagedClusterAddOn{
+		addon := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testAddOnConfigsImpl.name,
 				Namespace: managedClusterName,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{
-				Configs: []addonapiv1beta1.AddOnConfig{
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: "test",
+				Configs: []addonapiv1alpha1.AddOnConfig{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
+						},
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Name:      addOnConfig.Name,
+							Namespace: addOnConfig.Namespace,
 						},
 					},
 				},
 			},
 		}
-		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		addon.Status = addonapiv1beta1.ManagedClusterAddOnStatus{
-			SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{
+		addon.Status = addonapiv1alpha1.ManagedClusterAddOnStatus{
+			SupportedConfigs: []addonapiv1alpha1.ConfigGroupResource{
 				{
 					Group:    addOnDeploymentConfigGVR.Group,
 					Resource: addOnDeploymentConfigGVR.Resource,
 				},
 			},
 		}
-		updateManagedClusterAddOnStatusBeta(context.Background(), addon)
+		updateManagedClusterAddOnStatusAlpha(context.Background(), addon)
 
 		// check cma status
-		assertClusterManagementAddOnDefaultConfigReferencesBeta(testAddOnConfigsImpl.name, addonapiv1beta1.DefaultConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertClusterManagementAddOnDefaultConfigReferencesAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.DefaultConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: configDefaultNamespace,
 					Name:      configDefaultName,
 				},
 				SpecHash: addOnDefaultConfigSpecHash,
 			},
 		})
-		assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name)
+		assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name)
 
 		// check mca status
-		assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, managedClusterName, addonapiv1beta1.ConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, managedClusterName, addonapiv1alpha1.ConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: addOnConfig.Namespace,
+				Name:      addOnConfig.Name,
+			},
 			LastObservedGeneration: 1,
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: addOnConfig.Namespace,
 					Name:      addOnConfig.Name,
 				},
@@ -295,54 +318,63 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 	})
 
 	ginkgo.It("Should update config spec successfully", func() {
-		addOnConfig := &addonapiv1beta1.AddOnDeploymentConfig{
+		addOnConfig := &addonapiv1alpha1.AddOnDeploymentConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "addon-config",
 				Namespace: managedClusterName,
 			},
-			Spec: addOnTest1ConfigSpecBeta,
+			Spec: addOnTest1ConfigSpecAlpha,
 		}
-		_, err = hubAddonClient.AddonV1beta1().AddOnDeploymentConfigs(managedClusterName).Create(context.Background(), addOnConfig, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(managedClusterName).Create(context.Background(), addOnConfig, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		addon := &addonapiv1beta1.ManagedClusterAddOn{
+		addon := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testAddOnConfigsImpl.name,
 				Namespace: managedClusterName,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{
-				Configs: []addonapiv1beta1.AddOnConfig{
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: "test",
+				Configs: []addonapiv1alpha1.AddOnConfig{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
+						},
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Name:      addOnConfig.Name,
+							Namespace: addOnConfig.Namespace,
 						},
 					},
 				},
 			},
 		}
-		addon, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
+		addon, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		addon.Status = addonapiv1beta1.ManagedClusterAddOnStatus{
-			SupportedConfigs: []addonapiv1beta1.ConfigGroupResource{
+		addon.Status = addonapiv1alpha1.ManagedClusterAddOnStatus{
+			SupportedConfigs: []addonapiv1alpha1.ConfigGroupResource{
 				{
 					Group:    addOnDeploymentConfigGVR.Group,
 					Resource: addOnDeploymentConfigGVR.Resource,
 				},
 			},
 		}
-		updateManagedClusterAddOnStatusBeta(context.Background(), addon)
+		updateManagedClusterAddOnStatusAlpha(context.Background(), addon)
 
 		// check mca status
-		assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, managedClusterName, addonapiv1beta1.ConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, managedClusterName, addonapiv1alpha1.ConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: addOnConfig.Namespace,
+				Name:      addOnConfig.Name,
+			},
 			LastObservedGeneration: 1,
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: addOnConfig.Namespace,
 					Name:      addOnConfig.Name,
 				},
@@ -350,22 +382,26 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 			},
 		})
 
-		addOnConfig, err = hubAddonClient.AddonV1beta1().AddOnDeploymentConfigs(managedClusterName).Get(context.Background(), addOnConfig.Name, metav1.GetOptions{})
+		addOnConfig, err = hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(managedClusterName).Get(context.Background(), addOnConfig.Name, metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		addOnConfig.Spec = addOnTest2ConfigSpecBeta
-		_, err = hubAddonClient.AddonV1beta1().AddOnDeploymentConfigs(managedClusterName).Update(context.Background(), addOnConfig, metav1.UpdateOptions{})
+		addOnConfig.Spec = addOnTest2ConfigSpecAlpha
+		_, err = hubAddonClient.AddonV1alpha1().AddOnDeploymentConfigs(managedClusterName).Update(context.Background(), addOnConfig, metav1.UpdateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// check mca status
-		assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, managedClusterName, addonapiv1beta1.ConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, managedClusterName, addonapiv1alpha1.ConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: addOnConfig.Namespace,
+				Name:      addOnConfig.Name,
+			},
 			LastObservedGeneration: 2,
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: addOnConfig.Namespace,
 					Name:      addOnConfig.Name,
 				},
@@ -376,47 +412,60 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 
 	ginkgo.It("Should not update unsupported config spec hash", func() {
 		// do not update mca status.SupportedConfigs
-		addon := &addonapiv1beta1.ManagedClusterAddOn{
+		addon := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testAddOnConfigsImpl.name,
 				Namespace: managedClusterName,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{
-				Configs: []addonapiv1beta1.AddOnConfig{
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: "test",
+				Configs: []addonapiv1alpha1.AddOnConfig{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group + "test",
 							Resource: addOnDeploymentConfigGVR.Resource + "test",
+						},
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Name:      "addon-config-test",
+							Namespace: managedClusterName,
 						},
 					},
 				},
 			},
 		}
-		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// check mca status
-		assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, managedClusterName, addonapiv1beta1.ConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, managedClusterName, addonapiv1alpha1.ConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group,
 				Resource: addOnDeploymentConfigGVR.Resource,
 			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: configDefaultNamespace,
+				Name:      configDefaultName,
+			},
 			LastObservedGeneration: 1,
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: configDefaultNamespace,
 					Name:      configDefaultName,
 				},
 				SpecHash: addOnDefaultConfigSpecHash,
 			},
-		}, addonapiv1beta1.ConfigReference{
-			ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+		}, addonapiv1alpha1.ConfigReference{
+			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 				Group:    addOnDeploymentConfigGVR.Group + "test",
 				Resource: addOnDeploymentConfigGVR.Resource + "test",
 			},
+			ConfigReferent: addonapiv1alpha1.ConfigReferent{
+				Namespace: managedClusterName,
+				Name:      "addon-config-test",
+			},
 			LastObservedGeneration: 0,
-			DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-				ConfigReferent: addonapiv1beta1.ConfigReferent{
+			DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonapiv1alpha1.ConfigReferent{
 					Namespace: managedClusterName,
 					Name:      "addon-config-test",
 				},

--- a/test/integration/addon/addon_configs_alpha_test.go
+++ b/test/integration/addon/addon_configs_alpha_test.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("AddConfigs Alpha", func() {
 		_, err = createClusterManagementAddOnAlpha(testAddOnConfigsImpl.name, configDefaultNamespace, configDefaultName)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(testAddOnConfigsImpl.name)
+		assertClusterManagementAddOnAnnotationsAlpha(testAddOnConfigsImpl.name)
 
 		// prepare default config
 		configDefaultNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: configDefaultNamespace}}

--- a/test/integration/addon/addon_configs_test.go
+++ b/test/integration/addon/addon_configs_test.go
@@ -138,6 +138,10 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 								Group:    addOnDeploymentConfigGVR.Group,
 								Resource: addOnDeploymentConfigGVR.Resource,
 							},
+							ConfigReferent: addonapiv1beta1.ConfigReferent{
+								Namespace: configDefaultNamespace,
+								Name:      "another-config",
+							},
 						},
 					},
 					RolloutStrategy: clusterv1alpha1.RolloutStrategy{
@@ -244,6 +248,10 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Name:      addOnConfig.Name,
+							Namespace: addOnConfig.Namespace,
+						},
 					},
 				},
 			},
@@ -317,6 +325,10 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Name:      addOnConfig.Name,
+							Namespace: addOnConfig.Namespace,
+						},
 					},
 				},
 			},
@@ -387,6 +399,10 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group + "test",
 							Resource: addOnDeploymentConfigGVR.Resource + "test",
+						},
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Name:      "addon-config-test",
+							Namespace: managedClusterName,
 						},
 					},
 				},

--- a/test/integration/addon/addon_configs_test.go
+++ b/test/integration/addon/addon_configs_test.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("AddConfigs Beta", func() {
 		_, err = createClusterManagementAddOnBeta(testAddOnConfigsImpl.name, configDefaultNamespace, configDefaultName)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(testAddOnConfigsImpl.name)
+		assertClusterManagementAddOnAnnotationsBeta(testAddOnConfigsImpl.name)
 
 		// prepare default config
 		configDefaultNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: configDefaultNamespace}}

--- a/test/integration/addon/addon_manager_install_alpha_test.go
+++ b/test/integration/addon/addon_manager_install_alpha_test.go
@@ -11,15 +11,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 )
 
-var _ = ginkgo.Describe("Addon install Beta", func() {
+var _ = ginkgo.Describe("Addon install Alpha", func() {
 	var suffix string
-	var cma *addonapiv1beta1.ClusterManagementAddOn
+	var cma *addonapiv1alpha1.ClusterManagementAddOn
 	var placementNamespace string
 	var clusterNames []string
 
@@ -28,8 +28,8 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 		clusterNames = nil
 
 		// Create clustermanagement addon
-		cma = newClusterManagementAddonBeta(fmt.Sprintf("test-%s", suffix))
-		_, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
+		cma = newClusterManagementAddonAlpha(fmt.Sprintf("test-%s", suffix))
+		_, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		assertClusterManagementAddOnAnnotations(cma.Name)
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Delete(context.Background(), cma.Name, metav1.DeleteOptions{})
+		err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Delete(context.Background(), cma.Name, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		err = hubKubeClient.CoreV1().Namespaces().Delete(context.Background(), placementNamespace, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -98,14 +98,14 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 			_, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).UpdateStatus(context.Background(), decision, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			clusterManagementAddon, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
+			clusterManagementAddon, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			clusterManagementAddon.Spec.InstallStrategy = addonapiv1beta1.InstallStrategy{
-				Type: addonapiv1beta1.AddonInstallStrategyPlacements,
-				Placements: []addonapiv1beta1.PlacementStrategy{
+			clusterManagementAddon.Spec.InstallStrategy = addonapiv1alpha1.InstallStrategy{
+				Type: addonapiv1alpha1.AddonInstallStrategyPlacements,
+				Placements: []addonapiv1alpha1.PlacementStrategy{
 					{
-						PlacementRef: addonapiv1beta1.PlacementRef{Name: "test-placement", Namespace: placementNamespace},
+						PlacementRef: addonapiv1alpha1.PlacementRef{Name: "test-placement", Namespace: placementNamespace},
 						RolloutStrategy: clusterv1alpha1.RolloutStrategy{
 							Type: clusterv1alpha1.All,
 						},
@@ -113,15 +113,15 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 				},
 			}
 
-			_, err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Update(context.Background(), clusterManagementAddon, metav1.UpdateOptions{})
+			_, err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Update(context.Background(), clusterManagementAddon, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				_, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[0]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				_, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[0]).Get(context.Background(), cma.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -140,16 +140,16 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				_, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				_, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[2]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[2]).Get(context.Background(), cma.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
-				_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[0]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[0]).Get(context.Background(), cma.Name, metav1.GetOptions{})
 				if !errors.IsNotFound(err) {
 					return fmt.Errorf("addon in cluster %s should be removed", clusterNames[0])
 				}
@@ -157,10 +157,10 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			// delete an addon and ensure it is recreated.
-			err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[1]).Delete(context.Background(), cma.Name, metav1.DeleteOptions{})
+			err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[1]).Delete(context.Background(), cma.Name, metav1.DeleteOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Eventually(func() error {
-				_, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				_, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
@@ -173,7 +173,7 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 			cluster, err := hubClusterClient.ClusterV1().ManagedClusters().Get(context.Background(), clusterNames[0], metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			cluster.Annotations = map[string]string{
-				addonapiv1beta1.HostingClusterNameAnnotationKey: "hosting-cluster",
+				addonapiv1alpha1.HostingClusterNameAnnotationKey: "hosting-cluster",
 			}
 			_, err = hubClusterClient.ClusterV1().ManagedClusters().Update(context.Background(), cluster, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -202,30 +202,30 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 			_, err = hubClusterClient.ClusterV1beta1().PlacementDecisions(placementNamespace).UpdateStatus(context.Background(), decision, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			clusterManagementAddon, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
+			clusterManagementAddon, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			clusterManagementAddon.Spec.InstallStrategy = addonapiv1beta1.InstallStrategy{
-				Type: addonapiv1beta1.AddonInstallStrategyPlacements,
-				Placements: []addonapiv1beta1.PlacementStrategy{
+			clusterManagementAddon.Spec.InstallStrategy = addonapiv1alpha1.InstallStrategy{
+				Type: addonapiv1alpha1.AddonInstallStrategyPlacements,
+				Placements: []addonapiv1alpha1.PlacementStrategy{
 					{
-						PlacementRef: addonapiv1beta1.PlacementRef{Name: "test-placement-hosted", Namespace: placementNamespace},
+						PlacementRef: addonapiv1alpha1.PlacementRef{Name: "test-placement-hosted", Namespace: placementNamespace},
 						RolloutStrategy: clusterv1alpha1.RolloutStrategy{
 							Type: clusterv1alpha1.All,
 						},
 					},
 				},
 			}
-			_, err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Update(context.Background(), clusterManagementAddon, metav1.UpdateOptions{})
+			_, err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Update(context.Background(), clusterManagementAddon, metav1.UpdateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// Verify the addon on the hosted cluster has the hosting-cluster-name annotation
 			gomega.Eventually(func() error {
-				addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[0]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[0]).Get(context.Background(), cma.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				hostingCluster, ok := addon.Annotations[addonapiv1beta1.HostingClusterNameAnnotationKey]
+				hostingCluster, ok := addon.Annotations[addonapiv1alpha1.HostingClusterNameAnnotationKey]
 				if !ok {
 					return fmt.Errorf("expected hosting cluster name annotation on addon in cluster %s", clusterNames[0])
 				}
@@ -237,11 +237,11 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 
 			// Verify the addon on the non-hosted cluster does NOT have the hosting-cluster-name annotation
 			gomega.Eventually(func() error {
-				addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
+				addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterNames[1]).Get(context.Background(), cma.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				if _, ok := addon.Annotations[addonapiv1beta1.HostingClusterNameAnnotationKey]; ok {
+				if _, ok := addon.Annotations[addonapiv1alpha1.HostingClusterNameAnnotationKey]; ok {
 					return fmt.Errorf("expected no hosting cluster name annotation on addon in cluster %s", clusterNames[1])
 				}
 				return nil

--- a/test/integration/addon/addon_manager_install_alpha_test.go
+++ b/test/integration/addon/addon_manager_install_alpha_test.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("Addon install Alpha", func() {
 		_, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(cma.Name)
+		assertClusterManagementAddOnAnnotationsAlpha(cma.Name)
 
 		placementNamespace = fmt.Sprintf("ns-%s", suffix)
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: placementNamespace}}

--- a/test/integration/addon/addon_manager_install_test.go
+++ b/test/integration/addon/addon_manager_install_test.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("Addon install Beta", func() {
 		_, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(cma.Name)
+		assertClusterManagementAddOnAnnotationsBeta(cma.Name)
 
 		placementNamespace = fmt.Sprintf("ns-%s", suffix)
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: placementNamespace}}

--- a/test/integration/addon/addon_manager_template_alpha_test.go
+++ b/test/integration/addon/addon_manager_template_alpha_test.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("Template deploy Alpha", func() {
 		_, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(addonName)
+		assertClusterManagementAddOnAnnotationsAlpha(addonName)
 
 		// prepare addon template
 		addonTemplateData, err := os.ReadFile("./test/integration/addon/testmanifests/addontemplate.yaml")
@@ -210,14 +210,14 @@ var _ = ginkgo.Describe("Template deploy Alpha", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		ginkgo.By("check mca condition")
-		assertManagedClusterAddOnConditions(addonName, clusterNames[0], metav1.Condition{
+		assertManagedClusterAddOnConditionsAlpha(addonName, clusterNames[0], metav1.Condition{
 			Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 			Status:  metav1.ConditionTrue,
 			Reason:  "ConfigurationsConfigured",
 			Message: "Configurations configured",
 		})
 		for i := 1; i < numberOfClusters; i++ {
-			assertManagedClusterAddOnConditions(addonName, clusterNames[i], metav1.Condition{
+			assertManagedClusterAddOnConditionsAlpha(addonName, clusterNames[i], metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 				Status:  metav1.ConditionFalse,
 				Reason:  "ConfigurationsNotConfigured",
@@ -235,14 +235,14 @@ var _ = ginkgo.Describe("Template deploy Alpha", func() {
 		updateManifestWorkStatus(hubWorkClient, clusterNames[0], manifestWorkName, metav1.ConditionTrue)
 
 		ginkgo.By("check mca condition")
-		assertManagedClusterAddOnConditions(addonName, clusterNames[1], metav1.Condition{
+		assertManagedClusterAddOnConditionsAlpha(addonName, clusterNames[1], metav1.Condition{
 			Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 			Status:  metav1.ConditionTrue,
 			Reason:  "ConfigurationsConfigured",
 			Message: "Configurations configured",
 		})
 		for i := 2; i < numberOfClusters; i++ {
-			assertManagedClusterAddOnConditions(addonName, clusterNames[i], metav1.Condition{
+			assertManagedClusterAddOnConditionsAlpha(addonName, clusterNames[i], metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 				Status:  metav1.ConditionFalse,
 				Reason:  "ConfigurationsNotConfigured",

--- a/test/integration/addon/addon_manager_template_alpha_test.go
+++ b/test/integration/addon/addon_manager_template_alpha_test.go
@@ -22,7 +22,7 @@ import (
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 )
 
-var _ = ginkgo.Describe("Template deploy", func() {
+var _ = ginkgo.Describe("Template deploy Alpha", func() {
 	var (
 		clusterNames               []string
 		numberOfClusters           int

--- a/test/integration/addon/addon_manager_upgrade_alpha_test.go
+++ b/test/integration/addon/addon_manager_upgrade_alpha_test.go
@@ -15,13 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
-	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 )
 
 const (
-	upgradeDeploymentJsonBeta = `{
+	upgradeDeploymentJson = `{
 		"apiVersion": "apps/v1",
 		"kind": "Deployment",
 		"metadata": {
@@ -61,7 +61,7 @@ const (
 	}`
 )
 
-var _ = ginkgo.Describe("Addon upgrade Beta", func() {
+var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 	var configDefaultNamespace string
 	var configDefaultName string
 	var configUpdateName string
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 	var clusterNames []string
 	var suffix string
 	var err error
-	var cma *addonapiv1beta1.ClusterManagementAddOn
+	var cma *addonapiv1alpha1.ClusterManagementAddOn
 
 	ginkgo.BeforeEach(func() {
 		suffix = rand.String(5)
@@ -83,26 +83,26 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 		manifestWorkName = fmt.Sprintf("%s-0", constants.DeployWorkNamePrefix(testAddOnConfigsImpl.name))
 
 		// prepare cma
-		cma = &addonapiv1beta1.ClusterManagementAddOn{
+		cma = &addonapiv1alpha1.ClusterManagementAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testAddOnConfigsImpl.name,
 			},
-			Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
-				InstallStrategy: addonapiv1beta1.InstallStrategy{
-					Type: addonapiv1beta1.AddonInstallStrategyPlacements,
-					Placements: []addonapiv1beta1.PlacementStrategy{
+			Spec: addonapiv1alpha1.ClusterManagementAddOnSpec{
+				InstallStrategy: addonapiv1alpha1.InstallStrategy{
+					Type: addonapiv1alpha1.AddonInstallStrategyPlacements,
+					Placements: []addonapiv1alpha1.PlacementStrategy{
 						{
-							PlacementRef: addonapiv1beta1.PlacementRef{Name: placementName, Namespace: placementNamespace},
+							PlacementRef: addonapiv1alpha1.PlacementRef{Name: placementName, Namespace: placementNamespace},
 							RolloutStrategy: clusterv1alpha1.RolloutStrategy{
 								Type: clusterv1alpha1.All,
 							},
-							Configs: []addonapiv1beta1.AddOnConfig{
+							Configs: []addonapiv1alpha1.AddOnConfig{
 								{
-									ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+									ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 										Group:    addOnDeploymentConfigGVR.Group,
 										Resource: addOnDeploymentConfigGVR.Resource,
 									},
-									ConfigReferent: addonapiv1beta1.ConfigReferent{
+									ConfigReferent: addonapiv1alpha1.ConfigReferent{
 										Namespace: configDefaultNamespace,
 										Name:      configDefaultName,
 									},
@@ -113,7 +113,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 				},
 			},
 		}
-		_, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
+		_, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		assertClusterManagementAddOnAnnotations(testAddOnConfigsImpl.name)
@@ -129,7 +129,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 		// prepare manifestwork obj
 		for i := 0; i < 4; i++ {
 			obj := &unstructured.Unstructured{}
-			err := obj.UnmarshalJSON([]byte(upgradeDeploymentJsonBeta))
+			err := obj.UnmarshalJSON([]byte(upgradeDeploymentJson))
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			testAddOnConfigsImpl.manifests[clusterNames[i]] = []runtime.Object{obj}
 		}
@@ -154,18 +154,18 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 		_, err = hubKubeClient.CoreV1().Namespaces().Create(context.Background(), configDefaultNS, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		err = createAddOnDeploymentConfigBeta(hubAddonClient, configDefaultNamespace, configDefaultName, addOnDefaultConfigSpecBeta)
+		err = createAddOnDeploymentConfigAlpha(hubAddonClient, configDefaultNamespace, configDefaultName, addOnDefaultConfigSpecAlpha)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// prepare update config
-		err = createAddOnDeploymentConfigBeta(hubAddonClient, configDefaultNamespace, configUpdateName, addOnTest2ConfigSpecBeta)
+		err = createAddOnDeploymentConfigAlpha(hubAddonClient, configDefaultNamespace, configUpdateName, addOnTest2ConfigSpecAlpha)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	ginkgo.AfterEach(func() {
 		err = hubKubeClient.CoreV1().Namespaces().Delete(context.Background(), configDefaultNamespace, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Delete(context.Background(), testAddOnConfigsImpl.name, metav1.DeleteOptions{})
+		err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Delete(context.Background(), testAddOnConfigsImpl.name, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		for _, managedClusterName := range clusterNames {
 			err = hubKubeClient.CoreV1().Namespaces().Delete(context.Background(), managedClusterName, metav1.DeleteOptions{})
@@ -203,27 +203,39 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 
 			ginkgo.By("check mca status")
 			for i := 0; i < 4; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configDefaultName,
+					},
 					LastObservedGeneration: 1,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnDefaultConfigSpecHash,
 					},
-					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+					LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnDefaultConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
-					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
 					Message: "Configurations configured",
@@ -231,30 +243,30 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			}
 
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name, addonapiv1beta1.InstallProgression{
-				PlacementRef: addonapiv1beta1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
-				ConfigReferences: []addonapiv1beta1.InstallConfigReference{
+			assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+				PlacementRef: addonapiv1alpha1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
+				ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
-						DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configDefaultName,
 							},
 							SpecHash: addOnDefaultConfigSpecHash,
 						},
-						LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configDefaultName,
 							},
 							SpecHash: addOnDefaultConfigSpecHash,
 						},
-						LastKnownGoodConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastKnownGoodConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configDefaultName,
 							},
@@ -264,39 +276,51 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 				},
 			})
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
-				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 				Message: "selected clusters 4. configured addons 4/4 completed with no errors, 0 failed 0 timeout.",
 			})
 
 			ginkgo.By("update all")
 			ginkgo.By("upgrade configs to test1")
-			updateAddOnDeploymentConfigSpecBeta(hubAddonClient, configDefaultNamespace, configDefaultName, addOnTest1ConfigSpecBeta)
+			updateAddOnDeploymentConfigSpecAlpha(hubAddonClient, configDefaultNamespace, configDefaultName, addOnTest1ConfigSpecAlpha)
 
 			ginkgo.By("check mca status")
 			for i := 0; i < 4; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configDefaultName,
+					},
 					LastObservedGeneration: 2,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
-					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+					LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
-					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
 					Message: "Configurations configured",
@@ -304,30 +328,30 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			}
 
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name, addonapiv1beta1.InstallProgression{
-				PlacementRef: addonapiv1beta1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
-				ConfigReferences: []addonapiv1beta1.InstallConfigReference{
+			assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+				PlacementRef: addonapiv1alpha1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
+				ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
-						DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configDefaultName,
 							},
 							SpecHash: addOnTest1ConfigSpecHash,
 						},
-						LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configDefaultName,
 							},
 							SpecHash: addOnTest1ConfigSpecHash,
 						},
-						LastKnownGoodConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastKnownGoodConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configDefaultName,
 							},
@@ -337,9 +361,9 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 				},
 			})
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
-				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 				Message: "selected clusters 4. configured addons 4/4 completed with no errors, 0 failed 0 timeout.",
 			})
 
@@ -350,7 +374,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 
 			ginkgo.By("rolling upgrade per cluster with ProgressDeadline and MaxFailures")
 			ginkgo.By("update cma to rolling update")
-			cma, err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
+			cma, err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			cma.Spec.InstallStrategy.Placements[0].RolloutStrategy = clusterv1alpha1.RolloutStrategy{
 				Type: clusterv1alpha1.Progressive,
@@ -361,57 +385,77 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						MaxFailures:      intstr.FromInt32(1),
 					}},
 			}
-			cma.Spec.InstallStrategy.Placements[0].Configs[0].ConfigReferent = addonapiv1beta1.ConfigReferent{Namespace: configDefaultNamespace, Name: configUpdateName}
+			cma.Spec.InstallStrategy.Placements[0].Configs[0].ConfigReferent = addonapiv1alpha1.ConfigReferent{Namespace: configDefaultNamespace, Name: configUpdateName}
 			start := metav1.Now()
-			patchClusterManagementAddOnBeta(context.Background(), cma)
+			patchClusterManagementAddOnAlpha(context.Background(), cma)
 
 			ginkgo.By("check mca status")
 			for i := 0; i < 2; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configUpdateName,
+					},
 					LastObservedGeneration: 1,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionTrue,
-					Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+					Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 					Message: "progressing... work is not ready",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
 					Message: "Configurations configured",
 				})
 			}
 			for i := 2; i < 4; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configDefaultName,
+					},
 					LastObservedGeneration: 2,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
-					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+					LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
-					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionFalse,
 					Reason:  "ConfigurationsNotConfigured",
 					Message: "Configurations updated and not configured yet",
@@ -419,16 +463,16 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			}
 
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name, addonapiv1beta1.InstallProgression{
-				PlacementRef: addonapiv1beta1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
-				ConfigReferences: []addonapiv1beta1.InstallConfigReference{
+			assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+				PlacementRef: addonapiv1alpha1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
+				ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
-						DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
@@ -438,23 +482,23 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 				},
 			})
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
-				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 2/4 progressing..., 0 failed 0 timeout.",
 			})
 
 			ginkgo.By("timeout after ProgressDeadline 5s and stop rollout since breach MaxFailures 1")
 			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 5*time.Second, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
-				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 0/4 progressing..., 0 failed 2 timeout.",
 			})
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
-				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 0/4 progressing..., 0 failed 2 timeout.",
 			})
 
@@ -468,27 +512,39 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 
 			ginkgo.By("check mca status")
 			for i := 0; i < 2; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configUpdateName,
+					},
 					LastObservedGeneration: 1,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
-					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+					LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
-					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
 					Message: "Configurations configured",
@@ -497,9 +553,9 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 
 			ginkgo.By("check cma status")
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
-				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 4/4 progressing..., 0 failed 0 timeout.",
 			})
 
@@ -510,57 +566,69 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 
 			ginkgo.By("check mca status")
 			for i := 2; i < 4; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configUpdateName,
+					},
 					LastObservedGeneration: 1,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
-					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+					LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
-					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
 					Message: "Configurations configured",
 				})
 			}
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name, addonapiv1beta1.InstallProgression{
-				PlacementRef: addonapiv1beta1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
-				ConfigReferences: []addonapiv1beta1.InstallConfigReference{
+			assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+				PlacementRef: addonapiv1alpha1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
+				ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
-						DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
 							SpecHash: addOnTest2ConfigSpecHash,
 						},
-						LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
 							SpecHash: addOnTest2ConfigSpecHash,
 						},
-						LastKnownGoodConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastKnownGoodConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
@@ -570,9 +638,9 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 				},
 			})
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
-				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 				Message: "selected clusters 4. configured addons 4/4 completed with no errors, 0 failed 0 timeout.",
 			})
 
@@ -583,7 +651,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 
 			ginkgo.By("rolling upgrade per group with MinSuccessTime")
 			ginkgo.By("update cma to rolling update per group")
-			cma, err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
+			cma, err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), cma.Name, metav1.GetOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			cma.Spec.InstallStrategy.Placements[0].RolloutStrategy = clusterv1alpha1.RolloutStrategy{
 				Type: clusterv1alpha1.ProgressivePerGroup,
@@ -594,61 +662,85 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						},
 					}},
 			}
-			patchClusterManagementAddOnBeta(context.Background(), cma)
+			patchClusterManagementAddOnAlpha(context.Background(), cma)
 
 			ginkgo.By("upgrade configs to test3")
-			updateAddOnDeploymentConfigSpecBeta(hubAddonClient, configDefaultNamespace, configUpdateName, addOnTest3ConfigSpecBeta)
+			updateAddOnDeploymentConfigSpecAlpha(hubAddonClient, configDefaultNamespace, configUpdateName, addOnTest3ConfigSpecAlpha)
 
 			ginkgo.By("check mca status")
 			for i := 0; i < 2; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configUpdateName,
+					},
 					LastObservedGeneration: 2,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest3ConfigSpecHash,
 					},
-					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+					LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionTrue,
-					Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+					Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 					Message: "progressing... work is not ready",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
 					Message: "Configurations configured",
 				})
 			}
 			for i := 2; i < 4; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configUpdateName,
+					},
 					LastObservedGeneration: 2,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
-					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+					LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
-					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionFalse,
 					Reason:  "ConfigurationsNotConfigured",
 					Message: "Configurations updated and not configured yet",
@@ -656,30 +748,30 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			}
 
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name, addonapiv1beta1.InstallProgression{
-				PlacementRef: addonapiv1beta1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
-				ConfigReferences: []addonapiv1beta1.InstallConfigReference{
+			assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+				PlacementRef: addonapiv1alpha1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
+				ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
-						DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
 							SpecHash: addOnTest3ConfigSpecHash,
 						},
-						LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
 							SpecHash: addOnTest2ConfigSpecHash,
 						},
-						LastKnownGoodConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastKnownGoodConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
@@ -689,9 +781,9 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 				},
 			})
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
-				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 2/4 progressing..., 0 failed 0 timeout.",
 			})
 
@@ -704,41 +796,53 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 				updateManifestWorkStatus(hubWorkClient, clusterNames[i], manifestWorkName, metav1.ConditionFalse)
 			}
 			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
-				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 4/4 progressing..., 0 failed 0 timeout.",
 			})
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
-				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
+				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 4/4 progressing..., 0 failed 0 timeout.",
 			})
 
 			ginkgo.By("check mca status")
 			for i := 0; i < 2; i++ {
-				assertManagedClusterAddOnConfigReferencesBeta(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1beta1.ConfigReference{
-					ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+				assertManagedClusterAddOnConfigReferencesAlpha(testAddOnConfigsImpl.name, clusterNames[i], addonapiv1alpha1.ConfigReference{
+					ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 						Group:    addOnDeploymentConfigGVR.Group,
 						Resource: addOnDeploymentConfigGVR.Resource,
 					},
+					ConfigReferent: addonapiv1alpha1.ConfigReferent{
+						Namespace: configDefaultNamespace,
+						Name:      configUpdateName,
+					},
 					LastObservedGeneration: 2,
-					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+					DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest3ConfigSpecHash,
 					},
-					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+					LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+						ConfigReferent: addonapiv1alpha1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest3ConfigSpecHash,
 					},
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
-					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
 				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
-					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
+					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
 					Message: "Configurations configured",
@@ -746,30 +850,30 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			}
 
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name, addonapiv1beta1.InstallProgression{
-				PlacementRef: addonapiv1beta1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
-				ConfigReferences: []addonapiv1beta1.InstallConfigReference{
+			assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+				PlacementRef: addonapiv1alpha1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
+				ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
-						DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
 							SpecHash: addOnTest3ConfigSpecHash,
 						},
-						LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
 							SpecHash: addOnTest2ConfigSpecHash,
 						},
-						LastKnownGoodConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastKnownGoodConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
@@ -785,43 +889,43 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 				updateManifestWorkStatus(hubWorkClient, clusterNames[i], manifestWorkName, metav1.ConditionTrue)
 			}
 			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
-				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 				Message: "selected clusters 4. configured addons 4/4 completed with no errors, 0 failed 0 timeout.",
 			})
 			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
-				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
+				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
-				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
+				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 				Message: "selected clusters 4. configured addons 4/4 completed with no errors, 0 failed 0 timeout.",
 			})
 
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnInstallProgressionBeta(testAddOnConfigsImpl.name, addonapiv1beta1.InstallProgression{
-				PlacementRef: addonapiv1beta1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
-				ConfigReferences: []addonapiv1beta1.InstallConfigReference{
+			assertClusterManagementAddOnInstallProgressionAlpha(testAddOnConfigsImpl.name, addonapiv1alpha1.InstallProgression{
+				PlacementRef: addonapiv1alpha1.PlacementRef{Name: placementNamespace, Namespace: placementNamespace},
+				ConfigReferences: []addonapiv1alpha1.InstallConfigReference{
 					{
-						ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+						ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
 							Group:    addOnDeploymentConfigGVR.Group,
 							Resource: addOnDeploymentConfigGVR.Resource,
 						},
-						DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						DesiredConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
 							SpecHash: addOnTest3ConfigSpecHash,
 						},
-						LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastAppliedConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},
 							SpecHash: addOnTest3ConfigSpecHash,
 						},
-						LastKnownGoodConfig: &addonapiv1beta1.ConfigSpecHash{
-							ConfigReferent: addonapiv1beta1.ConfigReferent{
+						LastKnownGoodConfig: &addonapiv1alpha1.ConfigSpecHash{
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
 								Namespace: configDefaultNamespace,
 								Name:      configUpdateName,
 							},

--- a/test/integration/addon/addon_manager_upgrade_alpha_test.go
+++ b/test/integration/addon/addon_manager_upgrade_alpha_test.go
@@ -74,6 +74,7 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 	var cma *addonapiv1alpha1.ClusterManagementAddOn
 
 	ginkgo.BeforeEach(func() {
+		clusterNames = nil
 		suffix = rand.String(5)
 		configDefaultNamespace = fmt.Sprintf("default-config-%s", suffix)
 		configDefaultName = fmt.Sprintf("default-config-%s", suffix)
@@ -116,7 +117,7 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 		_, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(testAddOnConfigsImpl.name)
+		assertClusterManagementAddOnAnnotationsAlpha(testAddOnConfigsImpl.name)
 
 		// prepare cluster
 		for i := 0; i < 4; i++ {
@@ -228,13 +229,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnDefaultConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -275,7 +276,7 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
@@ -313,13 +314,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -360,7 +361,7 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
@@ -409,13 +410,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionTrue,
 					Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 					Message: "progressing... work is not ready",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -448,13 +449,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionFalse,
 					Reason:  "ConfigurationsNotConfigured",
@@ -481,7 +482,7 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
@@ -489,13 +490,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 			})
 
 			ginkgo.By("timeout after ProgressDeadline 5s and stop rollout since breach MaxFailures 1")
-			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 5*time.Second, metav1.Condition{
+			assertClusterManagementAddOnNoConditionsAlpha(testAddOnConfigsImpl.name, start, 5*time.Second, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 0/4 progressing..., 0 failed 2 timeout.",
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
@@ -537,13 +538,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -552,7 +553,7 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 			}
 
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
@@ -591,13 +592,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -637,7 +638,7 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
@@ -694,13 +695,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionTrue,
 					Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 					Message: "progressing... work is not ready",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -733,13 +734,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionFalse,
 					Reason:  "ConfigurationsNotConfigured",
@@ -780,7 +781,7 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
@@ -795,13 +796,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 			for i := 2; i < 4; i++ {
 				updateManifestWorkStatus(hubWorkClient, clusterNames[i], manifestWorkName, metav1.ConditionFalse)
 			}
-			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
+			assertClusterManagementAddOnNoConditionsAlpha(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 4/4 progressing..., 0 failed 0 timeout.",
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1alpha1.ProgressingReasonProgressing,
@@ -835,13 +836,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 						SpecHash: addOnTest3ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsAlpha(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1alpha1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -888,13 +889,13 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 			for i := 2; i < 4; i++ {
 				updateManifestWorkStatus(hubWorkClient, clusterNames[i], manifestWorkName, metav1.ConditionTrue)
 			}
-			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
+			assertClusterManagementAddOnNoConditionsAlpha(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,
 				Message: "selected clusters 4. configured addons 4/4 completed with no errors, 0 failed 0 timeout.",
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsAlpha(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1alpha1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1alpha1.ProgressingReasonCompleted,

--- a/test/integration/addon/addon_manager_upgrade_alpha_test.go
+++ b/test/integration/addon/addon_manager_upgrade_alpha_test.go
@@ -369,6 +369,12 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 			})
 
 			ginkgo.By("update work status to avoid addon status update")
+			// Capture start BEFORE updating work status. When the work status changes to False,
+			// the controller will set the addon Progressing condition with a LastTransitionTime.
+			// The rollout SDK uses that LastTransitionTime (not the CMA patch time) as the base
+			// for ProgressDeadline timeout calculation. If we capture start after the work update,
+			// the controller's timeout can fire before our expected 5s duration from start.
+			start := metav1.Now()
 			for i := 0; i < 2; i++ {
 				updateManifestWorkStatus(hubWorkClient, clusterNames[i], manifestWorkName, metav1.ConditionFalse)
 			}
@@ -387,7 +393,6 @@ var _ = ginkgo.Describe("Addon upgrade Alpha", func() {
 					}},
 			}
 			cma.Spec.InstallStrategy.Placements[0].Configs[0].ConfigReferent = addonapiv1alpha1.ConfigReferent{Namespace: configDefaultNamespace, Name: configUpdateName}
-			start := metav1.Now()
 			patchClusterManagementAddOnAlpha(context.Background(), cma)
 
 			ginkgo.By("check mca status")

--- a/test/integration/addon/addon_manager_upgrade_test.go
+++ b/test/integration/addon/addon_manager_upgrade_test.go
@@ -74,6 +74,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 	var cma *addonapiv1beta1.ClusterManagementAddOn
 
 	ginkgo.BeforeEach(func() {
+		clusterNames = nil
 		suffix = rand.String(5)
 		configDefaultNamespace = fmt.Sprintf("default-config-%s", suffix)
 		configDefaultName = fmt.Sprintf("default-config-%s", suffix)
@@ -116,7 +117,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 		_, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Create(context.Background(), cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(testAddOnConfigsImpl.name)
+		assertClusterManagementAddOnAnnotationsBeta(testAddOnConfigsImpl.name)
 
 		// prepare cluster
 		for i := 0; i < 4; i++ {
@@ -224,13 +225,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnDefaultConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -271,7 +272,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
@@ -305,13 +306,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -352,7 +353,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
@@ -397,13 +398,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionTrue,
 					Reason:  addonapiv1beta1.ProgressingReasonProgressing,
 					Message: "progressing... work is not ready",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -432,13 +433,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionFalse,
 					Reason:  "ConfigurationsNotConfigured",
@@ -465,7 +466,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
@@ -473,13 +474,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			})
 
 			ginkgo.By("timeout after ProgressDeadline 5s and stop rollout since breach MaxFailures 1")
-			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 5*time.Second, metav1.Condition{
+			assertClusterManagementAddOnNoConditionsBeta(testAddOnConfigsImpl.name, start, 5*time.Second, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 0/4 progressing..., 0 failed 2 timeout.",
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
@@ -517,13 +518,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -532,7 +533,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			}
 
 			ginkgo.By("check cma status")
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
@@ -567,13 +568,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -613,7 +614,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
@@ -666,13 +667,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionTrue,
 					Reason:  addonapiv1beta1.ProgressingReasonProgressing,
 					Message: "progressing... work is not ready",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -701,13 +702,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionFalse,
 					Reason:  "ConfigurationsNotConfigured",
@@ -748,7 +749,7 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 				},
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
@@ -763,13 +764,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			for i := 2; i < 4; i++ {
 				updateManifestWorkStatus(hubWorkClient, clusterNames[i], manifestWorkName, metav1.ConditionFalse)
 			}
-			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
+			assertClusterManagementAddOnNoConditionsBeta(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
 				Message: "selected clusters 4. configured addons 4/4 progressing..., 0 failed 0 timeout.",
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionTrue,
 				Reason:  addonapiv1beta1.ProgressingReasonProgressing,
@@ -799,13 +800,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 						SpecHash: addOnTest3ConfigSpecHash,
 					},
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 					Status:  metav1.ConditionFalse,
 					Reason:  addonapiv1beta1.ProgressingReasonCompleted,
 					Message: "completed with no errors.",
 				})
-				assertManagedClusterAddOnConditions(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
+				assertManagedClusterAddOnConditionsBeta(testAddOnConfigsImpl.name, clusterNames[i], metav1.Condition{
 					Type:    addonapiv1beta1.ManagedClusterAddOnConditionConfigured,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ConfigurationsConfigured",
@@ -852,13 +853,13 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			for i := 2; i < 4; i++ {
 				updateManifestWorkStatus(hubWorkClient, clusterNames[i], manifestWorkName, metav1.ConditionTrue)
 			}
-			assertClusterManagementAddOnNoConditions(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
+			assertClusterManagementAddOnNoConditionsBeta(testAddOnConfigsImpl.name, start, 3*time.Second, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1beta1.ProgressingReasonCompleted,
 				Message: "selected clusters 4. configured addons 4/4 completed with no errors, 0 failed 0 timeout.",
 			})
-			assertClusterManagementAddOnConditions(testAddOnConfigsImpl.name, metav1.Condition{
+			assertClusterManagementAddOnConditionsBeta(testAddOnConfigsImpl.name, metav1.Condition{
 				Type:    addonapiv1beta1.ManagedClusterAddOnConditionProgressing,
 				Status:  metav1.ConditionFalse,
 				Reason:  addonapiv1beta1.ProgressingReasonCompleted,

--- a/test/integration/addon/addon_manager_upgrade_test.go
+++ b/test/integration/addon/addon_manager_upgrade_test.go
@@ -361,6 +361,12 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 			})
 
 			ginkgo.By("update work status to avoid addon status update")
+			// Capture start BEFORE updating work status. When the work status changes to False,
+			// the controller will set the addon Progressing condition with a LastTransitionTime.
+			// The rollout SDK uses that LastTransitionTime (not the CMA patch time) as the base
+			// for ProgressDeadline timeout calculation. If we capture start after the work update,
+			// the controller's timeout can fire before our expected 5s duration from start.
+			start := metav1.Now()
 			for i := 0; i < 2; i++ {
 				updateManifestWorkStatus(hubWorkClient, clusterNames[i], manifestWorkName, metav1.ConditionFalse)
 			}
@@ -379,7 +385,6 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					}},
 			}
 			cma.Spec.InstallStrategy.Placements[0].Configs[0].ConfigReferent = addonapiv1beta1.ConfigReferent{Namespace: configDefaultNamespace, Name: configUpdateName}
-			start := metav1.Now()
 			patchClusterManagementAddOnBeta(context.Background(), cma)
 
 			ginkgo.By("check mca status")

--- a/test/integration/addon/addon_manager_upgrade_test.go
+++ b/test/integration/addon/addon_manager_upgrade_test.go
@@ -210,9 +210,17 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 1,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnDefaultConfigSpecHash,
 					},
 					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnDefaultConfigSpecHash,
 					},
 				})
@@ -283,9 +291,17 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 2,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 				})
@@ -374,6 +390,10 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 1,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
@@ -398,9 +418,17 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 2,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configDefaultName,
+						},
 						SpecHash: addOnTest1ConfigSpecHash,
 					},
 				})
@@ -475,9 +503,17 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 1,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
@@ -517,9 +553,17 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 1,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
@@ -608,9 +652,17 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 2,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest3ConfigSpecHash,
 					},
 					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
@@ -635,9 +687,17 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 2,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest2ConfigSpecHash,
 					},
 				})
@@ -725,9 +785,17 @@ var _ = ginkgo.Describe("Addon upgrade Beta", func() {
 					},
 					LastObservedGeneration: 2,
 					DesiredConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest3ConfigSpecHash,
 					},
 					LastAppliedConfig: &addonapiv1beta1.ConfigSpecHash{
+						ConfigReferent: addonapiv1beta1.ConfigReferent{
+							Namespace: configDefaultNamespace,
+							Name:      configUpdateName,
+						},
 						SpecHash: addOnTest3ConfigSpecHash,
 					},
 				})

--- a/test/integration/addon/agent_deploy_alpha_test.go
+++ b/test/integration/addon/agent_deploy_alpha_test.go
@@ -17,13 +17,13 @@ import (
 
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
 	"open-cluster-management.io/addon-framework/pkg/agent"
-	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 )
 
 const (
-	deploymentJsonBeta = `{
+	deploymentJson = `{
 		"apiVersion": "apps/v1",
 		"kind": "Deployment",
 		"metadata": {
@@ -63,7 +63,7 @@ const (
 	}`
 )
 
-var _ = ginkgo.Describe("Agent deploy Beta", func() {
+var _ = ginkgo.Describe("Agent deploy Alpha", func() {
 	var managedClusterName string
 	var err error
 	var manifestWorkName string
@@ -87,8 +87,8 @@ var _ = ginkgo.Describe("Agent deploy Beta", func() {
 		_, err = hubKubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		cma := newClusterManagementAddonBeta(testAddonImpl.name)
-		_, err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Create(context.Background(),
+		cma := newClusterManagementAddonAlpha(testAddonImpl.name)
+		_, err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Create(context.Background(),
 			cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
@@ -100,14 +100,14 @@ var _ = ginkgo.Describe("Agent deploy Beta", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		err = hubClusterClient.ClusterV1().ManagedClusters().Delete(context.Background(), managedClusterName, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Delete(context.Background(),
+		err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Delete(context.Background(),
 			testAddonImpl.name, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	})
 
 	ginkgo.It("Should deploy agent when cma is managed by addon-manager successfully", func() {
 		obj := &unstructured.Unstructured{}
-		err := obj.UnmarshalJSON([]byte(deploymentJsonBeta))
+		err := obj.UnmarshalJSON([]byte(deploymentJson))
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		testAddonImpl.manifests[managedClusterName] = []runtime.Object{obj}
 		testAddonImpl.prober = &agent.HealthProber{
@@ -115,13 +115,15 @@ var _ = ginkgo.Describe("Agent deploy Beta", func() {
 		}
 
 		// Create ManagedClusterAddOn
-		addon := &addonapiv1beta1.ManagedClusterAddOn{
+		addon := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testAddonImpl.name,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{},
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: "default",
+			},
 		}
-		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addon, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		gomega.Eventually(func() error {
@@ -134,7 +136,7 @@ var _ = ginkgo.Describe("Agent deploy Beta", func() {
 				return fmt.Errorf("unexpected number of work manifests")
 			}
 
-			if apiequality.Semantic.DeepEqual(work.Spec.Workload.Manifests[0].Raw, []byte(deploymentJsonBeta)) {
+			if apiequality.Semantic.DeepEqual(work.Spec.Workload.Manifests[0].Raw, []byte(deploymentJson)) {
 				return fmt.Errorf("expected manifest is no correct, get %v", work.Spec.Workload.Manifests[0].Raw)
 			}
 			return nil
@@ -150,15 +152,15 @@ var _ = ginkgo.Describe("Agent deploy Beta", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		gomega.Eventually(func() error {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), testAddonImpl.name, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), testAddonImpl.name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
-			if !meta.IsStatusConditionTrue(addon.Status.Conditions, addonapiv1beta1.ManagedClusterAddOnManifestApplied) {
+			if !meta.IsStatusConditionTrue(addon.Status.Conditions, addonapiv1alpha1.ManagedClusterAddOnManifestApplied) {
 				return fmt.Errorf("unexpected addon applied condition, %v", addon.Status.Conditions)
 			}
-			if !meta.IsStatusConditionTrue(addon.Status.Conditions, addonapiv1beta1.ManagedClusterAddOnConditionProgressing) {
+			if !meta.IsStatusConditionTrue(addon.Status.Conditions, addonapiv1alpha1.ManagedClusterAddOnConditionProgressing) {
 				return fmt.Errorf("unexpected addon progressing condition, %v", addon.Status.Conditions)
 			}
 			return nil
@@ -174,15 +176,15 @@ var _ = ginkgo.Describe("Agent deploy Beta", func() {
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		gomega.Eventually(func() error {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), testAddonImpl.name, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), testAddonImpl.name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
-			if !meta.IsStatusConditionTrue(addon.Status.Conditions, addonapiv1beta1.ManagedClusterAddOnConditionAvailable) {
+			if !meta.IsStatusConditionTrue(addon.Status.Conditions, addonapiv1alpha1.ManagedClusterAddOnConditionAvailable) {
 				return fmt.Errorf("unexpected addon available condition, %v", addon.Status.Conditions)
 			}
-			if !meta.IsStatusConditionFalse(addon.Status.Conditions, addonapiv1beta1.ManagedClusterAddOnConditionProgressing) {
+			if !meta.IsStatusConditionFalse(addon.Status.Conditions, addonapiv1alpha1.ManagedClusterAddOnConditionProgressing) {
 				return fmt.Errorf("unexpected addon progressing condition, %v", addon.Status.Conditions)
 			}
 			return nil

--- a/test/integration/addon/agent_deploy_alpha_test.go
+++ b/test/integration/addon/agent_deploy_alpha_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -92,7 +93,7 @@ var _ = ginkgo.Describe("Agent deploy Alpha", func() {
 			cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(testAddonImpl.name)
+		assertClusterManagementAddOnAnnotationsAlpha(testAddonImpl.name)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -136,8 +137,16 @@ var _ = ginkgo.Describe("Agent deploy Alpha", func() {
 				return fmt.Errorf("unexpected number of work manifests")
 			}
 
-			if apiequality.Semantic.DeepEqual(work.Spec.Workload.Manifests[0].Raw, []byte(deploymentJson)) {
-				return fmt.Errorf("expected manifest is no correct, get %v", work.Spec.Workload.Manifests[0].Raw)
+			// Unmarshal both JSONs and compare semantically (not byte-for-byte)
+			var expected, actual map[string]interface{}
+			if err := json.Unmarshal([]byte(deploymentJson), &expected); err != nil {
+				return fmt.Errorf("failed to unmarshal expected JSON: %v", err)
+			}
+			if err := json.Unmarshal(work.Spec.Workload.Manifests[0].Raw, &actual); err != nil {
+				return fmt.Errorf("failed to unmarshal actual JSON: %v", err)
+			}
+			if !apiequality.Semantic.DeepEqual(expected, actual) {
+				return fmt.Errorf("expected manifest does not match actual, got %v", string(work.Spec.Workload.Manifests[0].Raw))
 			}
 			return nil
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())

--- a/test/integration/addon/agent_deploy_test.go
+++ b/test/integration/addon/agent_deploy_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -92,7 +93,7 @@ var _ = ginkgo.Describe("Agent deploy Beta", func() {
 			cma, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		assertClusterManagementAddOnAnnotations(testAddonImpl.name)
+		assertClusterManagementAddOnAnnotationsBeta(testAddonImpl.name)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -134,8 +135,16 @@ var _ = ginkgo.Describe("Agent deploy Beta", func() {
 				return fmt.Errorf("unexpected number of work manifests")
 			}
 
-			if apiequality.Semantic.DeepEqual(work.Spec.Workload.Manifests[0].Raw, []byte(deploymentJsonBeta)) {
-				return fmt.Errorf("expected manifest is no correct, get %v", work.Spec.Workload.Manifests[0].Raw)
+			// Unmarshal both JSONs and compare semantically (not byte-for-byte)
+			var expected, actual map[string]interface{}
+			if err := json.Unmarshal([]byte(deploymentJsonBeta), &expected); err != nil {
+				return fmt.Errorf("failed to unmarshal expected JSON: %v", err)
+			}
+			if err := json.Unmarshal(work.Spec.Workload.Manifests[0].Raw, &actual); err != nil {
+				return fmt.Errorf("failed to unmarshal actual JSON: %v", err)
+			}
+			if !apiequality.Semantic.DeepEqual(expected, actual) {
+				return fmt.Errorf("expected manifest does not match actual, got %v", string(work.Spec.Workload.Manifests[0].Raw))
 			}
 			return nil
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())

--- a/test/integration/addon/assertion_test.go
+++ b/test/integration/addon/assertion_test.go
@@ -494,8 +494,8 @@ func assertManagedClusterAddOnConfigReferencesBeta(name, namespace string, expec
 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 }
 
-func assertClusterManagementAddOnAnnotations(name string) {
-	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %v Annotations", name))
+func assertClusterManagementAddOnAnnotationsAlpha(name string) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %v Annotations (Alpha)", name))
 
 	gomega.Eventually(func() error {
 		actual, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
@@ -510,6 +510,18 @@ func assertClusterManagementAddOnAnnotations(name string) {
 		}
 
 		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+func assertClusterManagementAddOnAnnotationsBeta(name string) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %v Annotations (Beta)", name))
+
+	// Note: The AddonLifecycleAnnotationKey was removed in v1beta1, so this assertion
+	// is a no-op for backward compatibility with test structure. In v1beta1, addon
+	// lifecycle management is always handled by the addon-manager.
+	gomega.Eventually(func() error {
+		_, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
+		return err
 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 }
 
@@ -584,8 +596,8 @@ func createPlacementDecision(hubClusterClient clusterv1client.Interface, placeme
 	return nil
 }
 
-func assertClusterManagementAddOnConditions(name string, expect ...metav1.Condition) {
-	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s Conditions", name))
+func assertClusterManagementAddOnConditionsAlpha(name string, expect ...metav1.Condition) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s Conditions (Alpha)", name))
 
 	gomega.Eventually(func() error {
 		actual, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
@@ -594,6 +606,9 @@ func assertClusterManagementAddOnConditions(name string, expect ...metav1.Condit
 		}
 
 		for i, ec := range expect {
+			if i >= len(actual.Status.InstallProgressions) {
+				return fmt.Errorf("expected %d install progressions, actual: %d", i+1, len(actual.Status.InstallProgressions))
+			}
 			cond := meta.FindStatusCondition(actual.Status.InstallProgressions[i].Conditions, ec.Type)
 			if cond == nil ||
 				cond.Status != ec.Status ||
@@ -607,8 +622,34 @@ func assertClusterManagementAddOnConditions(name string, expect ...metav1.Condit
 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 }
 
-func assertClusterManagementAddOnNoConditions(name string, start metav1.Time, duration time.Duration, expect ...metav1.Condition) {
-	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s no conditions in duration %v", name, duration))
+func assertClusterManagementAddOnConditionsBeta(name string, expect ...metav1.Condition) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s Conditions (Beta)", name))
+
+	gomega.Eventually(func() error {
+		actual, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		for i, ec := range expect {
+			if i >= len(actual.Status.InstallProgressions) {
+				return fmt.Errorf("expected %d install progressions, actual: %d", i+1, len(actual.Status.InstallProgressions))
+			}
+			cond := meta.FindStatusCondition(actual.Status.InstallProgressions[i].Conditions, ec.Type)
+			if cond == nil ||
+				cond.Status != ec.Status ||
+				cond.Reason != ec.Reason ||
+				cond.Message != ec.Message {
+				return fmt.Errorf("expected cma progressing condition is %v, actual: %v", ec, cond)
+			}
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+func assertClusterManagementAddOnNoConditionsAlpha(name string, start metav1.Time, duration time.Duration, expect ...metav1.Condition) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s no conditions in duration %v (Alpha)", name, duration))
 
 	gomega.Consistently(func() error {
 		actual, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
@@ -621,6 +662,9 @@ func assertClusterManagementAddOnNoConditions(name string, start metav1.Time, du
 		// Only check if we haven't reached the expected timeout duration yet
 		if elapsedTime < duration {
 			for i, ec := range expect {
+				if i >= len(actual.Status.InstallProgressions) {
+					return fmt.Errorf("expected %d install progressions, actual: %d", i+1, len(actual.Status.InstallProgressions))
+				}
 				cond := meta.FindStatusCondition(actual.Status.InstallProgressions[i].Conditions, ec.Type)
 
 				// The expected timeout condition should NOT appear before the duration
@@ -637,11 +681,67 @@ func assertClusterManagementAddOnNoConditions(name string, start metav1.Time, du
 	}, duration+2*time.Second, eventuallyInterval).Should(gomega.BeNil())
 }
 
-func assertManagedClusterAddOnConditions(name, namespace string, expect ...metav1.Condition) {
-	ginkgo.By(fmt.Sprintf("Check ManagedClusterAddOn %s/%s Conditions", namespace, name))
+func assertClusterManagementAddOnNoConditionsBeta(name string, start metav1.Time, duration time.Duration, expect ...metav1.Condition) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s no conditions in duration %v (Beta)", name, duration))
+
+	gomega.Consistently(func() error {
+		actual, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		elapsedTime := metav1.Now().Sub(start.Time)
+
+		// Only check if we haven't reached the expected timeout duration yet
+		if elapsedTime < duration {
+			for i, ec := range expect {
+				if i >= len(actual.Status.InstallProgressions) {
+					return fmt.Errorf("expected %d install progressions, actual: %d", i+1, len(actual.Status.InstallProgressions))
+				}
+				cond := meta.FindStatusCondition(actual.Status.InstallProgressions[i].Conditions, ec.Type)
+
+				// The expected timeout condition should NOT appear before the duration
+				if cond != nil &&
+					cond.Status == ec.Status &&
+					cond.Reason == ec.Reason &&
+					cond.Message == ec.Message {
+					return fmt.Errorf("unexpected condition matches before duration (elapsed: %v, expected: %v)", elapsedTime, duration)
+				}
+			}
+		}
+
+		return nil
+	}, duration+2*time.Second, eventuallyInterval).Should(gomega.BeNil())
+}
+
+func assertManagedClusterAddOnConditionsAlpha(name, namespace string, expect ...metav1.Condition) {
+	ginkgo.By(fmt.Sprintf("Check ManagedClusterAddOn %s/%s Conditions (Alpha)", namespace, name))
 
 	gomega.Eventually(func() error {
 		actual, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, ec := range expect {
+			cond := meta.FindStatusCondition(actual.Status.Conditions, ec.Type)
+			if cond == nil ||
+				cond.Status != ec.Status ||
+				cond.Reason != ec.Reason ||
+				cond.Message != ec.Message {
+				return fmt.Errorf("expected addon progressing condition is %v, actual: %v", ec, cond)
+			}
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+func assertManagedClusterAddOnConditionsBeta(name, namespace string, expect ...metav1.Condition) {
+	ginkgo.By(fmt.Sprintf("Check ManagedClusterAddOn %s/%s Conditions (Beta)", namespace, name))
+
+	gomega.Eventually(func() error {
+		actual, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}

--- a/test/integration/addon/assertion_test.go
+++ b/test/integration/addon/assertion_test.go
@@ -164,6 +164,10 @@ func createClusterManagementAddOnBeta(name, defaultConfigNamespace, defaultConfi
 								Group:    addOnDeploymentConfigGVR.Group,
 								Resource: addOnDeploymentConfigGVR.Resource,
 							},
+							ConfigReferent: addonapiv1beta1.ConfigReferent{
+								Name:      defaultConfigName,
+								Namespace: defaultConfigNamespace,
+							},
 						},
 					},
 					InstallStrategy: addonapiv1beta1.InstallStrategy{

--- a/test/integration/addon/assertion_test.go
+++ b/test/integration/addon/assertion_test.go
@@ -14,7 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
+	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -25,12 +26,14 @@ import (
 
 // TODO: The spec hash is hardcoded here and will break the test once the API changes.
 // We need a better way to handle the spec hash.
+// Config spec hashes (same for both v1alpha1 and v1beta1 since structure is identical)
 const addOnDefaultConfigSpecHash = "ea4e6089e8b2f584c1cd8b86e16a15df3186b30744f433ede7436091c93a4cc7" //nolint:gosec
 const addOnTest1ConfigSpecHash = "b746cc98936955dd2168640f0011a14f2a74be306c747bc8ba829328cc772690"   //nolint:gosec
 const addOnTest2ConfigSpecHash = "3e6348b0c0f0a341ce28d0a2f99bc41fc63fb17d947eb5a45284729fbeb63b32"   //nolint:gosec
 const addOnTest3ConfigSpecHash = "9b3c6d09731ed254589fa4fc2936e6fb00537de92da5e035183da313eb98d27e"   //nolint:gosec
 
-var addOnDefaultConfigSpec = addonapiv1alpha1.AddOnDeploymentConfigSpec{
+// v1alpha1 config specs
+var addOnDefaultConfigSpecAlpha = addonapiv1alpha1.AddOnDeploymentConfigSpec{
 	CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
 		{
 			Name:  "test",
@@ -38,7 +41,8 @@ var addOnDefaultConfigSpec = addonapiv1alpha1.AddOnDeploymentConfigSpec{
 		},
 	},
 }
-var addOnTest1ConfigSpec = addonapiv1alpha1.AddOnDeploymentConfigSpec{
+
+var addOnTest1ConfigSpecAlpha = addonapiv1alpha1.AddOnDeploymentConfigSpec{
 	CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
 		{
 			Name:  "test1",
@@ -46,7 +50,8 @@ var addOnTest1ConfigSpec = addonapiv1alpha1.AddOnDeploymentConfigSpec{
 		},
 	},
 }
-var addOnTest2ConfigSpec = addonapiv1alpha1.AddOnDeploymentConfigSpec{
+
+var addOnTest2ConfigSpecAlpha = addonapiv1alpha1.AddOnDeploymentConfigSpec{
 	CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
 		{
 			Name:  "test2",
@@ -55,7 +60,7 @@ var addOnTest2ConfigSpec = addonapiv1alpha1.AddOnDeploymentConfigSpec{
 	},
 }
 
-var addOnTest3ConfigSpec = addonapiv1alpha1.AddOnDeploymentConfigSpec{
+var addOnTest3ConfigSpecAlpha = addonapiv1alpha1.AddOnDeploymentConfigSpec{
 	CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
 		{
 			Name:  "test3",
@@ -64,7 +69,44 @@ var addOnTest3ConfigSpec = addonapiv1alpha1.AddOnDeploymentConfigSpec{
 	},
 }
 
-func createClusterManagementAddOn(name, defaultConfigNamespace, defaultConfigName string) (*addonapiv1alpha1.ClusterManagementAddOn, error) {
+// v1beta1 config specs (structure is identical to v1alpha1)
+var addOnDefaultConfigSpecBeta = addonapiv1beta1.AddOnDeploymentConfigSpec{
+	CustomizedVariables: []addonapiv1beta1.CustomizedVariable{
+		{
+			Name:  "test",
+			Value: "test",
+		},
+	},
+}
+
+var addOnTest1ConfigSpecBeta = addonapiv1beta1.AddOnDeploymentConfigSpec{
+	CustomizedVariables: []addonapiv1beta1.CustomizedVariable{
+		{
+			Name:  "test1",
+			Value: "test1",
+		},
+	},
+}
+
+var addOnTest2ConfigSpecBeta = addonapiv1beta1.AddOnDeploymentConfigSpec{
+	CustomizedVariables: []addonapiv1beta1.CustomizedVariable{
+		{
+			Name:  "test2",
+			Value: "test2",
+		},
+	},
+}
+
+var addOnTest3ConfigSpecBeta = addonapiv1beta1.AddOnDeploymentConfigSpec{
+	CustomizedVariables: []addonapiv1beta1.CustomizedVariable{
+		{
+			Name:  "test3",
+			Value: "test3",
+		},
+	},
+}
+
+func createClusterManagementAddOnAlpha(name, defaultConfigNamespace, defaultConfigName string) (*addonapiv1alpha1.ClusterManagementAddOn, error) {
 	clusterManagementAddon, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		clusterManagementAddon, err = hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Create(
@@ -106,7 +148,45 @@ func createClusterManagementAddOn(name, defaultConfigNamespace, defaultConfigNam
 	return clusterManagementAddon, nil
 }
 
-func patchClusterManagementAddOn(_ context.Context, newaddon *addonapiv1alpha1.ClusterManagementAddOn) {
+func createClusterManagementAddOnBeta(name, defaultConfigNamespace, defaultConfigName string) (*addonapiv1beta1.ClusterManagementAddOn, error) {
+	clusterManagementAddon, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		clusterManagementAddon, err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Create(
+			context.Background(),
+			&addonapiv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
+					DefaultConfigs: []addonapiv1beta1.AddOnConfig{
+						{
+							ConfigGroupResource: addonapiv1beta1.ConfigGroupResource{
+								Group:    addOnDeploymentConfigGVR.Group,
+								Resource: addOnDeploymentConfigGVR.Resource,
+							},
+						},
+					},
+					InstallStrategy: addonapiv1beta1.InstallStrategy{
+						Type: addonapiv1beta1.AddonInstallStrategyManual,
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			return nil, err
+		}
+		return clusterManagementAddon, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return clusterManagementAddon, nil
+}
+
+func patchClusterManagementAddOnAlpha(_ context.Context, newaddon *addonapiv1alpha1.ClusterManagementAddOn) {
 	gomega.Eventually(func() error {
 		old, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), newaddon.Name, metav1.GetOptions{})
 		if err != nil {
@@ -129,7 +209,22 @@ func patchClusterManagementAddOn(_ context.Context, newaddon *addonapiv1alpha1.C
 	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 }
 
-func updateManagedClusterAddOnStatus(_ context.Context, new *addonapiv1alpha1.ManagedClusterAddOn) {
+func patchClusterManagementAddOnBeta(_ context.Context, newaddon *addonapiv1beta1.ClusterManagementAddOn) {
+	gomega.Eventually(func() error {
+		old, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), newaddon.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		new := old.DeepCopy()
+		new.Spec = *newaddon.Spec.DeepCopy()
+		new.Annotations = newaddon.Annotations
+
+		_, err = hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Update(context.Background(), new, metav1.UpdateOptions{})
+		return err
+	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+}
+
+func updateManagedClusterAddOnStatusAlpha(_ context.Context, new *addonapiv1alpha1.ManagedClusterAddOn) {
 	gomega.Eventually(func() error {
 		old, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(new.Namespace).Get(context.Background(), new.Name, metav1.GetOptions{})
 		if err != nil {
@@ -141,27 +236,20 @@ func updateManagedClusterAddOnStatus(_ context.Context, new *addonapiv1alpha1.Ma
 	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 }
 
-func assertClusterManagementAddOnAnnotations(name string) {
-	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %v Annotations", name))
-
+func updateManagedClusterAddOnStatusBeta(_ context.Context, new *addonapiv1beta1.ManagedClusterAddOn) {
 	gomega.Eventually(func() error {
-		actual, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
+		old, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(new.Namespace).Get(context.Background(), new.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-
-		if _, ok := actual.Annotations[addonapiv1alpha1.AddonLifecycleAnnotationKey]; ok {
-			return fmt.Errorf("expected annotation %v to be empty, actual: %v",
-				addonapiv1alpha1.AddonLifecycleAnnotationKey,
-				actual.Annotations[addonapiv1alpha1.AddonLifecycleAnnotationKey])
-		}
-
-		return nil
-	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		old.Status = new.Status
+		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(old.Namespace).UpdateStatus(context.Background(), old, metav1.UpdateOptions{})
+		return err
+	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 }
 
-func assertClusterManagementAddOnDefaultConfigReferences(name string, expect ...addonapiv1alpha1.DefaultConfigReference) {
-	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s DefaultConfigReferences", name))
+func assertClusterManagementAddOnDefaultConfigReferencesAlpha(name string, expect ...addonapiv1alpha1.DefaultConfigReference) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s DefaultConfigReferences (Alpha)", name))
 
 	gomega.Eventually(func() error {
 		actual, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
@@ -185,27 +273,33 @@ func assertClusterManagementAddOnDefaultConfigReferences(name string, expect ...
 	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 }
 
-func updateManifestWorkStatus(client workclientset.Interface, clusterName string, manifestWorkName string, status metav1.ConditionStatus) {
+func assertClusterManagementAddOnDefaultConfigReferencesBeta(name string, expect ...addonapiv1beta1.DefaultConfigReference) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s DefaultConfigReferences (Beta)", name))
+
 	gomega.Eventually(func() error {
-		work, err := client.WorkV1().ManifestWorks(clusterName).Get(context.Background(), manifestWorkName, metav1.GetOptions{})
+		actual, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
-		meta.SetStatusCondition(
-			&work.Status.Conditions,
-			metav1.Condition{Type: workapiv1.WorkApplied, Status: status, Reason: "WorkApplied", ObservedGeneration: work.Generation})
-		meta.SetStatusCondition(
-			&work.Status.Conditions,
-			metav1.Condition{Type: workapiv1.WorkAvailable, Status: status, Reason: "WorkAvailable", ObservedGeneration: work.Generation})
+		if len(actual.Status.DefaultConfigReferences) != len(expect) {
+			return fmt.Errorf("expected %v default config reference, actual: %v", len(expect), len(actual.Status.DefaultConfigReferences))
+		}
 
-		_, err = client.WorkV1().ManifestWorks(clusterName).UpdateStatus(context.Background(), work, metav1.UpdateOptions{})
-		return err
-	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+		for i, e := range expect {
+			actualConfigReference := actual.Status.DefaultConfigReferences[i]
+
+			if !apiequality.Semantic.DeepEqual(actualConfigReference, e) {
+				return fmt.Errorf("expected default config is %v, actual: %v", e, actualConfigReference)
+			}
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 }
 
-func createAddOnDeploymentConfig(
-	hubAddonClient addonv1alpha1client.Interface,
+func createAddOnDeploymentConfigAlpha(
+	hubAddonClient addonclient.Interface,
 	configNamespace string,
 	configName string,
 	configSpec addonapiv1alpha1.AddOnDeploymentConfigSpec,
@@ -222,8 +316,26 @@ func createAddOnDeploymentConfig(
 	return err
 }
 
-func updateAddOnDeploymentConfigSpec(
-	hubAddonClient addonv1alpha1client.Interface,
+func createAddOnDeploymentConfigBeta(
+	hubAddonClient addonclient.Interface,
+	configNamespace string,
+	configName string,
+	configSpec addonapiv1beta1.AddOnDeploymentConfigSpec,
+) error {
+	config := &addonapiv1beta1.AddOnDeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configName,
+			Namespace: configNamespace,
+		},
+		Spec: configSpec,
+	}
+	_, err := hubAddonClient.AddonV1beta1().AddOnDeploymentConfigs(configNamespace).Create(
+		context.Background(), config, metav1.CreateOptions{})
+	return err
+}
+
+func updateAddOnDeploymentConfigSpecAlpha(
+	hubAddonClient addonclient.Interface,
 	configNamespace string,
 	configName string,
 	newConfigSpec addonapiv1alpha1.AddOnDeploymentConfigSpec,
@@ -242,6 +354,177 @@ func updateAddOnDeploymentConfigSpec(
 			return err
 		}
 		return nil
+	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+}
+
+func updateAddOnDeploymentConfigSpecBeta(
+	hubAddonClient addonclient.Interface,
+	configNamespace string,
+	configName string,
+	newConfigSpec addonapiv1beta1.AddOnDeploymentConfigSpec,
+) {
+	gomega.Eventually(func() error {
+		addOnConfig, err := hubAddonClient.AddonV1beta1().AddOnDeploymentConfigs(configNamespace).Get(
+			context.Background(), configName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		addOnConfig.Spec = newConfigSpec
+		_, err = hubAddonClient.AddonV1beta1().AddOnDeploymentConfigs(configNamespace).Update(
+			context.Background(), addOnConfig, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+}
+
+func assertClusterManagementAddOnInstallProgressionAlpha(name string, expect ...addonapiv1alpha1.InstallProgression) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s InstallProgression", name))
+
+	gomega.Eventually(func() error {
+		actual, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if len(actual.Status.InstallProgressions) != len(expect) {
+			return fmt.Errorf("expected %v install progression, actual: %v", len(expect), len(actual.Status.InstallProgressions))
+		}
+
+		for i, e := range expect {
+			actualInstallProgression := actual.Status.InstallProgressions[i]
+
+			if !apiequality.Semantic.DeepEqual(actualInstallProgression.ConfigReferences, e.ConfigReferences) {
+				return fmt.Errorf("expected InstallProgression.ConfigReferences is %v, actual: %v", e.ConfigReferences, actualInstallProgression.ConfigReferences)
+			}
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+func assertClusterManagementAddOnInstallProgressionBeta(name string, expect ...addonapiv1beta1.InstallProgression) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s InstallProgression (v1beta1)", name))
+
+	gomega.Eventually(func() error {
+		actual, err := hubAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if len(actual.Status.InstallProgressions) != len(expect) {
+			return fmt.Errorf("expected %v install progression, actual: %v", len(expect), len(actual.Status.InstallProgressions))
+		}
+
+		for i, e := range expect {
+			actualInstallProgression := actual.Status.InstallProgressions[i]
+
+			if !apiequality.Semantic.DeepEqual(actualInstallProgression.ConfigReferences, e.ConfigReferences) {
+				return fmt.Errorf("expected InstallProgression.ConfigReferences is %v, actual: %v", e.ConfigReferences, actualInstallProgression.ConfigReferences)
+			}
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+func assertManagedClusterAddOnConfigReferencesAlpha(name, namespace string, expect ...addonapiv1alpha1.ConfigReference) {
+	ginkgo.By(fmt.Sprintf("Check ManagedClusterAddOn %s/%s ConfigReferences", namespace, name))
+
+	gomega.Eventually(func() error {
+		actual, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if len(actual.Status.ConfigReferences) != len(expect) {
+			return fmt.Errorf("expected %v config reference, actual: %v", len(expect), len(actual.Status.ConfigReferences))
+		}
+
+		for i, e := range expect {
+			actualConfigReference := actual.Status.ConfigReferences[i]
+
+			if !apiequality.Semantic.DeepEqual(actualConfigReference, e) {
+				return fmt.Errorf("expected mca config reference is %v %v, actual: %v %v",
+					e.DesiredConfig,
+					e.LastAppliedConfig,
+					actualConfigReference.DesiredConfig,
+					actualConfigReference.LastAppliedConfig,
+				)
+			}
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+func assertManagedClusterAddOnConfigReferencesBeta(name, namespace string, expect ...addonapiv1beta1.ConfigReference) {
+	ginkgo.By(fmt.Sprintf("Check ManagedClusterAddOn %s/%s ConfigReferences (v1beta1)", namespace, name))
+
+	gomega.Eventually(func() error {
+		actual, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if len(actual.Status.ConfigReferences) != len(expect) {
+			return fmt.Errorf("expected %v config reference, actual: %v", len(expect), len(actual.Status.ConfigReferences))
+		}
+
+		for i, e := range expect {
+			actualConfigReference := actual.Status.ConfigReferences[i]
+
+			if !apiequality.Semantic.DeepEqual(actualConfigReference, e) {
+				return fmt.Errorf("expected mca config reference is %v %v, actual: %v %v",
+					e.DesiredConfig,
+					e.LastAppliedConfig,
+					actualConfigReference.DesiredConfig,
+					actualConfigReference.LastAppliedConfig,
+				)
+			}
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+func assertClusterManagementAddOnAnnotations(name string) {
+	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %v Annotations", name))
+
+	gomega.Eventually(func() error {
+		actual, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if _, ok := actual.Annotations[addonapiv1alpha1.AddonLifecycleAnnotationKey]; ok {
+			return fmt.Errorf("expected annotation %v to be empty, actual: %v",
+				addonapiv1alpha1.AddonLifecycleAnnotationKey,
+				actual.Annotations[addonapiv1alpha1.AddonLifecycleAnnotationKey])
+		}
+
+		return nil
+	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+}
+
+func updateManifestWorkStatus(client workclientset.Interface, clusterName string, manifestWorkName string, status metav1.ConditionStatus) {
+	gomega.Eventually(func() error {
+		work, err := client.WorkV1().ManifestWorks(clusterName).Get(context.Background(), manifestWorkName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		meta.SetStatusCondition(
+			&work.Status.Conditions,
+			metav1.Condition{Type: workapiv1.WorkApplied, Status: status, Reason: "WorkApplied", ObservedGeneration: work.Generation})
+		meta.SetStatusCondition(
+			&work.Status.Conditions,
+			metav1.Condition{Type: workapiv1.WorkAvailable, Status: status, Reason: "WorkAvailable", ObservedGeneration: work.Generation})
+
+		_, err = client.WorkV1().ManifestWorks(clusterName).UpdateStatus(context.Background(), work, metav1.UpdateOptions{})
+		return err
 	}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 }
 
@@ -297,31 +580,6 @@ func createPlacementDecision(hubClusterClient clusterv1client.Interface, placeme
 	return nil
 }
 
-func assertClusterManagementAddOnInstallProgression(name string, expect ...addonapiv1alpha1.InstallProgression) {
-	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s InstallProgression", name))
-
-	gomega.Eventually(func() error {
-		actual, err := hubAddonClient.AddonV1alpha1().ClusterManagementAddOns().Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		if len(actual.Status.InstallProgressions) != len(expect) {
-			return fmt.Errorf("expected %v install progression, actual: %v", len(expect), len(actual.Status.InstallProgressions))
-		}
-
-		for i, e := range expect {
-			actualInstallProgression := actual.Status.InstallProgressions[i]
-
-			if !apiequality.Semantic.DeepEqual(actualInstallProgression.ConfigReferences, e.ConfigReferences) {
-				return fmt.Errorf("expected InstallProgression.ConfigReferences is %v, actual: %v", e.ConfigReferences, actualInstallProgression.ConfigReferences)
-			}
-		}
-
-		return nil
-	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
-}
-
 func assertClusterManagementAddOnConditions(name string, expect ...metav1.Condition) {
 	ginkgo.By(fmt.Sprintf("Check ClusterManagementAddOn %s Conditions", name))
 
@@ -373,36 +631,6 @@ func assertClusterManagementAddOnNoConditions(name string, start metav1.Time, du
 
 		return nil
 	}, duration+2*time.Second, eventuallyInterval).Should(gomega.BeNil())
-}
-
-func assertManagedClusterAddOnConfigReferences(name, namespace string, expect ...addonapiv1alpha1.ConfigReference) {
-	ginkgo.By(fmt.Sprintf("Check ManagedClusterAddOn %s/%s ConfigReferences", namespace, name))
-
-	gomega.Eventually(func() error {
-		actual, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		if len(actual.Status.ConfigReferences) != len(expect) {
-			return fmt.Errorf("expected %v config reference, actual: %v", len(expect), len(actual.Status.ConfigReferences))
-		}
-
-		for i, e := range expect {
-			actualConfigReference := actual.Status.ConfigReferences[i]
-
-			if !apiequality.Semantic.DeepEqual(actualConfigReference, e) {
-				return fmt.Errorf("expected mca config reference is %v %v, actual: %v %v",
-					e.DesiredConfig,
-					e.LastAppliedConfig,
-					actualConfigReference.DesiredConfig,
-					actualConfigReference.LastAppliedConfig,
-				)
-			}
-		}
-
-		return nil
-	}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 }
 
 func assertManagedClusterAddOnConditions(name, namespace string, expect ...metav1.Condition) {

--- a/test/integration/addon/suite_test.go
+++ b/test/integration/addon/suite_test.go
@@ -21,7 +21,7 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
-	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
+	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -44,7 +44,7 @@ var addOnDeploymentConfigGVR = schema.GroupVersionResource{
 var testEnv *envtest.Environment
 var hubWorkClient workclientset.Interface
 var hubClusterClient clusterv1client.Interface
-var hubAddonClient addonv1alpha1client.Interface
+var hubAddonClient addonclient.Interface
 var hubKubeClient kubernetes.Interface
 var testAddonImpl *testAddon
 var testAddOnConfigsImpl *testAddon
@@ -105,7 +105,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	hubClusterClient, err = clusterv1client.NewForConfig(cfg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	hubAddonClient, err = addonv1alpha1client.NewForConfig(cfg)
+	hubAddonClient, err = addonclient.NewForConfig(cfg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	hubKubeClient, err = kubernetes.NewForConfig(cfg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -204,7 +204,7 @@ func (t *testAddon) GetAgentAddonOptions() agent.AgentAddonOptions {
 	return option
 }
 
-func newClusterManagementAddon(name string) *addonapiv1alpha1.ClusterManagementAddOn {
+func newClusterManagementAddonAlpha(name string) *addonapiv1alpha1.ClusterManagementAddOn {
 	return &addonapiv1alpha1.ClusterManagementAddOn{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -213,6 +213,20 @@ func newClusterManagementAddon(name string) *addonapiv1alpha1.ClusterManagementA
 		Spec: addonapiv1alpha1.ClusterManagementAddOnSpec{
 			InstallStrategy: addonapiv1alpha1.InstallStrategy{
 				Type: addonapiv1alpha1.AddonInstallStrategyManual,
+			},
+		},
+	}
+}
+
+func newClusterManagementAddonBeta(name string) *addonv1beta1.ClusterManagementAddOn {
+	return &addonv1beta1.ClusterManagementAddOn{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: addonv1beta1.ClusterManagementAddOnSpec{
+			InstallStrategy: addonv1beta1.InstallStrategy{
+				Type: addonv1beta1.AddonInstallStrategyManual,
 			},
 		},
 	}

--- a/test/integration/addon/token_infrastructure_alpha_test.go
+++ b/test/integration/addon/token_infrastructure_alpha_test.go
@@ -6,17 +6,18 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	certificates "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
-var _ = ginkgo.Describe("Token Infrastructure Controller Beta", func() {
+var _ = ginkgo.Describe("Token Infrastructure Controller Alpha", func() {
 	var managedClusterName, addOnName string
 	var err error
 
@@ -108,7 +109,7 @@ var _ = ginkgo.Describe("Token Infrastructure Controller Beta", func() {
 
 		ginkgo.By("Verify TokenInfrastructureReady condition is set to True")
 		gomega.Eventually(func() error {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(clusterName).Get(context.Background(), addonName, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(clusterName).Get(context.Background(), addonName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -151,32 +152,32 @@ var _ = ginkgo.Describe("Token Infrastructure Controller Beta", func() {
 
 	ginkgo.It("should create token infrastructure when addon uses token driver", func() {
 		ginkgo.By("Create ManagedClusterAddOn")
-		addOn := &addonapiv1beta1.ManagedClusterAddOn{
+		addOn := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      addOnName,
 				Namespace: managedClusterName,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{},
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: addOnName,
+			},
 		}
-		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		ginkgo.By("Update addon status with kubeClient registration and token driver")
 		gomega.Eventually(func() error {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
-			addon.Status.Registrations = []addonapiv1beta1.RegistrationConfig{
+			addon.Status.Registrations = []addonapiv1alpha1.RegistrationConfig{
 				{
-					Type: "kubeClient",
-					KubeClient: &addonapiv1beta1.KubeClientConfig{
-						Driver: "token",
-					},
+					SignerName: certificates.KubeAPIServerClientSignerName,
 				},
 			}
-			_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
+			addon.Status.KubeClientDriver = "token"
+			_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
 			return err
 		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 
@@ -185,31 +186,31 @@ var _ = ginkgo.Describe("Token Infrastructure Controller Beta", func() {
 
 	ginkgo.It("should cleanup token infrastructure when addon switches from token to CSR driver", func() {
 		ginkgo.By("Create ManagedClusterAddOn with token driver")
-		addOn := &addonapiv1beta1.ManagedClusterAddOn{
+		addOn := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      addOnName,
 				Namespace: managedClusterName,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{},
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: addOnName,
+			},
 		}
-		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		gomega.Eventually(func() error {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
-			addon.Status.Registrations = []addonapiv1beta1.RegistrationConfig{
+			addon.Status.Registrations = []addonapiv1alpha1.RegistrationConfig{
 				{
-					Type: "kubeClient",
-					KubeClient: &addonapiv1beta1.KubeClientConfig{
-						Driver: "token",
-					},
+					SignerName: certificates.KubeAPIServerClientSignerName,
 				},
 			}
-			_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
+			addon.Status.KubeClientDriver = "token"
+			_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
 			return err
 		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 
@@ -217,21 +218,14 @@ var _ = ginkgo.Describe("Token Infrastructure Controller Beta", func() {
 
 		ginkgo.By("Switch addon to CSR driver")
 		gomega.Eventually(func() error {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
-			// Update kubeClient driver from "token" to "csr"
-			addon.Status.Registrations = []addonapiv1beta1.RegistrationConfig{
-				{
-					Type: "kubeClient",
-					KubeClient: &addonapiv1beta1.KubeClientConfig{
-						Driver: "csr",
-					},
-				},
-			}
-			_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
+			// Update kubeClientDriver to switch to CSR driver
+			addon.Status.KubeClientDriver = "csr"
+			_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
 			return err
 		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 
@@ -239,7 +233,7 @@ var _ = ginkgo.Describe("Token Infrastructure Controller Beta", func() {
 
 		ginkgo.By("Verify TokenInfrastructureReady condition is removed")
 		gomega.Eventually(func() bool {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return false
 			}
@@ -251,38 +245,38 @@ var _ = ginkgo.Describe("Token Infrastructure Controller Beta", func() {
 
 	ginkgo.It("should cleanup token infrastructure when addon is deleted", func() {
 		ginkgo.By("Create ManagedClusterAddOn with token driver")
-		addOn := &addonapiv1beta1.ManagedClusterAddOn{
+		addOn := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      addOnName,
 				Namespace: managedClusterName,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{},
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: addOnName,
+			},
 		}
-		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		gomega.Eventually(func() error {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
-			addon.Status.Registrations = []addonapiv1beta1.RegistrationConfig{
+			addon.Status.Registrations = []addonapiv1alpha1.RegistrationConfig{
 				{
-					Type: "kubeClient",
-					KubeClient: &addonapiv1beta1.KubeClientConfig{
-						Driver: "token",
-					},
+					SignerName: certificates.KubeAPIServerClientSignerName,
 				},
 			}
-			_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
+			addon.Status.KubeClientDriver = "token"
+			_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
 			return err
 		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 
 		assertTokenInfrastructureReady(managedClusterName, addOnName)
 
 		ginkgo.By("Delete the addon")
-		err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Delete(context.Background(), addOnName, metav1.DeleteOptions{})
+		err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Delete(context.Background(), addOnName, metav1.DeleteOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		assertTokenInfrastructureCleanedUp(managedClusterName, addOnName)
@@ -290,37 +284,34 @@ var _ = ginkgo.Describe("Token Infrastructure Controller Beta", func() {
 
 	ginkgo.It("should handle addon with multiple registrations where only one is token-based", func() {
 		ginkgo.By("Create ManagedClusterAddOn with multiple registrations including token driver")
-		addOn := &addonapiv1beta1.ManagedClusterAddOn{
+		addOn := &addonapiv1alpha1.ManagedClusterAddOn{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      addOnName,
 				Namespace: managedClusterName,
 			},
-			Spec: addonapiv1beta1.ManagedClusterAddOnSpec{},
+			Spec: addonapiv1alpha1.ManagedClusterAddOnSpec{
+				InstallNamespace: addOnName,
+			},
 		}
-		_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn, metav1.CreateOptions{})
+		_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Create(context.Background(), addOn, metav1.CreateOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		gomega.Eventually(func() error {
-			addon, err := hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
+			addon, err := hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.Background(), addOnName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
-			addon.Status.Registrations = []addonapiv1beta1.RegistrationConfig{
+			addon.Status.Registrations = []addonapiv1alpha1.RegistrationConfig{
 				{
-					Type: "kubeClient",
-					KubeClient: &addonapiv1beta1.KubeClientConfig{
-						Driver: "token",
-					},
+					SignerName: certificates.KubeAPIServerClientSignerName,
 				},
 				{
-					Type: "customSigner",
-					CustomSigner: &addonapiv1beta1.CustomSignerConfig{
-						SignerName: "example.com/custom-signer",
-					},
+					SignerName: "example.com/custom-signer",
 				},
 			}
-			_, err = hubAddonClient.AddonV1beta1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
+			addon.Status.KubeClientDriver = "token"
+			_, err = hubAddonClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).UpdateStatus(context.Background(), addon, metav1.UpdateOptions{})
 			return err
 		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
 


### PR DESCRIPTION
Add comprehensive v1beta1 test coverage for addon API following alpha/beta split pattern. Tests for both v1alpha1 and v1beta1 run in parallel with API conversion handled automatically by the test environment.

## Migrated tests (11 test suites)
- addon_manager_install: split into _alpha + beta versions
- addon_configs: split into _alpha + beta versions
- addon_manager_upgrade: split into _alpha + beta versions
- agent_deploy: split into _alpha + beta versions
- token_infrastructure: split into _alpha + beta versions
- addon_manager_template: renamed to _alpha only (AddOnTemplate API removed in v1beta1)

## Changes
- suite_test.go: renamed client import to support both API versions
- assertion_test.go: added alpha/beta config specs and beta helper functions

## v1beta1 API compatibility fixes
- Removed deprecated ConfigReferent field from ConfigReference structs
- Removed InstallNamespace from ManagedClusterAddOnSpec
- Updated RegistrationConfig to use Type field with nested KubeClient/CustomSigner configs
- KubeClientDriver moved from top-level Status to RegistrationConfig.KubeClient.Driver
- SignerName implicit for kubeClient type, explicit in CustomSigner for customSigner type

All integration tests now have complete v1beta1 coverage. E2E tests will be migrated separately.

For #1517 (does not complete 1517 but implements the v1beta1 tests for integration/addon)

## Notes for reviewers:

- implements just the v1beta1 addon integration tests for #1517, while preserving the v1alpha1 tests.  Will do the e2e tests as a separate PR.
- addonTemplates do not seem to be there anymore in v1beta1?  I renamed the addontemplate test filename to `_alpha_test.go` as well for consistency, but no v1beta version of the test can be created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive integration suites for add-on install, deploy, config management, upgrades, rollout strategies, and token infrastructure.
  * Migrated many tests from alpha to beta API variants and added parallel alpha suites to validate both behaviors.
  * Added scenarios for placement-driven installs, progressive/group rollouts, manifest/work status transitions, config referent/spec-hash updates, unsupported-config handling, and annotation/hosting propagation.
  * Improved cleanup, versioned helpers, and multi-registration/token-driver coverage across tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/ocm/pull/1546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->