### PR TITLE
:bug: Start csr informer in awsirsa driver

### DIFF
--- a/pkg/registration/register/aws_irsa/aws_irsa.go
+++ b/pkg/registration/register/aws_irsa/aws_irsa.go
@@ -154,6 +154,11 @@ func (c *AWSIRSADriver) BuildClients(ctx context.Context, secretOption register.
 			return nil, fmt.Errorf("failed to create CSR control: %w", err)
 		}
 		c.csrControl = csrControl
+
+		// Start the informer factory to sync the csr informer. The csr informer is
+		// consumed by the drivers forked for addon registration, while the
+		// InformerHandler of this driver only exposes the awsIRSAControl informer.
+		go kubeInformerFactory.Start(ctx.Done())
 	}
 
 	return clients, nil

--- a/pkg/registration/register/aws_irsa/aws_irsa_test.go
+++ b/pkg/registration/register/aws_irsa/aws_irsa_test.go
@@ -2,6 +2,9 @@ package aws_irsa
 
 import (
 	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"strings"
@@ -15,8 +18,10 @@ import (
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	addonfake "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
+	ocmfeature "open-cluster-management.io/api/feature"
 	"open-cluster-management.io/sdk-go/pkg/basecontroller/events"
 
+	"open-cluster-management.io/ocm/pkg/features"
 	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
 	"open-cluster-management.io/ocm/pkg/registration/register"
 	"open-cluster-management.io/ocm/pkg/registration/register/csr"
@@ -210,6 +215,67 @@ func TestIsHubKubeConfigValidFunc(t *testing.T) {
 				t.Errorf("expect %t, but %t", c.isValid, valid)
 			}
 		})
+	}
+}
+
+func TestAWSIRSADriver_BuildClients_StartsCSRInformer(t *testing.T) {
+	err := features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// start a fake hub apiserver returning an empty csr list, so the csr informer
+	// is able to sync once it is started
+	apiServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"CertificateSigningRequestList","apiVersion":"certificates.k8s.io/v1","metadata":{"resourceVersion":"1"},"items":[]}`))
+	}))
+	defer apiServer.Close()
+	caData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: apiServer.Certificate().Raw})
+
+	tempDir, err := os.MkdirTemp("", "testbuildclients")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cert1 := testinghelpers.NewTestCert("system:open-cluster-management:cluster1:agent1", 60*time.Second)
+	testinghelpers.WriteFile(path.Join(tempDir, "kubeconfig"),
+		testinghelpers.NewKubeconfig("c1", apiServer.URL, "", "", caData, cert1.Key, cert1.Cert))
+
+	secretOption := register.SecretOption{
+		ClusterName:       "cluster1",
+		AgentName:         "agent1",
+		HubKubeconfigFile: path.Join(tempDir, "kubeconfig"),
+	}
+	driver := NewAWSIRSADriver(NewAWSOption(), secretOption).(*AWSIRSADriver)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := driver.BuildClients(ctx, secretOption, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cache.WaitForCacheSync(ctx.Done(), driver.csrControl.Informer().HasSynced) {
+		t.Errorf("csr informer is not started, the informer cache never syncs")
+	}
+
+	// the drivers forked for addon registration share the csr control, and the
+	// addon client cert controllers wait on its informer cache before starting
+	forkedDriver, err := driver.Fork("addon1", &registertesting.TestAddonAuthConfig{
+		KubeClientAuth: "csr",
+		CSROption:      csr.NewCSROption(),
+	}, register.SecretOption{
+		ClusterName: "cluster1",
+		Signer:      "custom.signer.io/custom",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	forkedInformer, _ := forkedDriver.InformerHandler()
+	if !cache.WaitForCacheSync(ctx.Done(), forkedInformer.HasSynced) {
+		t.Errorf("the informer cache of the forked addon driver never syncs")
 	}
 }
 


### PR DESCRIPTION
## Summary
The awsirsa driver's `BuildClients` creates an informer factory for its csr control, but the factory is never started: the driver's `InformerHandler` only exposes the awsIRSAControl (ManagedCluster) informer, so unlike the csr and grpc drivers, the spoke agent never runs the csr informer. The drivers forked for addon registration share that csr control, so their client cert controllers wait on a cache that can never sync, hit the cache-sync timeout, and kill the agent — and addon CSRs are never created.

This starts the informer factory in `BuildClients` when the csr control is created, and adds a unit test verifying that the csr informer (and the informer exposed by a forked addon driver) syncs after `BuildClients`.

## Related issue(s)

Fixes #1263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSR informer initialization during client setup so it reliably starts and synchronizes, keeping registration/auth components in sync with the latest CertificateSigningRequest data.

* **Tests**
  * Added an end-to-end test that simulates a hub API and validates CSR informer cache synchronization, including confirmation that addon registration drivers can also reach sync and use the CSR information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->