### PR TITLE
:bug: fix: properly detect empty `CONTAINER_CLI`

### DIFF
--- a/test/kind-images.mk
+++ b/test/kind-images.mk
@@ -5,7 +5,7 @@
 # Auto-detect container runtime (docker or podman)
 # Only check when actually needed (not during container builds)
 CONTAINER_CLI ?= $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
-ifdef CONTAINER_CLI
+ifneq ($(CONTAINER_CLI),)
 CONTAINER_RUNTIME := $(notdir $(CONTAINER_CLI))
 endif
 
@@ -35,7 +35,7 @@ endef
 
 # Build all images with correct architecture for kind
 images-kind:
-ifndef CONTAINER_CLI
+ifeq ($(CONTAINER_CLI),)
 	$(error Neither docker nor podman found. Please install one of them.)
 endif
 	@echo "Building images for kind cluster..."
@@ -63,7 +63,7 @@ images-and-load-kind: images-kind load-images-kind
 
 # Display detected settings
 show-kind-config:
-ifndef CONTAINER_CLI
+ifeq ($(CONTAINER_CLI),)
 	$(error Neither docker nor podman found. Please install one of them.)
 endif
 	@echo "Container runtime: $(CONTAINER_RUNTIME)"


### PR DESCRIPTION
## Summary

`CONTAINER_CLI` is getting populated with an empty string, which `ifdef` is considering as populated. Update to use `ifeq`/`ifneq`.

## Related issue(s)

Fixes # N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automatic detection of container runtime availability (Docker or Podman).
  * Enhanced error handling with clearer messaging when no container runtime is found.
  * Better validation and reporting of container configuration and build platform details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->