### PR TITLE
:seedling: deflake registration integration tests (ClusterProfile, addon lease resync)

### DIFF
--- a/test/integration/registration/addon_lease_test.go
+++ b/test/integration/registration/addon_lease_test.go
@@ -193,6 +193,32 @@ var _ = ginkgo.Describe("Addon Lease Resync", func() {
 	ginkgo.It("should update addon status to unavailable after addon lease controller resync", func() {
 		assertSuccessClusterBootstrap()
 		assertAddOn()
+
+		// The addon lease is created once and is not renewed by any agent in this test.
+		// With AddOnLeaseControllerLeaseDurationSeconds=1 the lease goes stale after a
+		// ~5s grace period, so the "available" window is too short to observe reliably
+		// on a slow machine. Keep the lease fresh until we have confirmed "available",
+		// then stop renewing to exercise the transition to "unavailable".
+		renewCtx, stopRenew := context.WithCancel(context.TODO())
+		defer stopRenew()
+		go func() {
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-renewCtx.Done():
+					return
+				case <-ticker.C:
+					lease, err := kubeClient.CoordinationV1().Leases(addOnName).Get(renewCtx, addOnName, metav1.GetOptions{})
+					if err != nil {
+						continue
+					}
+					lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+					_, _ = kubeClient.CoordinationV1().Leases(addOnName).Update(renewCtx, lease, metav1.UpdateOptions{})
+				}
+			}
+		}()
+
 		gomega.Eventually(func() error {
 			addOn, err := addOnClient.AddonV1alpha1().ManagedClusterAddOns(managedClusterName).Get(context.TODO(), addOnName, metav1.GetOptions{})
 			if err != nil {
@@ -206,6 +232,9 @@ var _ = ginkgo.Describe("Addon Lease Resync", func() {
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 		assertAddonLabel(managedClusterName, addOnName, "available")
+
+		// stop renewing the lease so it goes stale and the addon becomes unavailable
+		stopRenew()
 
 		// do not update addon lease, wait resync once, the addon status should be unavailable
 		gomega.Eventually(func() error {

--- a/test/integration/registration/clusterprofile_test.go
+++ b/test/integration/registration/clusterprofile_test.go
@@ -1265,21 +1265,14 @@ var _ = ginkgo.Describe("ClusterProfile", func() {
 		_, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Create ManagedClusterSet")
-		clusterSet := &clusterv1beta2.ManagedClusterSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: clusterSetName,
-			},
-			Spec: clusterv1beta2.ManagedClusterSetSpec{
-				ClusterSelector: clusterv1beta2.ManagedClusterSelector{
-					SelectorType: clusterv1beta2.ExclusiveClusterSetLabel,
-				},
-			},
-		}
-		_, err = clusterClient.ClusterV1beta2().ManagedClusterSets().Create(context.Background(), clusterSet, metav1.CreateOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// NOTE: intentionally do NOT create the ManagedClusterSet. Without it, the
+		// ManagedClusterSetBinding controller keeps the binding unbound
+		// (condition Bound=False, reason ClusterSetNotFound), which deterministically
+		// exercises the "binding is not bound" path. If the clusterset existed the
+		// binding would become bound and a ClusterProfile would (correctly) be
+		// created, which previously made this test race against that transition.
 
-		ginkgo.By("Create ManagedCluster")
+		ginkgo.By("Create ManagedCluster labeled for the absent clusterset")
 		cluster := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterName,
@@ -1294,7 +1287,7 @@ var _ = ginkgo.Describe("ClusterProfile", func() {
 		_, err = clusterClient.ClusterV1().ManagedClusters().Create(context.Background(), cluster, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Create ManagedClusterSetBinding")
+		ginkgo.By("Create ManagedClusterSetBinding referencing the absent clusterset")
 		binding := &clusterv1beta2.ManagedClusterSetBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterSetName,
@@ -1307,18 +1300,17 @@ var _ = ginkgo.Describe("ClusterProfile", func() {
 		_, err = clusterClient.ClusterV1beta2().ManagedClusterSetBindings(namespace).Create(context.Background(), binding, metav1.CreateOptions{})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By("Verify ClusterProfile is NOT created while binding is not bound")
-		gomega.Consistently(func() bool {
-			binding, err := clusterClient.ClusterV1beta2().ManagedClusterSetBindings(namespace).Get(context.Background(), clusterSetName, metav1.GetOptions{})
-			if err != nil {
-				return false
-			}
-			// If binding is not bound, profile should not exist
-			if !meta.IsStatusConditionTrue(binding.Status.Conditions, clusterv1beta2.ClusterSetBindingBoundType) {
-				_, err := clusterProfileClient.ApisV1alpha1().ClusterProfiles(namespace).Get(context.Background(), clusterName, metav1.GetOptions{})
-				return errors.IsNotFound(err)
-			}
-			return true
-		}, "10s", "2s").Should(gomega.BeTrue())
+		ginkgo.By("Verify the binding is reported as not bound")
+		gomega.Eventually(func(g gomega.Gomega) {
+			b, err := clusterClient.ClusterV1beta2().ManagedClusterSetBindings(namespace).Get(context.Background(), clusterSetName, metav1.GetOptions{})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(meta.IsStatusConditionTrue(b.Status.Conditions, clusterv1beta2.ClusterSetBindingBoundType)).To(gomega.BeFalse())
+		}, "10s", "1s").Should(gomega.Succeed())
+
+		ginkgo.By("Verify ClusterProfile is NOT created while the binding is not bound")
+		gomega.Consistently(func(g gomega.Gomega) {
+			_, err := clusterProfileClient.ApisV1alpha1().ClusterProfiles(namespace).Get(context.Background(), clusterName, metav1.GetOptions{})
+			g.Expect(errors.IsNotFound(err)).To(gomega.BeTrue(), "ClusterProfile should not be created while the binding is not bound")
+		}, "10s", "2s").Should(gomega.Succeed())
 	})
 })


### PR DESCRIPTION
  PR title

  :seedling: deflake registration integration tests (ClusterProfile and addon lease resync)

  PR description

  ## Summary

  Fixes two flaky tests in the registration integration suite (test-only changes).

  **1. ClusterProfile — "should NOT create ClusterProfile when binding is not bound"**
  The test created the `ManagedClusterSet`, which made the binding become *bound* — so it never really tested the "not bound" case and raced while the binding flipped.
 
 Fix: don't create the clusterset, so the binding stays unbound for the whole test,
  then assert no ClusterProfile is created.

  **2. Addon Lease Resync — "should update addon status to unavailable after addon lease controller resync"**
  The addon lease was created once and never renewed, so the "available" window was only ~5s and a slow runner could miss it.
  Fix: keep the lease renewed until the addon is confirmed "available", then stop renewing to test the transition to "unavailable".

  ## Related issue(s)

  Part of #1402



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added addon lease renewal test with background refresh cycles to validate availability state transitions and status changes.
  * Improved ClusterProfile binding test determinism by ensuring referenced resources are absent, preventing race conditions and reliably verifying that profiles are not created when bindings remain unbound.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->