### PR TITLE
:seedling: chore: pin GitHub Actions to digest SHAs and replace setup-kind

### DIFF
--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/ocm
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: submit cluster-manager chart to OCM chart repo
         if: github.event_name != 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.OCM_BOT_PAT }}
           script: |
@@ -61,7 +61,7 @@ jobs:
             }
       - name: submit klusterlet chart to OCM chart repo
         if: github.event_name != 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.OCM_BOT_PAT }}
           script: |

--- a/.github/workflows/cloudevents-integration.yml
+++ b/.github/workflows/cloudevents-integration.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: integration

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,7 @@ env:
   GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   USE_EXISTING_CLUSTER: false # set to true to use an existing kind cluster for debugging with act
+  KUBERNETES_VERSION: 'v1.29.2'
 
 permissions:
   contents: read
@@ -30,21 +31,19 @@ jobs:
         run: sudo chown runner:docker /var/run/docker.sock
         if: ${{ env.ACT }} # this step only runs locally when using the https://github.com/nektos/act to debug the e2e
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kind
-        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc # v0.6.2
-        with:
-          version: v0.22.0
-          skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
+        if: ${{ env.USE_EXISTING_CLUSTER != 'true' }}
+        run: kind create cluster --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Set KUBECONFIG
         run: |
           mkdir -p /home/runner/.kube
           kind get kubeconfig > /home/runner/.kube/config
-        if: ${{ env.USE_EXISTING_CLUSTER }}
+        if: ${{ env.USE_EXISTING_CLUSTER == 'true' }}
       - name: Test E2E
         run: |
           IMAGE_TAG=e2e make test-e2e
@@ -57,21 +56,19 @@ jobs:
         run: sudo chown runner:docker /var/run/docker.sock
         if: ${{ env.ACT }} # this step only runs locally when using the https://github.com/nektos/act to debug the e2e
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kind
-        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc # v0.6.2
-        with:
-          version: v0.22.0
-          skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
+        if: ${{ env.USE_EXISTING_CLUSTER != 'true' }}
+        run: kind create cluster --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Set KUBECONFIG
         run: |
           mkdir -p /home/runner/.kube
           kind get kubeconfig > /home/runner/.kube/config
-        if: ${{ env.USE_EXISTING_CLUSTER }}
+        if: ${{ env.USE_EXISTING_CLUSTER == 'true' }}
       - name: Test E2E
         run: |
           IMAGE_TAG=e2e KLUSTERLET_DEPLOY_MODE=SingletonHosted make test-e2e
@@ -84,21 +81,19 @@ jobs:
         run: sudo chown runner:docker /var/run/docker.sock
         if: ${{ env.ACT }} # this step only runs locally when using the https://github.com/nektos/act to debug the e2e
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kind
-        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc # v0.6.2
-        with:
-          version: v0.22.0
-          skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
+        if: ${{ env.USE_EXISTING_CLUSTER != 'true' }}
+        run: kind create cluster --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Set KUBECONFIG
         run: |
           mkdir -p /home/runner/.kube
           kind get kubeconfig > /home/runner/.kube/config
-        if: ${{ env.USE_EXISTING_CLUSTER }}
+        if: ${{ env.USE_EXISTING_CLUSTER == 'true' }}
       - name: Test E2E
         run: |
           IMAGE_TAG=e2e KLUSTERLET_DEPLOY_MODE=Singleton make test-e2e
@@ -111,21 +106,19 @@ jobs:
         run: sudo chown runner:docker /var/run/docker.sock
         if: ${{ env.ACT }} # this step only runs locally when using the https://github.com/nektos/act to debug the e2e
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kind
-        uses: engineerd/setup-kind@ecfad61750951586a9ef973db567df1d28671bdc # v0.6.2
-        with:
-          version: v0.22.0
-          skipClusterCreation: ${{ env.USE_EXISTING_CLUSTER }}
+        if: ${{ env.USE_EXISTING_CLUSTER != 'true' }}
+        run: kind create cluster --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Set KUBECONFIG
         run: |
           mkdir -p /home/runner/.kube
           kind get kubeconfig > /home/runner/.kube/config
-        if: ${{ env.USE_EXISTING_CLUSTER }}
+        if: ${{ env.USE_EXISTING_CLUSTER == 'true' }}
       - name: Test E2E
         run: |
           IMAGE_TAG=e2e REGISTRATION_DRIVER=grpc make test-e2e

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -27,15 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: unit
         run: make test
       - name: report coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./coverage.out
@@ -52,9 +52,9 @@ jobs:
         image-name: [ registration-operator, registration, work, placement, addon-manager ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -74,13 +74,13 @@ jobs:
           image_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "quay.io/open-cluster-management/${{ matrix.image-name }}:latest-${{ matrix.arch }}" | cut -d'@' -f2)
           echo "IMAGE_DIGEST=${image_digest}" >> $GITHUB_ENV
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: quay.io/open-cluster-management/${{ matrix.image-name }}:latest-${{ matrix.arch }}
           format: 'spdx-json'
           output-file: 'sbom.spdx.json'
       - name: Attest
-        uses: actions/attest-sbom@v4
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
         id: attest
         with:
           subject-name: quay.io/open-cluster-management/${{ matrix.image-name }}
