### PR TITLE
:bug: Fix config references order

### DIFF
--- a/pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler.go
+++ b/pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler.go
@@ -86,44 +86,46 @@ func (d *managedClusterAddonConfigurationReconciler) mergeAddonConfig(
 	mca *addonv1beta1.ManagedClusterAddOn, desiredConfigMap addonConfigMap) *addonv1beta1.ManagedClusterAddOn {
 	mcaCopy := mca.DeepCopy()
 
-	mergedConfigs := make(addonConfigMap)
-	// First go through the configReferences listed in mca status,
-	// if the existing config (gvk + namespace + name) is also in the desiredConfigMap, append it to mergedConfigs,
-	// this will save the LastAppliedConfig and LastObservedGeneration from mca status.
+	type configKey struct {
+		gr      addonv1beta1.ConfigGroupResource
+		refName string
+		refNs   string
+	}
+
+	// Build a lookup from old status to preserve LastAppliedConfig and LastObservedGeneration
+	oldStatusByKey := map[configKey]addonv1beta1.ConfigReference{}
 	for _, configRef := range mcaCopy.Status.ConfigReferences {
-		gr := configRef.ConfigGroupResource
-		if _, ok := mergedConfigs[gr]; !ok {
-			mergedConfigs[gr] = []addonv1beta1.ConfigReference{}
+		if configRef.DesiredConfig == nil {
+			continue
 		}
-		if _, ok := desiredConfigMap.containsConfig(gr, configRef.DesiredConfig.ConfigReferent); ok {
-			mergedConfigs[gr] = append(mergedConfigs[gr], configRef)
+		key := configKey{
+			gr:      configRef.ConfigGroupResource,
+			refName: configRef.DesiredConfig.ConfigReferent.Name,
+			refNs:   configRef.DesiredConfig.ConfigReferent.Namespace,
 		}
+		oldStatusByKey[key] = configRef
 	}
 
-	// Then go through the desiredConfigMap, for each configReference,
-	// if the desired config (gvk + namespace + name) is aleady in the mergedConfigs,
-	// update the ConfigReferent and DesiredConfig (including desired spechash) to mergedConfigs.
-	// else just append it to the mergedConfigs.
-	for gr, configReferences := range desiredConfigMap {
-		for _, configRef := range configReferences {
-			if _, ok := mergedConfigs[gr]; !ok {
-				mergedConfigs[gr] = []addonv1beta1.ConfigReference{}
-			}
-
-			referent := configRef.DesiredConfig.ConfigReferent
-			if i, exist := mergedConfigs.containsConfig(gr, referent); exist {
-				mergedConfigs[gr][i].DesiredConfig = configRef.DesiredConfig.DeepCopy()
-			} else {
-				mergedConfigs[gr] = append(mergedConfigs[gr], configRef)
-			}
-		}
-	}
-
-	// sort by gvk and set the final config references
+	// Iterate desiredConfigMap in sorted GR order — this is the source of truth for ordering.
+	// Within each GR, the slice order from the desired config map is preserved.
 	configRefs := []addonv1beta1.ConfigReference{}
-	for _, gvk := range mergedConfigs.orderedKeys() {
-		configRefs = append(configRefs, mergedConfigs[gvk]...)
+	for _, gr := range desiredConfigMap.orderedKeys() {
+		for _, configRef := range desiredConfigMap[gr] {
+			key := configKey{
+				gr:      gr,
+				refName: configRef.DesiredConfig.ConfigReferent.Name,
+				refNs:   configRef.DesiredConfig.ConfigReferent.Namespace,
+			}
+			if old, ok := oldStatusByKey[key]; ok {
+				// Preserve rollout tracking fields, update desired config
+				old.DesiredConfig = configRef.DesiredConfig.DeepCopy()
+				configRefs = append(configRefs, old)
+			} else {
+				configRefs = append(configRefs, configRef)
+			}
+		}
 	}
+
 	mcaCopy.Status.ConfigReferences = configRefs
 	return mcaCopy
 }

--- a/pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler_test.go
+++ b/pkg/addon/controllers/addonconfiguration/addon_configuration_reconciler_test.go
@@ -461,6 +461,109 @@ func TestAddonConfigReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "reordering spec.configs triggers status update",
+			managedClusteraddon: []runtime.Object{
+				// spec.configs has test3 before test2 (reversed from status)
+				newManagedClusterAddon("test", "cluster1", []addonv1beta1.AddOnConfig{
+					{
+						ConfigGroupResource: addonv1beta1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						ConfigReferent:      addonv1beta1.ConfigReferent{Name: "test3"},
+					},
+					{
+						ConfigGroupResource: addonv1beta1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						ConfigReferent:      addonv1beta1.ConfigReferent{Name: "test2"},
+					},
+				}, []addonv1beta1.ConfigReference{
+					// status has test2 before test3 (old order)
+					{
+						ConfigGroupResource: addonv1beta1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "test2"},
+							SpecHash:       "",
+						},
+						LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "test2"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 1,
+					},
+					{
+						ConfigGroupResource: addonv1beta1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "test3"},
+							SpecHash:       "",
+						},
+						LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "test3"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 1,
+					},
+				}, []metav1.Condition{
+					{
+						Type:   addonv1beta1.ManagedClusterAddOnConditionProgressing,
+						Reason: addonv1beta1.ProgressingReasonCompleted,
+					},
+				}),
+			},
+			placements: []runtime.Object{
+				&clusterv1beta1.Placement{ObjectMeta: metav1.ObjectMeta{Name: "test-placement", Namespace: "default"}},
+			},
+			placementDecisions: []runtime.Object{
+				&clusterv1beta1.PlacementDecision{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-placement",
+						Namespace: "default",
+						Labels: map[string]string{
+							clusterv1beta1.PlacementLabel:          "test-placement",
+							clusterv1beta1.DecisionGroupIndexLabel: "0",
+						},
+					},
+					Status: clusterv1beta1.PlacementDecisionStatus{
+						Decisions: []clusterv1beta1.ClusterDecision{{ClusterName: "cluster1"}},
+					},
+				},
+			},
+			clusterManagementAddon: addontesting.NewClusterManagementAddon("test", "", "").WithPlacementStrategy(addonv1beta1.PlacementStrategy{
+				PlacementRef:    addonv1beta1.PlacementRef{Name: "test-placement", Namespace: "default"},
+				RolloutStrategy: clusterv1alpha1.RolloutStrategy{Type: clusterv1alpha1.All},
+			}).WithInstallProgression(addonv1beta1.InstallProgression{
+				PlacementRef: addonv1beta1.PlacementRef{Name: "test-placement", Namespace: "default"},
+			}).Build(),
+			validateAddonActions: func(t *testing.T, actions []clienttesting.Action) {
+				addontesting.AssertActions(t, actions, "patch")
+				// Status should be reordered to match spec: test3 first, then test2.
+				// LastAppliedConfig and LastObservedGeneration are preserved.
+				expectPatchConfigurationAction(t, actions[0], []addonv1beta1.ConfigReference{
+					{
+						ConfigGroupResource: addonv1beta1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "test3"},
+							SpecHash:       "",
+						},
+						LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "test3"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 1,
+					},
+					{
+						ConfigGroupResource: addonv1beta1.ConfigGroupResource{Group: "core", Resource: "Foo"},
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "test2"},
+							SpecHash:       "",
+						},
+						LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "test2"},
+							SpecHash:       "",
+						},
+						LastObservedGeneration: 1,
+					},
+				})
+				expectPatchConditionAction(t, actions[0], metav1.ConditionTrue)
+			},
+		},
+		{
 			name: "duplicate configs",
 			managedClusteraddon: []runtime.Object{
 				newManagedClusterAddon("test", "cluster1", []addonv1beta1.AddOnConfig{
@@ -1289,5 +1392,256 @@ func expectPatchConditionAction(t *testing.T, action clienttesting.Action, expec
 	actualCond := meta.FindStatusCondition(mca.Status.Conditions, addonv1beta1.ManagedClusterAddOnConditionConfigured)
 	if actualCond == nil || actualCond.Status != expected {
 		t.Errorf("Condition not correctly patched, expected %v, actual %v", expected, mca.Status.Conditions)
+	}
+}
+
+func TestMergeAddonConfig(t *testing.T) {
+	fooGR := addonv1beta1.ConfigGroupResource{Group: "core", Resource: "Foo"}
+	barGR := addonv1beta1.ConfigGroupResource{Group: "core", Resource: "Bar"}
+
+	cases := []struct {
+		name             string
+		mca              *addonv1beta1.ManagedClusterAddOn
+		desiredConfigMap addonConfigMap
+		expected         []addonv1beta1.ConfigReference
+	}{
+		{
+			name: "reordering same-GR configs updates status order",
+			mca: &addonv1beta1.ManagedClusterAddOn{
+				Status: addonv1beta1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonv1beta1.ConfigReference{
+						{
+							ConfigGroupResource: fooGR,
+							DesiredConfig: &addonv1beta1.ConfigSpecHash{
+								ConfigReferent: addonv1beta1.ConfigReferent{Name: "alpha"},
+								SpecHash:       "hash-alpha",
+							},
+							LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+								ConfigReferent: addonv1beta1.ConfigReferent{Name: "alpha"},
+								SpecHash:       "hash-alpha",
+							},
+							LastObservedGeneration: 3,
+						},
+						{
+							ConfigGroupResource: fooGR,
+							DesiredConfig: &addonv1beta1.ConfigSpecHash{
+								ConfigReferent: addonv1beta1.ConfigReferent{Name: "beta"},
+								SpecHash:       "hash-beta",
+							},
+							LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+								ConfigReferent: addonv1beta1.ConfigReferent{Name: "beta"},
+								SpecHash:       "hash-beta",
+							},
+							LastObservedGeneration: 2,
+						},
+					},
+				},
+			},
+			desiredConfigMap: addonConfigMap{
+				fooGR: {
+					{
+						ConfigGroupResource: fooGR,
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "beta"},
+							SpecHash:       "hash-beta-new",
+						},
+					},
+					{
+						ConfigGroupResource: fooGR,
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "alpha"},
+							SpecHash:       "hash-alpha-new",
+						},
+					},
+				},
+			},
+			expected: []addonv1beta1.ConfigReference{
+				{
+					ConfigGroupResource: fooGR,
+					DesiredConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "beta"},
+						SpecHash:       "hash-beta-new",
+					},
+					LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "beta"},
+						SpecHash:       "hash-beta",
+					},
+					LastObservedGeneration: 2,
+				},
+				{
+					ConfigGroupResource: fooGR,
+					DesiredConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "alpha"},
+						SpecHash:       "hash-alpha-new",
+					},
+					LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "alpha"},
+						SpecHash:       "hash-alpha",
+					},
+					LastObservedGeneration: 3,
+				},
+			},
+		},
+		{
+			name: "new entry is appended without old status fields",
+			mca: &addonv1beta1.ManagedClusterAddOn{
+				Status: addonv1beta1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonv1beta1.ConfigReference{
+						{
+							ConfigGroupResource: fooGR,
+							DesiredConfig: &addonv1beta1.ConfigSpecHash{
+								ConfigReferent: addonv1beta1.ConfigReferent{Name: "existing"},
+								SpecHash:       "hash1",
+							},
+							LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+								ConfigReferent: addonv1beta1.ConfigReferent{Name: "existing"},
+								SpecHash:       "hash1",
+							},
+							LastObservedGeneration: 5,
+						},
+					},
+				},
+			},
+			desiredConfigMap: addonConfigMap{
+				fooGR: {
+					{
+						ConfigGroupResource: fooGR,
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "existing"},
+							SpecHash:       "hash1",
+						},
+					},
+					{
+						ConfigGroupResource: fooGR,
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "brand-new"},
+							SpecHash:       "hash-new",
+						},
+					},
+				},
+			},
+			expected: []addonv1beta1.ConfigReference{
+				{
+					ConfigGroupResource: fooGR,
+					DesiredConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "existing"},
+						SpecHash:       "hash1",
+					},
+					LastAppliedConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "existing"},
+						SpecHash:       "hash1",
+					},
+					LastObservedGeneration: 5,
+				},
+				{
+					ConfigGroupResource: fooGR,
+					DesiredConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "brand-new"},
+						SpecHash:       "hash-new",
+					},
+				},
+			},
+		},
+		{
+			name: "removed entry is dropped from status",
+			mca: &addonv1beta1.ManagedClusterAddOn{
+				Status: addonv1beta1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonv1beta1.ConfigReference{
+						{
+							ConfigGroupResource: fooGR,
+							DesiredConfig: &addonv1beta1.ConfigSpecHash{
+								ConfigReferent: addonv1beta1.ConfigReferent{Name: "keep"},
+								SpecHash:       "hash-keep",
+							},
+							LastObservedGeneration: 1,
+						},
+						{
+							ConfigGroupResource: fooGR,
+							DesiredConfig: &addonv1beta1.ConfigSpecHash{
+								ConfigReferent: addonv1beta1.ConfigReferent{Name: "remove"},
+								SpecHash:       "hash-remove",
+							},
+							LastObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			desiredConfigMap: addonConfigMap{
+				fooGR: {
+					{
+						ConfigGroupResource: fooGR,
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "keep"},
+							SpecHash:       "hash-keep",
+						},
+					},
+				},
+			},
+			expected: []addonv1beta1.ConfigReference{
+				{
+					ConfigGroupResource: fooGR,
+					DesiredConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "keep"},
+						SpecHash:       "hash-keep",
+					},
+					LastObservedGeneration: 1,
+				},
+			},
+		},
+		{
+			name: "cross-GR ordering follows sorted GR keys",
+			mca: &addonv1beta1.ManagedClusterAddOn{
+				Status: addonv1beta1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonv1beta1.ConfigReference{},
+				},
+			},
+			desiredConfigMap: addonConfigMap{
+				fooGR: {
+					{
+						ConfigGroupResource: fooGR,
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "foo-config"},
+							SpecHash:       "hash-foo",
+						},
+					},
+				},
+				barGR: {
+					{
+						ConfigGroupResource: barGR,
+						DesiredConfig: &addonv1beta1.ConfigSpecHash{
+							ConfigReferent: addonv1beta1.ConfigReferent{Name: "bar-config"},
+							SpecHash:       "hash-bar",
+						},
+					},
+				},
+			},
+			expected: []addonv1beta1.ConfigReference{
+				{
+					ConfigGroupResource: barGR,
+					DesiredConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "bar-config"},
+						SpecHash:       "hash-bar",
+					},
+				},
+				{
+					ConfigGroupResource: fooGR,
+					DesiredConfig: &addonv1beta1.ConfigSpecHash{
+						ConfigReferent: addonv1beta1.ConfigReferent{Name: "foo-config"},
+						SpecHash:       "hash-foo",
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := &managedClusterAddonConfigurationReconciler{}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := reconciler.mergeAddonConfig(c.mca, c.desiredConfigMap)
+			if !apiequality.Semantic.DeepEqual(result.Status.ConfigReferences, c.expected) {
+				t.Errorf("mergeAddonConfig result mismatch\nexpected: %v\n  actual: %v",
+					c.expected, result.Status.ConfigReferences)
+			}
+		})
 	}
 }

