### PR TITLE
:sparkles: feat: support clusterLabels for klusterlet

### DIFF
--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -103,6 +103,9 @@ spec:
           {{if .ClusterAnnotationsString}}
           - "--cluster-annotations={{ .ClusterAnnotationsString }}"
           {{end}}
+          {{if .ClusterLabelsString}}
+          - "--cluster-labels={{ .ClusterLabelsString }}"
+          {{end}}
           {{if eq .InstallMode "SingletonHosted"}}
           - "--spoke-kubeconfig=/spoke/config/kubeconfig"
           - "--terminate-on-files=/spoke/config/kubeconfig"

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -88,6 +88,9 @@ spec:
           {{if .ClusterAnnotationsString}}
           - "--cluster-annotations={{ .ClusterAnnotationsString }}"
           {{end}}
+          {{if .ClusterLabelsString}}
+          - "--cluster-labels={{ .ClusterLabelsString }}"
+          {{end}}
           {{if gt .RegistrationKubeAPIQPS 0.0}}
           - "--kube-api-qps={{ .RegistrationKubeAPIQPS }}"
           {{end}}

--- a/pkg/common/helpers/labels.go
+++ b/pkg/common/helpers/labels.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 )
 
@@ -21,6 +22,16 @@ func FilterClusterLabels(labels map[string]string) map[string]string {
 	for k, v := range labels {
 		if isReservedLabelKey(k) {
 			klog.Warningf("label %q is reserved by open-cluster-management and will be ignored", k)
+			continue
+		}
+		// Drop labels that are not valid Kubernetes labels so a single bad entry
+		// cannot block the ManagedCluster creation during bootstrap.
+		if errs := validation.IsQualifiedName(k); len(errs) > 0 {
+			klog.Warningf("label key %q is not a valid label key and will be ignored: %s", k, strings.Join(errs, "; "))
+			continue
+		}
+		if errs := validation.IsValidLabelValue(v); len(errs) > 0 {
+			klog.Warningf("label value of %q is not a valid label value and will be ignored: %s", k, strings.Join(errs, "; "))
 			continue
 		}
 		clusterLabels[k] = v

--- a/pkg/common/helpers/labels.go
+++ b/pkg/common/helpers/labels.go
@@ -1,0 +1,38 @@
+package helpers
+
+import (
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// reservedLabelDomain is the label key domain OCM owns; the spoke agent must not set labels in it.
+const reservedLabelDomain = "open-cluster-management.io"
+
+// FilterClusterLabels keeps only the labels the spoke is meant to set on the
+// ManagedCluster, dropping any key in the OCM reserved domain. It is input hygiene
+// for the operator-provided labels, not a hub-side authorization check.
+func FilterClusterLabels(labels map[string]string) map[string]string {
+	clusterLabels := make(map[string]string)
+	if labels == nil {
+		return clusterLabels
+	}
+
+	for k, v := range labels {
+		if isReservedLabelKey(k) {
+			klog.Warningf("label %q is reserved by open-cluster-management and will be ignored", k)
+			continue
+		}
+		clusterLabels[k] = v
+	}
+
+	return clusterLabels
+}
+
+func isReservedLabelKey(key string) bool {
+	domain, _, found := strings.Cut(key, "/")
+	if !found {
+		return false
+	}
+	return domain == reservedLabelDomain || strings.HasSuffix(domain, "."+reservedLabelDomain)
+}

--- a/pkg/common/helpers/labels_test.go
+++ b/pkg/common/helpers/labels_test.go
@@ -1,0 +1,113 @@
+package helpers
+
+import (
+	"reflect"
+	"testing"
+
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+)
+
+func TestFilterClusterLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   map[string]string
+	}{
+		{
+			name:   "nil labels",
+			labels: nil,
+			want:   map[string]string{},
+		},
+		{
+			name:   "empty labels",
+			labels: map[string]string{},
+			want:   map[string]string{},
+		},
+		{
+			name: "plain user labels are kept",
+			labels: map[string]string{
+				"env":    "prod",
+				"region": "us-west",
+			},
+			want: map[string]string{
+				"env":    "prod",
+				"region": "us-west",
+			},
+		},
+		{
+			name: "clusterset label is dropped",
+			labels: map[string]string{
+				clusterv1beta2.ClusterSetLabel: "team-a",
+				"env":                          "prod",
+			},
+			want: map[string]string{
+				"env": "prod",
+			},
+		},
+		{
+			name: "cluster-name label is dropped",
+			labels: map[string]string{
+				clusterv1.ClusterNameLabelKey: "cluster1",
+				"team":                        "platform",
+			},
+			want: map[string]string{
+				"team": "platform",
+			},
+		},
+		{
+			name: "any open-cluster-management.io subdomain is dropped",
+			labels: map[string]string{
+				"feature.open-cluster-management.io/addon": "enabled",
+				"env": "dev",
+			},
+			want: map[string]string{
+				"env": "dev",
+			},
+		},
+		{
+			name: "trailing slash on the reserved domain is dropped",
+			labels: map[string]string{
+				"open-cluster-management.io/": "x",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "reserved domain used as a bare name is kept",
+			labels: map[string]string{
+				"open-cluster-management.io": "x",
+				"env":                        "prod",
+			},
+			want: map[string]string{
+				"open-cluster-management.io": "x",
+				"env":                        "prod",
+			},
+		},
+		{
+			name: "other vendor domains are kept",
+			labels: map[string]string{
+				"example.com/team": "blue",
+			},
+			want: map[string]string{
+				"example.com/team": "blue",
+			},
+		},
+		{
+			name: "lookalike domain is not treated as reserved",
+			labels: map[string]string{
+				"myopen-cluster-management.io/foo": "bar",
+			},
+			want: map[string]string{
+				"myopen-cluster-management.io/foo": "bar",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FilterClusterLabels(tt.labels); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FilterClusterLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/common/helpers/labels_test.go
+++ b/pkg/common/helpers/labels_test.go
@@ -84,6 +84,35 @@ func TestFilterClusterLabels(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid label key is dropped",
+			labels: map[string]string{
+				"not a valid key": "x",
+				"env":             "prod",
+			},
+			want: map[string]string{
+				"env": "prod",
+			},
+		},
+		{
+			name: "invalid label value is dropped",
+			labels: map[string]string{
+				"team": "not a valid value!",
+				"env":  "prod",
+			},
+			want: map[string]string{
+				"env": "prod",
+			},
+		},
+		{
+			name: "empty label value is kept",
+			labels: map[string]string{
+				"env": "",
+			},
+			want: map[string]string{
+				"env": "",
+			},
+		},
+		{
 			name: "other vendor domains are kept",
 			labels: map[string]string{
 				"example.com/team": "blue",

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -3,6 +3,7 @@ package klusterletcontroller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -168,6 +169,7 @@ type klusterletConfig struct {
 	Replica                                     int32
 	ClientCertExpirationSeconds                 int32
 	ClusterAnnotationsString                    string
+	ClusterLabelsString                         string
 	RegistrationKubeAPIQPS                      float32
 	RegistrationKubeAPIBurst                    int32
 	WorkKubeAPIQPS                              float32
@@ -404,6 +406,15 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 			annotationsArray = append(annotationsArray, fmt.Sprintf("%s=%s", k, v))
 		}
 		config.ClusterAnnotationsString = strings.Join(annotationsArray, ",")
+
+		// construct cluster labels string, the final format is "key1=value1,key2=value2".
+		// keys are sorted so the rendered arg is stable and does not churn the deployment.
+		var labelsArray []string
+		for k, v := range commonhelpers.FilterClusterLabels(klusterlet.Spec.RegistrationConfiguration.ClusterLabels) {
+			labelsArray = append(labelsArray, fmt.Sprintf("%s=%s", k, v))
+		}
+		sort.Strings(labelsArray)
+		config.ClusterLabelsString = strings.Join(labelsArray, ",")
 
 		// Set AddOnKubeClientRegistrationAuth from the Klusterlet spec
 		if klusterlet.Spec.RegistrationConfiguration.AddOnKubeClientRegistrationDriver != nil &&

--- a/pkg/registration/spoke/options.go
+++ b/pkg/registration/spoke/options.go
@@ -36,6 +36,7 @@ type SpokeAgentOptions struct {
 	MaxCustomClusterClaims       int
 	ReservedClusterClaimSuffixes []string
 	ClusterAnnotations           map[string]string
+	ClusterLabels                map[string]string
 
 	RegisterDriverOption *registerfactory.Options
 }
@@ -76,6 +77,8 @@ func (o *SpokeAgentOptions) AddFlags(fs *pflag.FlagSet) {
 		"A list of suffixes for reserved cluster claims.")
 	fs.StringToStringVar(&o.ClusterAnnotations, "cluster-annotations", o.ClusterAnnotations, `the annotations with the reserve
 	 prefix "agent.open-cluster-management.io" set on ManagedCluster when creating only, other actors can update it afterwards.`)
+	fs.StringToStringVar(&o.ClusterLabels, "cluster-labels", o.ClusterLabels, `the labels set on ManagedCluster when creating only,
+	 other actors can update it afterwards. Keys in the reserved "open-cluster-management.io" domain are ignored.`)
 
 	o.RegisterDriverOption.AddFlags(fs)
 }

--- a/pkg/registration/spoke/registration/creating_controller.go
+++ b/pkg/registration/spoke/registration/creating_controller.go
@@ -132,6 +132,25 @@ func AnnotationDecorator(annotations map[string]string) ManagedClusterDecorator 
 	}
 }
 
+// LabelDecorator sets user-defined labels on the ManagedCluster. Reserved labels are
+// filtered out, and a label that already exists is left untouched so the agent never
+// overwrites a label set by the user or another actor on the hub.
+func LabelDecorator(labels map[string]string) ManagedClusterDecorator {
+	return func(cluster *clusterv1.ManagedCluster) *clusterv1.ManagedCluster {
+		filteredLabels := commonhelpers.FilterClusterLabels(labels)
+		if cluster.Labels == nil {
+			cluster.Labels = make(map[string]string)
+		}
+		for key, value := range filteredLabels {
+			if _, ok := cluster.Labels[key]; ok {
+				continue
+			}
+			cluster.Labels[key] = value
+		}
+		return cluster
+	}
+}
+
 // ClientConfigDecorator merge ClientConfig
 func ClientConfigDecorator(externalServerURLs []string, caBundle []byte) ManagedClusterDecorator {
 	return func(cluster *clusterv1.ManagedCluster) *clusterv1.ManagedCluster {

--- a/pkg/registration/spoke/registration/creating_controller_test.go
+++ b/pkg/registration/spoke/registration/creating_controller_test.go
@@ -2,6 +2,7 @@ package registration
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -9,6 +10,7 @@ import (
 
 	clusterfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 
 	testingcommon "open-cluster-management.io/ocm/pkg/common/testing"
 	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
@@ -75,6 +77,56 @@ func TestCreateSpokeCluster(t *testing.T) {
 			}
 
 			c.validateActions(t, clusterClient.Actions())
+		})
+	}
+}
+
+func TestLabelDecorator(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing map[string]string
+		input    map[string]string
+		want     map[string]string
+	}{
+		{
+			name:  "apply user labels on a cluster without labels",
+			input: map[string]string{"env": "prod"},
+			want:  map[string]string{"env": "prod"},
+		},
+		{
+			name:  "reserved labels are dropped",
+			input: map[string]string{"env": "prod", clusterv1beta2.ClusterSetLabel: "team-a"},
+			want:  map[string]string{"env": "prod"},
+		},
+		{
+			name:     "existing labels are not overwritten",
+			existing: map[string]string{"env": "staging"},
+			input:    map[string]string{"env": "prod", "tier": "gold"},
+			want:     map[string]string{"env": "staging", "tier": "gold"},
+		},
+		{
+			name:     "existing reserved label is preserved and injected reserved value is ignored",
+			existing: map[string]string{clusterv1beta2.ClusterSetLabel: "keep-me"},
+			input:    map[string]string{clusterv1beta2.ClusterSetLabel: "attacker", "env": "prod"},
+			want:     map[string]string{clusterv1beta2.ClusterSetLabel: "keep-me", "env": "prod"},
+		},
+		{
+			name:  "nil input is safe",
+			input: nil,
+			want:  map[string]string{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cluster := &clusterv1.ManagedCluster{}
+			if c.existing != nil {
+				cluster.Labels = c.existing
+			}
+			got := LabelDecorator(c.input)(cluster)
+			if !reflect.DeepEqual(got.Labels, c.want) {
+				t.Errorf("LabelDecorator() labels = %v, want %v", got.Labels, c.want)
+			}
 		})
 	}
 }

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -293,6 +293,7 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 			o.agentOptions.SpokeClusterName,
 			[]registration.ManagedClusterDecorator{
 				registration.AnnotationDecorator(o.registrationOption.ClusterAnnotations),
+				registration.LabelDecorator(o.registrationOption.ClusterLabels),
 				registration.ClientConfigDecorator(o.registrationOption.SpokeExternalServerURLs, spokeClusterCABundle),
 				o.driver.ManagedClusterDecorator,
 			},

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -606,14 +606,13 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 				// klusterlet has no condition, replica is 0
 				gomega.Expect(actual.Status.Replicas).Should(gomega.Equal(int32(0)))
 
-				// Print actual args for debugging
 				actualArgs := actual.Spec.Template.Spec.Containers[0].Args
 				if len(actualArgs) != 8 {
+					// the work deployment may still be mid-reconcile; keep polling instead of failing
 					fmt.Fprintf(ginkgo.GinkgoWriter, "should get 8 args, actual got %v\n", actualArgs)
+					return false
 				}
-
-				gomega.Expect(len(actualArgs)).Should(gomega.Equal(8))
-				return actual.Spec.Template.Spec.Containers[0].Args[2] != "--spoke-cluster-name=cluster2"
+				return actualArgs[2] == "--spoke-cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			gomega.Eventually(func() bool {

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -1128,6 +1128,11 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 					"foo":                                  "bar", // should be ignored
 					"agent.open-cluster-management.io/foo": "bar",
 				},
+				ClusterLabels: map[string]string{
+					"env":  "prod",
+					"team": "blue",
+					"cluster.open-cluster-management.io/clusterset": "should-be-dropped", // reserved, should be filtered out
+				},
 			}
 			klusterlet.Spec.WorkConfiguration = &operatorapiv1.WorkAgentConfiguration{
 				FeatureGates: []operatorapiv1.FeatureGate{
@@ -1189,6 +1194,10 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 			ginkgo.By("Check the registration-agent has the expected cluster-annotations")
 			gomega.Expect(registrationDeployment.Spec.Template.Spec.Containers[0].Args).Should(
 				gomega.ContainElement("--cluster-annotations=agent.open-cluster-management.io/foo=bar"))
+
+			ginkgo.By("Check the registration-agent has the expected cluster-labels: reserved keys filtered out and keys sorted")
+			gomega.Expect(registrationDeployment.Spec.Template.Spec.Containers[0].Args).Should(
+				gomega.ContainElement("--cluster-labels=env=prod,team=blue"))
 
 			ginkgo.By("Check the work-agent has the expected feature gates")
 			workDeployment, err := kubeClient.AppsV1().Deployments(klusterletNamespace).Get(

--- a/test/integration/registration/clusterlabels_test.go
+++ b/test/integration/registration/clusterlabels_test.go
@@ -1,0 +1,65 @@
+package registration_test
+
+import (
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	registerfactory "open-cluster-management.io/ocm/pkg/registration/register/factory"
+	"open-cluster-management.io/ocm/pkg/registration/spoke"
+	"open-cluster-management.io/ocm/test/integration/util"
+)
+
+var _ = ginkgo.Describe("Cluster Labels", func() {
+	ginkgo.It("Cluster Labels should be created on the managed cluster", func() {
+		managedClusterName := "clusterlabels-spokecluster"
+		//#nosec G101
+		hubKubeconfigSecret := "clusterlabels-hub-kubeconfig-secret"
+		hubKubeconfigDir := path.Join(util.TestDir, "clusterlabels", "hub-kubeconfig")
+
+		reservedLabel := "cluster.open-cluster-management.io/clusterset"
+		agentOptions := &spoke.SpokeAgentOptions{
+			BootstrapKubeconfig:      bootstrapKubeConfigFile,
+			HubKubeconfigSecret:      hubKubeconfigSecret,
+			ClusterHealthCheckPeriod: 1 * time.Minute,
+			ClusterLabels: map[string]string{
+				"env":         "prod",
+				reservedLabel: "should-be-dropped", // reserved, should be filtered out
+			},
+			RegisterDriverOption: registerfactory.NewOptions(),
+		}
+
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+
+		// run registration agent
+		cancel := runAgent("clusterlabelstest", agentOptions, commOptions, spokeCfg)
+		defer cancel()
+
+		// after bootstrap the user-defined label should be set and the reserved one filtered out
+		gomega.Eventually(func() error {
+			mc, err := util.GetManagedCluster(clusterClient, managedClusterName)
+			if err != nil {
+				return err
+			}
+
+			if mc.Labels["env"] != "prod" {
+				return fmt.Errorf("expected label env=prod, got %q in %v", mc.Labels["env"], mc.Labels)
+			}
+
+			// Assert the spoke-injected value never wins, rather than absence: the hub may
+			// legitimately own this label (a mutating webhook can default it), so the contract
+			// is only that the value supplied by the spoke is dropped.
+			if mc.Labels[reservedLabel] == "should-be-dropped" {
+				return fmt.Errorf("reserved label %q should have been filtered out, got %v", reservedLabel, mc.Labels)
+			}
+
+			return nil
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+	})
+})


### PR DESCRIPTION
## Summary

Makes the klusterlet `clusterLabels` option functional (#1541). The
`RegistrationConfiguration.ClusterLabels` field already existed in the API but
nothing consumed it, so setting it had no effect. This wires it end-to-end,
mirroring the existing `clusterAnnotations` path.

## What

- Spoke agent: new `--cluster-labels` flag and a `LabelDecorator` that applies the
  labels to the ManagedCluster at creation. It never overwrites a label that
  already exists, and drops keys in the reserved `open-cluster-management.io`
  domain (for example `cluster.open-cluster-management.io/clusterset`).
- Operator: renders `--cluster-labels` onto the registration and singleton agent
  deployments, with keys sorted so the argument is stable and does not cause
  spurious deployment rollouts.
- Helper `FilterClusterLabels` in `pkg/common/helpers`, applied in both the
  operator and the agent.
- Unit and integration tests for filtering, no-overwrite, and the rendered arg.

## Design notes

This addresses the review feedback on the earlier #1123:

- Labels are set on creation only and an existing label is never overwritten.
- Reserved/hub-controlled labels cannot be set from the spoke. A required prefix
  (as annotations use) is not reusable here, because the use case needs arbitrary
  user labels such as `env=prod` for a labelSelector ManagedClusterSet; the filter
  is therefore a denylist on the OCM-owned domain.

The spoke-side filter is input hygiene / defense-in-depth, not an authorization
boundary: the ManagedCluster is created by the agent with its own credentials, so
the hub admission webhook remains the authoritative guard for the clusterset
label. No API/CRD/vendor changes are needed; the field already ships in the pinned
api version.

## Testing

- Unit: `FilterClusterLabels` and `LabelDecorator` (apply, drop reserved, never
  overwrite an existing label).
- Integration (envtest): the operator renders `--cluster-labels=env=prod,team=blue`
  with the reserved key filtered out and keys sorted; the registration agent
  applies `env=prod` to the ManagedCluster and drops the reserved value.

## Related issue(s)

Fixes #1541
Supersedes #1123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing `--cluster-labels` during registration so spoke-provided labels are applied to newly created managed clusters.
  * Cluster labels are serialized in a deterministic order for stable deployment arguments.
* **Bug Fixes**
  * Reserved `open-cluster-management.io` label keys (including subdomains) and invalid label keys/values are now filtered out instead of being set.
  * Existing labels already present on the cluster are preserved and not overwritten.
* **Tests**
  * Expanded unit and integration coverage for label filtering and end-to-end label propagation, plus improved resilience of a klusterlet deployment test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->