### PR TITLE
:sparkles: feat: add `verify-csv` check

### DIFF
--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -36,6 +36,8 @@ jobs:
         run: make verify-deps
       - name: verify-fmt-imports
         run: make verify-fmt-imports
+      - name: verify-csv
+        run: make verify-csv </dev/null
 
   build:
     name: build

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ test-unit: envtest-setup
 update-csv: ensure-operator-sdk ensure-helm
 	bash -x hack/update-csv.sh
 
+verify-csv:
+	bash hack/verify-csv.sh
+
 verify-crds: ensure-yaml-patch
 	bash -x hack/verify-crds.sh $(YAML_PATCH)
 

--- a/hack/verify-csv.sh
+++ b/hack/verify-csv.sh
@@ -1,0 +1,41 @@
+#! /bin/bash
+
+set -e
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")"/..)
+
+if [[ ${PWD} != "${REPO_ROOT}" ]]; then
+  echo "ERROR: Run this script from the root of the repository."
+  exit 1
+fi
+
+SED_CMD="sed"
+if [[ "$(uname)" == "Darwin" ]]; then
+  if command -v gsed >/dev/null 2>&1; then
+    SED_CMD="gsed"
+  else
+    echo "Error: gsed not found. Please install it with 'brew install gnu-sed'" >&2
+    exit 1
+  fi
+fi
+
+# Get the createdAt timestamp from the CSV files
+cluster_manager_timestamp=$(yq '.metadata.annotations.createdAt' deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml)
+klusterlet_timestamp=$(yq '.metadata.annotations.createdAt' deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml)
+
+# Update the CSV files
+echo "::group::Update CSV"
+make update-csv
+echo "::endgroup::"
+
+# Reset the createdAt timestamp to the original value
+${SED_CMD} -i "s/createdAt: .*/createdAt: \"${cluster_manager_timestamp}\"/g" deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml
+${SED_CMD} -i "s/createdAt: .*/createdAt: \"${klusterlet_timestamp}\"/g" deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
+
+# Verify the CSV content is in sync
+git diff --exit-code \
+  deploy/cluster-manager/olm-catalog/latest/manifests/cluster-manager.clusterserviceversion.yaml \
+  deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml ||
+  (echo '❌ CSV content is out of sync. Run "make update-csv" to update the CSV content.' && false)
+
+echo "✅ CSV content is in sync."


### PR DESCRIPTION
Blocked by:
- #1567 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated verification step in CI to validate CSV/manifest consistency during the pre-merge checks.
  * Introduced a build helper target to run manifest regeneration and verification as part of the verification workflow.
  * Added a script that safely regenerates manifests, preserves original timestamps, and fails the check if any unintended changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->