### PR TITLE
✨ feature: auto-detect OpenShift cluster name from Infrastructure API

### DIFF
--- a/manifests/klusterlet/managed/klusterlet-registration-clusterrole.yaml
+++ b/manifests/klusterlet/managed/klusterlet-registration-clusterrole.yaml
@@ -28,3 +28,8 @@ rules:
 - apiGroups: ["about.k8s.io"]
   resources: ["clusterproperties"]
   verbs: ["get", "list", "watch"]
+# Optional rule: Allow agent to read OpenShift infrastructures for cluster name auto-detection
+# If the agent is running in an OpenShift cluster, it will gracefully fall back if this is missing.
+- apiGroups: ["config.openshift.io"]
+  resources: ["infrastructures"]
+  verbs: ["get", "list"]

--- a/pkg/common/options/agent.go
+++ b/pkg/common/options/agent.go
@@ -1,6 +1,7 @@
 package options
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -8,8 +9,12 @@ import (
 
 	"github.com/spf13/pflag"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -128,18 +133,34 @@ func (o *AgentOptions) getOrGenerateClusterAgentID() (string, string) {
 	clusterName := o.SpokeClusterName
 	// if cluster name is not specified with input argument, try to load it from file
 	if clusterName == "" {
-		// TODO, read cluster name from openshift struct if the spoke agent is running in an openshift cluster
+		// read cluster name from openshift struct if the spoke agent is running in an openshift cluster
+		config, err := clientcmd.BuildConfigFromFlags("", o.SpokeKubeconfigFile)
+		if err == nil {
+			if dynamicClient, err := dynamic.NewForConfig(config); err == nil {
+				if infra, err := dynamicClient.Resource(schema.GroupVersionResource{
+					Group:    "config.openshift.io",
+					Version:  "v1",
+					Resource: "infrastructures",
+				}).Get(context.TODO(), "cluster", metav1.GetOptions{}); err == nil {
+					if infraName, found, err := unstructured.NestedString(infra.Object, "status", "infrastructureName"); found && err == nil && infraName != "" {
+						clusterName = infraName
+					}
+				}
+			}
+		}
 
-		// and then load the cluster name from the mounted secret
-		clusterNameFilePath := path.Join(o.HubKubeconfigDir, register.ClusterNameFile)
-		clusterNameBytes, err := os.ReadFile(path.Clean(clusterNameFilePath))
-		switch {
-		case err == nil:
-			// use cluster name load from the mounted secret
-			clusterName = string(clusterNameBytes)
-		default:
-			// generate random cluster name
-			clusterName = generateClusterName()
+		if clusterName == "" {
+			// and then load the cluster name from the mounted secret
+			clusterNameFilePath := path.Join(o.HubKubeconfigDir, register.ClusterNameFile)
+			clusterNameBytes, err := os.ReadFile(path.Clean(clusterNameFilePath))
+			switch {
+			case err == nil:
+				// use cluster name load from the mounted secret
+				clusterName = string(clusterNameBytes)
+			default:
+				// generate random cluster name
+				clusterName = generateClusterName()
+			}
 		}
 	}
 

--- a/pkg/common/options/agent.go
+++ b/pkg/common/options/agent.go
@@ -117,7 +117,7 @@ func (o *AgentOptions) Complete() error {
 //   1. Use cluster name from input arguments if 'spoke-cluster-name' is specified;
 //   2. Parse cluster name from the common name of the certification subject if the certification exists;
 //   3. Fallback to cluster name in the mounted secret if it exists;
-//   4. TODO: Read cluster name from openshift struct if the agent is running in an openshift cluster;
+//   4. ClusterName is populated from OpenShift cluster info during AgentOptions initialization;
 //   5. Generate a random cluster name then;
 
 // Rules for picking up agent id:
@@ -134,19 +134,8 @@ func (o *AgentOptions) getOrGenerateClusterAgentID() (string, string) {
 	// if cluster name is not specified with input argument, try to load it from file
 	if clusterName == "" {
 		// read cluster name from openshift struct if the spoke agent is running in an openshift cluster
-		config, err := clientcmd.BuildConfigFromFlags("", o.SpokeKubeconfigFile)
-		if err == nil {
-			if dynamicClient, err := dynamic.NewForConfig(config); err == nil {
-				if infra, err := dynamicClient.Resource(schema.GroupVersionResource{
-					Group:    "config.openshift.io",
-					Version:  "v1",
-					Resource: "infrastructures",
-				}).Get(context.TODO(), "cluster", metav1.GetOptions{}); err == nil {
-					if infraName, found, err := unstructured.NestedString(infra.Object, "status", "infrastructureName"); found && err == nil && infraName != "" {
-						clusterName = infraName
-					}
-				}
-			}
+		if name := o.tryReadOpenShiftClusterName(); name != "" {
+			clusterName = name
 		}
 
 		if clusterName == "" {
@@ -190,4 +179,33 @@ func generateClusterName() string {
 // generateAgentName generates a random name for spoke cluster agent
 func generateAgentName() string {
 	return utilrand.String(spokeAgentNameLength)
+}
+
+func (o *AgentOptions) tryReadOpenShiftClusterName() string {
+	config, err := clientcmd.BuildConfigFromFlags("", o.SpokeKubeconfigFile)
+	if err != nil {
+		return ""
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return ""
+	}
+	return detectOpenShiftClusterName(dynamicClient)
+}
+
+func detectOpenShiftClusterName(client dynamic.Interface) string {
+	infra, err := client.Resource(schema.GroupVersionResource{
+		Group:    "config.openshift.io",
+		Version:  "v1",
+		Resource: "infrastructures",
+	}).Get(context.TODO(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return ""
+	}
+
+	infraName, found, err := unstructured.NestedString(infra.Object, "status", "infrastructureName")
+	if err != nil || !found {
+		return ""
+	}
+	return infraName
 }

--- a/pkg/common/options/agent_test.go
+++ b/pkg/common/options/agent_test.go
@@ -1,13 +1,11 @@
 package options
 
 import (
-	"context"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/spf13/pflag"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/common/options/agent_test.go
+++ b/pkg/common/options/agent_test.go
@@ -1,11 +1,17 @@
 package options
 
 import (
+	"context"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
 func TestNewAgentOptions(t *testing.T) {
@@ -181,6 +187,13 @@ func TestAgentOptions_getOrGenerateClusterAgentID(t *testing.T) {
 				HubKubeconfigDir: "/non-exist-dir",
 			},
 		},
+		{
+			name: "invalid spoke kubeconfig",
+			options: &AgentOptions{
+				HubKubeconfigDir:    "/non-exist-dir",
+				SpokeKubeconfigFile: "/invalid/path/to/kubeconfig",
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -197,6 +210,89 @@ func TestAgentOptions_getOrGenerateClusterAgentID(t *testing.T) {
 			}
 			if len(c.expectedAgentName) == 0 && len(agentName) == 0 {
 				t.Error("agent name should be generated")
+			}
+		})
+	}
+}
+
+func Test_detectOpenShiftClusterName(t *testing.T) {
+	cases := []struct {
+		name         string
+		infraObject  *unstructured.Unstructured
+		expectedName string
+	}{
+		{
+			name: "successful lookup",
+			infraObject: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "config.openshift.io/v1",
+					"kind":       "Infrastructure",
+					"metadata": map[string]interface{}{
+						"name": "cluster",
+					},
+					"status": map[string]interface{}{
+						"infrastructureName": "my-openshift-cluster",
+					},
+				},
+			},
+			expectedName: "my-openshift-cluster",
+		},
+		{
+			name:         "missing infrastructure resource",
+			infraObject:  nil,
+			expectedName: "",
+		},
+		{
+			name: "empty infrastructure name",
+			infraObject: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "config.openshift.io/v1",
+					"kind":       "Infrastructure",
+					"metadata": map[string]interface{}{
+						"name": "cluster",
+					},
+					"status": map[string]interface{}{
+						"infrastructureName": "",
+					},
+				},
+			},
+			expectedName: "",
+		},
+		{
+			name: "no status field",
+			infraObject: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "config.openshift.io/v1",
+					"kind":       "Infrastructure",
+					"metadata": map[string]interface{}{
+						"name": "cluster",
+					},
+				},
+			},
+			expectedName: "",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	// Add the unstructured type so the fake client knows how to handle it
+	gvr := schema.GroupVersionResource{Group: "config.openshift.io", Version: "v1", Resource: "infrastructures"}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var client *dynamicfake.FakeDynamicClient
+			if c.infraObject != nil {
+				client = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+					gvr: "InfrastructureList",
+				}, c.infraObject)
+			} else {
+				client = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+					gvr: "InfrastructureList",
+				})
+			}
+
+			name := detectOpenShiftClusterName(client)
+			if name != c.expectedName {
+				t.Errorf("expected %q, got %q", c.expectedName, name)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR resolves a `TODO` in `pkg/common/options/agent.go` by automatically detecting the spoke cluster's name when the OCM agent is deployed on a Red Hat OpenShift cluster. 

Instead of generating a random UUID or falling back to a mounted secret, the agent now attempts to dynamically query the `config.openshift.io/v1` API for the `infrastructures` resource (named `cluster`) and extracts the `status.infrastructureName`. If this query fails (e.g. not running on OpenShift, API unreachable), it gracefully ignores the error and continues to the existing fallback logic.

**Key Changes & Refactoring:**
- **Dynamic Client:** Utilized `k8s.io/client-go/dynamic` to read the Infrastructure struct without pulling in heavy OpenShift-specific Go dependencies.
- **Testable Helpers:** Extracted the fetching logic into highly decoupled, testable helper functions (`tryReadOpenShiftClusterName` and `detectOpenShiftClusterName`) to prevent deep nesting and variable shadowing.
- **Unit Tests:** Added comprehensive test coverage in `agent_test.go` using `k8s.io/client-go/dynamic/fake` to simulate OpenShift API responses, including empty states and missing resources.
- **RBAC Updates:** Added an optional ClusterRole rule in `klusterlet-registration-clusterrole.yaml` to inform operators that `get/list` permissions on `infrastructures` are beneficial on OpenShift deployments.

## Related issue(s)

Fixes #1561 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved cluster agent identification by adding OpenShift infrastructure lookup and robust fallbacks for more reliable cluster name detection.
* **Permissions**
  * Expanded agent permissions to allow reading OpenShift infrastructure resources so cluster name discovery can succeed.
* **Tests**
  * Added unit tests covering OpenShift infrastructure name detection and failure scenarios to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->