### PR TITLE
:book: docs: add AI policy referencing Linux Foundation gen AI guidelines

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,8 @@
+  ---
+###   AI Policy
+
+  This project follows the Linux Foundation's policy on the use of generative AI tools for contributions.
+
+  https://www.linuxfoundation.org/legal/generative-ai
+
+  ---

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,8 +1,8 @@
-  ---
-###   AI Policy
+---
+### AI Policy
 
-  This project follows the Linux Foundation's policy on the use of generative AI tools for contributions.
+This project follows the Linux Foundation's policy on the use of generative AI tools for contributions.
 
-  https://www.linuxfoundation.org/legal/generative-ai
+https://www.linuxfoundation.org/legal/generative-ai
 
-  ---
+---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
   - [Certificate of Origin](#certificate-of-origin)
   - [DCO Sign Off](#dco-sign-off)
   - [Code of Conduct](#code-of-conduct)
+  - [AI Policy and Guidance](#ai-policy-and-guidance)
   - [Contributing a patch](#contributing-a-patch)
   - [Setting up your dev environment, coding, and debugging](#setting-up-your-dev-environment-coding-and-debugging)
     - [Prerequisites](#prerequisites)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,29 @@ This can be done with the `--signoff` option to `git commit`. See the [Git docum
 
 The Open Cluster Management project has adopted the CNCF Code of Conduct. Refer to our [Community Code of Conduct](CODE_OF_CONDUCT.md) for details.
 
+## AI Policy and Guidance
+
+### AI-Assisted Contributions
+
+AI tools are welcome in this project. We use them ourselves. What matters is the quality of what you submit and your ownership of it.
+
+**You are responsible for everything you submit.** If you used AI to help write code, documentation, or a commit message, you must understand, review, and test it before opening a PR.
+
+**Respond to reviewers yourself.** When engaging with maintainers during review, do not use AI to generate your responses.
+
+**Disclose AI usage** in your PR description if AI tools played a significant role.
+
+**Please note:** We reserve the right to close low-quality or unreviewed AI-generated submissions without extensive feedback.
+
+*This guidance was shaped by the practices of the OCM community and other open source projects (thank you!) and will evolve. Contributions and suggestions are always welcome.*
+
+*This section was drafted with the assistance of AI, in keeping with the very guidance it describes.*
+
+*This project follows the Linux Foundation's policy on generative AI contributions: [https://www.linuxfoundation.org/legal/generative-ai](https://www.linuxfoundation.org/legal/generative-ai)*
+
+**We continue reviewing legal requirements and always have alignment with the CNCF rules and guidelines; this is an evolving space and may change without notice.**
+
+
 ## Contributing a patch
 
 1. Submit an issue describing your proposed change to the repository in question. The repository owners will respond to your issue promptly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ AI tools are welcome in this project. We use them ourselves. What matters is the
 
 *This section was drafted with the assistance of AI, in keeping with the very guidance it describes.*
 
-*This project follows the Linux Foundation's policy on generative AI contributions: [https://www.linuxfoundation.org/legal/generative-ai](https://www.linuxfoundation.org/legal/generative-ai)*
+*This project follows the Linux Foundation's policy on generative AI contributions — see [AI_POLICY.md](AI_POLICY.md) for details.*
 
 **We continue reviewing legal requirements and always have alignment with the CNCF rules and guidelines; this is an evolving space and may change without notice.**
 


### PR DESCRIPTION
## Summary

This project already operates under the Linux Foundation's Generative AI policy as an inherited CNCF policy, but this wasn't explicitly referenced anywhere in the repository. This PR adds AI_POLICY.md to surface that policy clearly for contributors.

  No new rules are introduced — this is purely a transparency and discoverability improvement.

## Related issue(s)

Fixes part 1 of #1545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a project AI policy outlining adherence to the Linux Foundation’s guidance on generative AI tools used in contributions.
  * Expanded contributor documentation with AI-assisted contribution guidance, including contributor understanding, disclosure, review, testing, and quality expectations.
  * Clarified that AI-generated reviewer responses are not permitted and that insufficiently reviewed or low-quality submissions may be closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->