--- a/pkg/addon/controllers/addonconfiguration/cma_progressing_reconciler.go
+++ b/pkg/addon/controllers/addonconfiguration/cma_progressing_reconciler.go
@@ -62,6 +62,9 @@ func setAddOnInstallProgressionsAndLastApplied(
 		condition.Message = fmt.Sprintf("selected clusters %d. configured addons %d/%d progressing..., %d failed %d timeout.", total, progressing+done, configuredTotal, failed, timeout)
 	} else {
 		for i, configRef := range installProgression.ConfigReferences {
+			if configRef.DesiredConfig == nil {
+				continue
+			}
 			installProgression.ConfigReferences[i].LastAppliedConfig = configRef.DesiredConfig.DeepCopy()
 			installProgression.ConfigReferences[i].LastKnownGoodConfig = configRef.DesiredConfig.DeepCopy()
 		}

--- a/pkg/addon/controllers/addonconfiguration/graph.go
+++ b/pkg/addon/controllers/addonconfiguration/graph.go
@@ -153,16 +153,13 @@ func (m addonConfigMap) containsConfig(expectConfigGr addonv1beta1.ConfigGroupRe
 	return -1, false
 }
 
-// orderMatchesStatus returns true if, for every ConfigGroupResource that has
-// multiple entries, the relative ordering of those entries in statusRefs
-// matches the slice order in the desired map.  Cross-GR ordering is ignored
-// because it has no semantic significance — only within-GR ordering affects
-// behaviour such as last-match-wins precedence.
+// orderMatchesStatus returns true if, for every ConfigGroupResource, the
+// entries in statusRefs match the desired slice in both count and order.
+// Cross-GR ordering is ignored because it has no semantic significance —
+// only within-GR count and ordering affects behaviour such as last-match-wins
+// precedence.
 func (m addonConfigMap) orderMatchesStatus(statusRefs []addonv1beta1.ConfigReference) bool {
 	for gr, desired := range m {
-		if len(desired) <= 1 {
-			continue
-		}
 		// Collect the sub-sequence of statusRefs that belong to this GR,
 		// preserving their relative order.
 		var statusOrder []addonv1beta1.ConfigReferent

--- a/pkg/addon/controllers/addonconfiguration/graph.go
+++ b/pkg/addon/controllers/addonconfiguration/graph.go
@@ -101,6 +101,15 @@ func (n *addonNode) setRolloutStatus() {
 		}
 	}
 
+	// Check that the ordering of status.configReferences matches the desired ordering.
+	// The content check above only validates that the same entries exist; if the user
+	// reordered spec.configs the status must be updated so that consumers that rely on
+	// position (e.g. last-match-wins) see the correct precedence.
+	if !n.desiredConfigs.orderMatchesStatus(n.mca.Status.ConfigReferences) {
+		n.status.Status = clustersdkv1alpha1.ToApply
+		return
+	}
+
 	// succeed
 	n.status.Status = clustersdkv1alpha1.Succeeded
 	if progressingCond.Reason == addonv1beta1.ProgressingReasonCompleted {
@@ -142,6 +151,36 @@ func (m addonConfigMap) containsConfig(expectConfigGr addonv1beta1.ConfigGroupRe
 	}
 
 	return -1, false
+}
+
+// orderMatchesStatus returns true if, for every ConfigGroupResource that has
+// multiple entries, the relative ordering of those entries in statusRefs
+// matches the slice order in the desired map.  Cross-GR ordering is ignored
+// because it has no semantic significance — only within-GR ordering affects
+// behaviour such as last-match-wins precedence.
+func (m addonConfigMap) orderMatchesStatus(statusRefs []addonv1beta1.ConfigReference) bool {
+	for gr, desired := range m {
+		if len(desired) <= 1 {
+			continue
+		}
+		// Collect the sub-sequence of statusRefs that belong to this GR,
+		// preserving their relative order.
+		var statusOrder []addonv1beta1.ConfigReferent
+		for _, ref := range statusRefs {
+			if ref.ConfigGroupResource == gr && ref.DesiredConfig != nil {
+				statusOrder = append(statusOrder, ref.DesiredConfig.ConfigReferent)
+			}
+		}
+		if len(statusOrder) != len(desired) {
+			return false
+		}
+		for i, d := range desired {
+			if statusOrder[i] != d.DesiredConfig.ConfigReferent {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (m addonConfigMap) orderedKeys() []addonv1beta1.ConfigGroupResource {


### PR DESCRIPTION
## Summary
After ManagedClusterAddOn status.configReferences are initially computed, the order is not updated if the order of configs in the spec changes. This PR corrects that.

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/ocm/issues/1600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved rollout tracking details when addon configuration references are refreshed, reordered, or updated.
  * Improved stability of `status.configReferences` ordering: if the observed order doesn’t match the desired order within a config group, the addon is set to require applying updates instead of reporting success.
  * Prevented potential nil-related failures by avoiding updates when a desired config reference is not present.

* **Tests**
  * Added unit tests covering config reference merge behavior and reconciliation patching when `spec.configs` ordering changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->