### PR TITLE
:bug: fix(cmainstallprogression): wrap PatchStatus calls in RetryOnConflict

### DIFF
--- a/pkg/addon/controllers/cmainstallprogression/controller.go
+++ b/pkg/addon/controllers/cmainstallprogression/controller.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
@@ -20,7 +22,8 @@ import (
 // cmaInstallProgressionController reconciles instances of clustermanagementaddon the hub
 // based to update related object and status condition.
 type cmaInstallProgressionController struct {
-	patcher patcher.Patcher[
+	addonClient addonclient.Interface
+	patcher     patcher.Patcher[
 		*addonv1beta1.ClusterManagementAddOn, addonv1beta1.ClusterManagementAddOnSpec, addonv1beta1.ClusterManagementAddOnStatus]
 	clusterManagementAddonLister addonlisterv1beta1.ClusterManagementAddOnLister
 	addonFilterFunc              factory.EventFilterFunc
@@ -33,6 +36,7 @@ func NewCMAInstallProgressionController(
 	addonFilterFunc factory.EventFilterFunc,
 ) factory.Controller {
 	c := &cmaInstallProgressionController{
+		addonClient: addonClient,
 		patcher: patcher.NewPatcher[
 			*addonv1beta1.ClusterManagementAddOn, addonv1beta1.ClusterManagementAddOnSpec, addonv1beta1.ClusterManagementAddOnStatus](
 			addonClient.AddonV1beta1().ClusterManagementAddOns()),
@@ -58,31 +62,101 @@ func (c *cmaInstallProgressionController) sync(ctx context.Context, syncCtx fact
 		return err
 	}
 
-	mgmtAddonCopy := mgmtAddon.DeepCopy()
-
-	// set default config reference
-	mgmtAddonCopy.Status.DefaultConfigReferences = setDefaultConfigReference(mgmtAddonCopy.Spec.DefaultConfigs, mgmtAddonCopy.Status.DefaultConfigReferences)
-
 	// update default config reference when type is manual
-	if mgmtAddonCopy.Spec.InstallStrategy.Type == "" || mgmtAddonCopy.Spec.InstallStrategy.Type == addonv1beta1.AddonInstallStrategyManual {
-		mgmtAddonCopy.Status.InstallProgressions = []addonv1beta1.InstallProgression{}
-		_, err = c.patcher.PatchStatus(ctx, mgmtAddonCopy, mgmtAddonCopy.Status, mgmtAddon.Status)
-		return err
+	if mgmtAddon.Spec.InstallStrategy.Type == "" || mgmtAddon.Spec.InstallStrategy.Type == addonv1beta1.AddonInstallStrategyManual {
+		return c.patchManualStatus(ctx, mgmtAddon)
 	}
 
 	// only update default config references and skip updating install progression for self-managed addon
 	if !c.addonFilterFunc(mgmtAddon) {
-		_, err = c.patcher.PatchStatus(ctx, mgmtAddonCopy, mgmtAddonCopy.Status, mgmtAddon.Status)
-		return err
+		return c.patchSelfManagedStatus(ctx, mgmtAddon)
 	}
 
 	// set install progression
-	mgmtAddonCopy.Status.InstallProgressions = setInstallProgression(mgmtAddonCopy.Spec.DefaultConfigs,
-		mgmtAddonCopy.Spec.InstallStrategy.Placements, mgmtAddonCopy.Status.InstallProgressions)
+	return c.patchInstallProgressionStatus(ctx, mgmtAddon)
+}
 
-	// update cma status
-	_, err = c.patcher.PatchStatus(ctx, mgmtAddonCopy, mgmtAddonCopy.Status, mgmtAddon.Status)
-	return err
+// patchManualStatus updates the CMA status for manual install strategy addons, retrying on conflict.
+func (c *cmaInstallProgressionController) patchManualStatus(
+	ctx context.Context,
+	seed *addonv1beta1.ClusterManagementAddOn,
+) error {
+	// needFresh tracks whether we need to re-fetch from the API server on subsequent retry iterations.
+	// The first attempt reuses the lister-cached object so no extra Get is issued on the happy path.
+	needFresh := false
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		base := seed
+		if needFresh {
+			fresh, err := c.addonClient.AddonV1beta1().ClusterManagementAddOns().
+				Get(ctx, seed.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			base = fresh
+		}
+		needFresh = true
+
+		newObj := base.DeepCopy()
+		newObj.Status.DefaultConfigReferences = setDefaultConfigReference(
+			newObj.Spec.DefaultConfigs, newObj.Status.DefaultConfigReferences)
+		newObj.Status.InstallProgressions = []addonv1beta1.InstallProgression{}
+		_, err := c.patcher.PatchStatus(ctx, newObj, newObj.Status, base.Status)
+		return err
+	})
+}
+
+// patchSelfManagedStatus updates only the default config references for self-managed addons, retrying on conflict.
+func (c *cmaInstallProgressionController) patchSelfManagedStatus(
+	ctx context.Context,
+	seed *addonv1beta1.ClusterManagementAddOn,
+) error {
+	needFresh := false
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		base := seed
+		if needFresh {
+			fresh, err := c.addonClient.AddonV1beta1().ClusterManagementAddOns().
+				Get(ctx, seed.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			base = fresh
+		}
+		needFresh = true
+
+		newObj := base.DeepCopy()
+		newObj.Status.DefaultConfigReferences = setDefaultConfigReference(
+			newObj.Spec.DefaultConfigs, newObj.Status.DefaultConfigReferences)
+		_, err := c.patcher.PatchStatus(ctx, newObj, newObj.Status, base.Status)
+		return err
+	})
+}
+
+// patchInstallProgressionStatus updates both the default config references and install progressions, retrying on conflict.
+func (c *cmaInstallProgressionController) patchInstallProgressionStatus(
+	ctx context.Context,
+	seed *addonv1beta1.ClusterManagementAddOn,
+) error {
+	needFresh := false
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		base := seed
+		if needFresh {
+			fresh, err := c.addonClient.AddonV1beta1().ClusterManagementAddOns().
+				Get(ctx, seed.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			base = fresh
+		}
+		needFresh = true
+
+		newObj := base.DeepCopy()
+		newObj.Status.DefaultConfigReferences = setDefaultConfigReference(
+			newObj.Spec.DefaultConfigs, newObj.Status.DefaultConfigReferences)
+		newObj.Status.InstallProgressions = setInstallProgression(newObj.Spec.DefaultConfigs,
+			newObj.Spec.InstallStrategy.Placements, newObj.Status.InstallProgressions)
+		_, err := c.patcher.PatchStatus(ctx, newObj, newObj.Status, base.Status)
+		return err
+	})
 }
 
 func setDefaultConfigReference(supportedConfigs []addonv1beta1.AddOnConfig,

--- a/pkg/addon/controllers/cmainstallprogression/controller.go
+++ b/pkg/addon/controllers/cmainstallprogression/controller.go
@@ -29,6 +29,8 @@ type cmaInstallProgressionController struct {
 	addonFilterFunc              factory.EventFilterFunc
 }
 
+// NewCMAInstallProgressionController creates a new controller that reconciles
+// ClusterManagementAddOn status.supportedConfigs and status.installProgressions.
 func NewCMAInstallProgressionController(
 	addonClient addonclient.Interface,
 	addonInformers addoninformerv1beta1.ManagedClusterAddOnInformer,
@@ -51,6 +53,9 @@ func NewCMAInstallProgressionController(
 
 }
 
+// sync reconciles a single ClusterManagementAddOn, updating its status based on
+// the install strategy type. It routes to the appropriate patch helper and retries
+// on 409 Conflict errors to avoid thundering-herd races on hub restart.
 func (c *cmaInstallProgressionController) sync(ctx context.Context, syncCtx factory.SyncContext, addonName string) error {
 	logger := klog.FromContext(ctx).WithValues("addonName", addonName)
 	logger.V(4).Info("Reconciling addon")
@@ -159,6 +164,8 @@ func (c *cmaInstallProgressionController) patchInstallProgressionStatus(
 	})
 }
 
+// setDefaultConfigReference builds the DefaultConfigReferences slice from the
+// supported configs, preserving existing spec hashes where the config already exists.
 func setDefaultConfigReference(supportedConfigs []addonv1beta1.AddOnConfig,
 	existDefaultConfigReferences []addonv1beta1.DefaultConfigReference) []addonv1beta1.DefaultConfigReference {
 	newDefaultConfigReferences := []addonv1beta1.DefaultConfigReference{}
@@ -181,6 +188,8 @@ func setDefaultConfigReference(supportedConfigs []addonv1beta1.AddOnConfig,
 	return newDefaultConfigReferences
 }
 
+// findDefaultConfigReference returns the existing DefaultConfigReference for the
+// given config group/resource pair, or false if none exists.
 func findDefaultConfigReference(
 	newobj *addonv1beta1.DefaultConfigReference,
 	oldobjs []addonv1beta1.DefaultConfigReference,
@@ -193,6 +202,8 @@ func findDefaultConfigReference(
 	return nil, false
 }
 
+// setInstallProgression builds the InstallProgressions slice from the placement
+// strategies, merging with any existing progression state.
 func setInstallProgression(supportedConfigs []addonv1beta1.AddOnConfig, placementStrategies []addonv1beta1.PlacementStrategy,
 	existInstallProgressions []addonv1beta1.InstallProgression) []addonv1beta1.InstallProgression {
 	newInstallProgressions := []addonv1beta1.InstallProgression{}
@@ -257,6 +268,8 @@ func setInstallProgression(supportedConfigs []addonv1beta1.AddOnConfig, placemen
 	return newInstallProgressions
 }
 
+// findInstallProgression returns the existing InstallProgression that matches the
+// placement name and namespace of newobj, or false if none exists.
 func findInstallProgression(newobj *addonv1beta1.InstallProgression, oldobjs []addonv1beta1.InstallProgression) (*addonv1beta1.InstallProgression, bool) {
 	for _, oldobj := range oldobjs {
 		if oldobj.PlacementRef == newobj.PlacementRef {
@@ -276,6 +289,8 @@ func findInstallProgression(newobj *addonv1beta1.InstallProgression, oldobjs []a
 	return nil, false
 }
 
+// mergeInstallProgression copies progression state (conditions, config references)
+// from oldobj into newobj so existing status is preserved across reconcile cycles.
 func mergeInstallProgression(newobj, oldobj *addonv1beta1.InstallProgression) {
 	// merge config reference
 	for i := range newobj.ConfigReferences {

--- a/pkg/addon/controllers/cmainstallprogression/controller_test.go
+++ b/pkg/addon/controllers/cmainstallprogression/controller_test.go
@@ -3,10 +3,15 @@ package cmainstallprogression
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clienttesting "k8s.io/client-go/testing"
 
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
@@ -14,6 +19,7 @@ import (
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
+	"open-cluster-management.io/sdk-go/pkg/patcher"
 
 	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
 )
@@ -489,5 +495,85 @@ func TestReconcile(t *testing.T) {
 			}
 			c.validateAddonActions(t, fakeAddonClient.Actions())
 		})
+	}
+}
+
+// TestPatchStatusRetriesOn409Conflict verifies that the sync function retries PatchStatus
+// on a 409 Conflict error. Two consecutive conflicts are injected; the third attempt must
+// succeed and leave status.defaultConfigReferences populated.
+func TestPatchStatusRetriesOn409Conflict(t *testing.T) {
+	cma := addontesting.NewClusterManagementAddon("test", "testcrd", "testcr").WithDefaultConfigs(
+		addonv1beta1.AddOnConfig{
+			ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+				Group:    "addon.open-cluster-management.io",
+				Resource: "addonhubconfigs",
+			},
+			ConfigReferent: addonv1beta1.ConfigReferent{
+				Name:      "test-config",
+				Namespace: "test-ns",
+			},
+		},
+	).Build()
+
+	fakeAddonClient := fakeaddon.NewSimpleClientset(cma)
+
+	// Count how many times the patch reactor fires a conflict.
+	var conflictsFired atomic.Int32
+
+	fakeAddonClient.PrependReactor("patch", "clustermanagementaddons",
+		func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+			if conflictsFired.Load() < 2 {
+				conflictsFired.Add(1)
+				return true, nil, errors.NewConflict(
+					schema.GroupResource{
+						Group:    "addon.open-cluster-management.io",
+						Resource: "clustermanagementaddons",
+					},
+					"test",
+					fmt.Errorf("simulated conflict"),
+				)
+			}
+			// Fall through to the default fake reactor on the 3rd attempt.
+			return false, nil, nil
+		},
+	)
+
+	addonInformers := addoninformers.NewSharedInformerFactory(fakeAddonClient, 10*time.Minute)
+	if err := addonInformers.Addon().V1beta1().ClusterManagementAddOns().Informer().GetStore().Add(cma); err != nil {
+		t.Fatal(err)
+	}
+
+	syncContext := testingcommon.NewFakeSyncContext(t, "test")
+
+	// Construct the controller directly so we can call sync() within this test package.
+	// The CMA has manual install strategy type (set by the builder default), so it exercises
+	// the patchManualStatus retry path.
+	c := &cmaInstallProgressionController{
+		addonClient: fakeAddonClient,
+		patcher: patcher.NewPatcher[
+			*addonv1beta1.ClusterManagementAddOn,
+			addonv1beta1.ClusterManagementAddOnSpec,
+			addonv1beta1.ClusterManagementAddOnStatus](
+			fakeAddonClient.AddonV1beta1().ClusterManagementAddOns()),
+		clusterManagementAddonLister: addonInformers.Addon().V1beta1().ClusterManagementAddOns().Lister(),
+		addonFilterFunc:              utils.ManagedByAddonManager,
+	}
+
+	err := c.sync(context.TODO(), syncContext, "test")
+	if err != nil {
+		t.Fatalf("expected sync to succeed after retries, got error: %v", err)
+	}
+
+	if got := conflictsFired.Load(); got != 2 {
+		t.Errorf("expected 2 conflicts to be fired, got %d", got)
+	}
+
+	// Verify the final CMA status has defaultConfigReferences populated.
+	updatedCMA, err := fakeAddonClient.AddonV1beta1().ClusterManagementAddOns().Get(context.TODO(), "test", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get CMA after sync: %v", err)
+	}
+	if len(updatedCMA.Status.DefaultConfigReferences) == 0 {
+		t.Errorf("expected status.defaultConfigReferences to be populated, got empty")
 	}
 }


### PR DESCRIPTION
## What this PR does

Wraps the three bare `PatchStatus` call sites in `cmainstallprogression/controller.go` in `retry.RetryOnConflict`, fixing a thundering-herd race that leaves `ClusterManagementAddOn.status.supportedConfigs` unpopulated after hub restart.

Fixes #1582

## Root cause

On hub restart the informer cache rebuilds and fires a reconcile event for every `ClusterManagementAddOn` simultaneously. Multiple goroutines race to patch the same CMA status. The sdk-go patcher makes a single `client.Patch()` with no retry — concurrent attempts fail with `409 Conflict`. The field is never written, so every subsequent `MCA.spec.configs` patch is rejected with `ConfigurationUnsupported` and ManifestWorks are never created.

## Changes

- Extracts each of the three `sync()` code paths into dedicated private methods: `patchManualStatus`, `patchSelfManagedStatus`, `patchInstallProgressionStatus`
- Each wraps its `PatchStatus` call in `retry.RetryOnConflict(retry.DefaultRetry, ...)`
- First attempt reuses the lister-cached object (no extra API call on the happy path); any retry re-fetches a fresh object from the API server to get the current `resourceVersion`
- Adds `addonClient` field to the struct for use in retry re-fetches

## Test

`TestPatchStatusRetriesOn409Conflict` injects 2 consecutive `409 Conflict` errors via `PrependReactor`, calls `sync()`, and asserts no error is returned, exactly 2 conflicts fired, and `status.defaultConfigReferences` is populated. The test fails to build on unpatched main, proving it is coupled to the fix.

## Testing

```
go test ./pkg/addon/controllers/cmainstallprogression/... -v -count=1
make test-addon-integration
```

Both pass on this branch (27/27 integration specs pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## New Features
* None.

## Bug Fixes
* Improved resilience when updating cluster management add-on status by retrying on concurrent modification (409) conflicts until the update succeeds.

## Refactor
* Reworked install progression reconciliation to use separate helper flows based on installation strategy, with updated status recalculation rules per path.

## Tests
* Added a unit test that simulates repeated 409 conflicts during status patching and verifies the controller succeeds and updates default configuration references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->