@@ -96,7 +96,7 @@ jobs:
     needs: [ images ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Step to install Skopeo
       - name: Install Skopeo and jq
         run: |
@@ -120,13 +120,13 @@ jobs:
           image_digest_latest=$(skopeo inspect docker://quay.io/open-cluster-management/${{ matrix.image-name }}:latest | jq -r '.Digest')
           echo "IMAGE_DIGEST_LATEST=${image_digest_latest}" >> $GITHUB_ENV
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: quay.io/open-cluster-management/${{ matrix.image-name }}:latest
           format: 'spdx-json'
           output-file: 'sbom.spdx.json'
       - name: Attest
-        uses: actions/attest-sbom@v4
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
         id: attest
         with:
           subject-name: quay.io/open-cluster-management/${{ matrix.image-name }}
@@ -138,7 +138,7 @@ jobs:
     name: trigger clusteradm e2e
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v4
+      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.OCM_BOT_PAT }}
           repository: open-cluster-management-io/clusteradm

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: unit
         run: make test
       - name: report coverage
@@ -57,6 +58,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: verify
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: build
@@ -57,15 +57,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: unit
         run: make test
       - name: report coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./coverage.out
@@ -79,9 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/ocm
@@ -45,12 +45,12 @@ jobs:
       attestations: write
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/ocm
       - name: set up Python 3.x
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -63,7 +63,7 @@ jobs:
           python hack/changelog.py ${{ secrets.GITHUB_TOKEN }} ${{ needs.env.outputs.RELEASE_VERSION }} > /home/runner/work/changelog.txt
           cat /home/runner/work/changelog.txt
       - name: setup helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
       - name: chart package
         if: github.event_name != 'pull_request'
         run: |
@@ -74,7 +74,7 @@ jobs:
           popd
       - name: publish release
         if: github.event_name != 'pull_request'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -84,6 +84,6 @@ jobs:
           files: |
             /home/runner/work/ocm/ocm/go/src/open-cluster-management.io/ocm/release/*.tgz
       - name: generate helm charts attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: '/home/runner/work/ocm/ocm/go/src/open-cluster-management.io/ocm/release/*.tgz'

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/ocm
@@ -50,12 +50,12 @@ jobs:
         image-name: [ registration-operator, registration, work, placement, addon-manager ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/ocm
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -75,14 +75,14 @@ jobs:
           image_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "quay.io/open-cluster-management/${{ matrix.image-name }}:${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }}" | cut -d'@' -f2)
           echo "IMAGE_DIGEST=${image_digest}" >> $GITHUB_ENV
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: quay.io/open-cluster-management/${{ matrix.image-name }}:${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }}
           format: 'spdx-json'
           output-file: 'sbom.spdx.json'
           upload-release-assets: false # disable uploading SBOM to release assets for images
       - name: Attest
-        uses: actions/attest-sbom@v4
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
         id: attest
         with:
           subject-name: quay.io/open-cluster-management/${{ matrix.image-name }}
@@ -98,7 +98,7 @@ jobs:
     needs: [ env, images ]
     steps:
       - name: checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           path: go/src/open-cluster-management.io/ocm
@@ -125,14 +125,14 @@ jobs:
           image_digest_release=$(skopeo inspect docker://quay.io/open-cluster-management/${{ matrix.image-name }}:${{ needs.env.outputs.RELEASE_VERSION }} | jq -r '.Digest')
           echo "IMAGE_DIGEST_RELEASE=${image_digest_release}" >> $GITHUB_ENV
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: quay.io/open-cluster-management/${{ matrix.image-name }}:${{ needs.env.outputs.RELEASE_VERSION }}
           format: 'spdx-json'
           output-file: 'sbom.spdx.json'
           upload-release-assets: false # disable uploading SBOM to release assets for images
       - name: Attest
-        uses: actions/attest-sbom@v4
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
         id: attest
         with:
           subject-name: quay.io/open-cluster-management/${{ matrix.image-name }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open for 120 days with no activity. After 14 days of inactivity, it will be closed. Remove the `stale` label to prevent this issue from being closed.'


### PR DESCRIPTION
Pin all GitHub Actions to immutable commit SHAs to prevent supply chain issues from moving tags.

Replace `engineerd/setup-kind` with a direct `kind create cluster` run step using the `kind` binary pre-installed on GitHub-hosted runners (v0.32.0). The Kubernetes node image version is now explicit via `KUBERNETES_VERSION` env variable set to `v1.29.2` (same version previously used by kind v0.22.0 by default).

Removing setup-kind GH action as it appears to no longer be maintained, and now is causing issues when we use v0.6.2 as the tag v0.6.2 points to a version that is not correct (actual version is the branch v0.6.2).  Note both are old and last modified in 2024.

Additionally, the GH actions runner image now already contains kind.

> **Note:** We can consider updating the Kubernetes version used for kind as well - as noted above we've set it to the old version used previously - but I would say we should consider updating.


Fixes: https://github.com/open-cluster-management-io/ocm/issues/1578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned third-party GitHub Actions used in CI, release, and image/manifest pipelines to specific commit SHAs (including checkout, Go/Python setup, Helm, release tooling, SBOM generation/attestation, coverage, and stale handling) for improved reproducibility and supply-chain security.
  * Updated the E2E workflow to use a configurable Kubernetes version (default `v1.29.2`) and switched to direct `kind create cluster` setup, gated by an existing-cluster flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->