### PR TITLE
:seedling: chore: update base image to distroless

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -60,7 +60,7 @@ jobs:
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image
-        run: docker pull gcr.io/distroless/base-debian13:latest --platform=linux/${{ matrix.arch }}
+        run: docker pull registry.access.redhat.com/ubi9/ubi-micro:latest --platform=linux/${{ matrix.arch }}
       - name: images
         run: |
           IMAGE_TAG=latest-${{ matrix.arch }} \

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -60,7 +60,7 @@ jobs:
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image
-        run: docker pull registry.access.redhat.com/ubi9/ubi-minimal:latest --platform=linux/${{ matrix.arch }}
+        run: docker pull gcr.io/distroless/base-debian13:latest --platform=linux/${{ matrix.arch }}
       - name: images
         run: |
           IMAGE_TAG=latest-${{ matrix.arch }} \

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -61,7 +61,7 @@ jobs:
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image
-        run: docker pull gcr.io/distroless/base-debian13:latest --platform=linux/${{ matrix.arch }}
+        run: docker pull registry.access.redhat.com/ubi9/ubi-micro:latest --platform=linux/${{ matrix.arch }}
       - name: images
         run: |
           IMAGE_TAG=${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }} \

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -61,7 +61,7 @@ jobs:
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image
-        run: docker pull registry.access.redhat.com/ubi9/ubi-minimal:latest --platform=linux/${{ matrix.arch }}
+        run: docker pull gcr.io/distroless/base-debian13:latest --platform=linux/${{ matrix.arch }}
       - name: images
         run: |
           IMAGE_TAG=${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }} \

--- a/build/Dockerfile.addon
+++ b/build/Dockerfile.addon
@@ -10,7 +10,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/addon \
     make build --warn-undefined-variables
 
-FROM gcr.io/distroless/base-debian13:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ENV USER_UID=10001
 COPY --from=builder /go/src/open-cluster-management.io/ocm/addon /
 

--- a/build/Dockerfile.addon
+++ b/build/Dockerfile.addon
@@ -10,7 +10,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/addon \
     make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM gcr.io/distroless/base-debian13:latest
 ENV USER_UID=10001
 COPY --from=builder /go/src/open-cluster-management.io/ocm/addon /
 

--- a/build/Dockerfile.placement
+++ b/build/Dockerfile.placement
@@ -10,7 +10,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/placement \
     make build --warn-undefined-variables
 
-FROM gcr.io/distroless/base-debian13:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ENV USER_UID=10001
 
 COPY --from=builder /go/src/open-cluster-management.io/ocm/placement /

--- a/build/Dockerfile.placement
+++ b/build/Dockerfile.placement
@@ -10,7 +10,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/placement \
     make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM gcr.io/distroless/base-debian13:latest
 ENV USER_UID=10001
 
 COPY --from=builder /go/src/open-cluster-management.io/ocm/placement /

--- a/build/Dockerfile.registration
+++ b/build/Dockerfile.registration
@@ -15,7 +15,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/server \
     make build --warn-undefined-variables
 
-FROM gcr.io/distroless/base-debian13:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ENV USER_UID=10001
 
 COPY --from=builder /go/src/open-cluster-management.io/ocm/registration /

--- a/build/Dockerfile.registration
+++ b/build/Dockerfile.registration
@@ -15,7 +15,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/server \
     make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM gcr.io/distroless/base-debian13:latest
 ENV USER_UID=10001
 
 COPY --from=builder /go/src/open-cluster-management.io/ocm/registration /

--- a/build/Dockerfile.registration-operator
+++ b/build/Dockerfile.registration-operator
@@ -10,7 +10,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/registration-operator \
     make build --warn-undefined-variables
 
-FROM gcr.io/distroless/base-debian13:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ENV USER_UID=10001
 
 COPY --from=builder /go/src/open-cluster-management.io/ocm/registration-operator /

--- a/build/Dockerfile.registration-operator
+++ b/build/Dockerfile.registration-operator
@@ -10,7 +10,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/registration-operator \
     make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM gcr.io/distroless/base-debian13:latest
 ENV USER_UID=10001
 
 COPY --from=builder /go/src/open-cluster-management.io/ocm/registration-operator /

--- a/build/Dockerfile.work
+++ b/build/Dockerfile.work
@@ -10,7 +10,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/work \
     make build --warn-undefined-variables
 
-FROM gcr.io/distroless/base-debian13:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ENV USER_UID=10001
 
 COPY --from=builder /go/src/open-cluster-management.io/ocm/work /

--- a/build/Dockerfile.work
+++ b/build/Dockerfile.work
@@ -10,7 +10,7 @@ RUN GOOS=${OS} \
     GO_BUILD_PACKAGES=./cmd/work \
     make build --warn-undefined-variables
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM gcr.io/distroless/base-debian13:latest
 ENV USER_UID=10001
 
 COPY --from=builder /go/src/open-cluster-management.io/ocm/work /

--- a/test/e2e-test.mk
+++ b/test/e2e-test.mk
@@ -64,6 +64,7 @@ apply-hub-cr:
 
 # E2E test target
 # Set SKIP_IMAGE_BUILD=true to skip image building and loading (useful when only test code changes)
+SKIP_IMAGE_BUILD?=false
 ifeq ($(SKIP_IMAGE_BUILD),true)
 test-e2e: deploy-hub deploy-spoke-operator-helm run-e2e
 else


### PR DESCRIPTION
## Summary

Reduces attack surface of the image and increase CVE maintainability

## Related issue(s)

Fixes # N/A

Closes #1367 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched final runtime base across container builds to a smaller UBI micro image and updated CI image-pull steps accordingly, affecting final runtime images.
* **Tests**
  * Added a configurable option to skip image builds when running end-to-end tests, making the test dependency chain deterministic and speeding CI when rebuilds aren’t required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->