### PR TITLE
:sparkles: feat: surface invalid ManifestWork owner label on MWRS status

### DIFF
--- a/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_reconcile.go
+++ b/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_reconcile.go
@@ -3,12 +3,14 @@ package manifestworkreplicasetcontroller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	clusterlister "open-cluster-management.io/api/client/cluster/listers/cluster/v1beta1"
 	worklisterv1 "open-cluster-management.io/api/client/work/listers/work/v1"
@@ -20,6 +22,9 @@ import (
 	"open-cluster-management.io/ocm/pkg/common/helpers"
 	"open-cluster-management.io/ocm/pkg/work/helper"
 )
+
+// ReasonInvalidManifestWorkName indicates an invalid ManifestWork owner label.
+const ReasonInvalidManifestWorkName = "InvalidManifestWorkName"
 
 // deployReconciler is to manage ManifestWork based on the placement.
 type deployReconciler struct {
@@ -36,6 +41,16 @@ func (d *deployReconciler) reconcile(
 	var plcsSummary []workapiv1alpha1.PlacementSummary
 	minRequeue := maxRequeueTime
 	count, total, succeededCount := 0, 0, 0
+
+	// Report invalid ManifestWork owner labels in status.
+	ownerValue := manifestWorkReplicaSetKey(mwrSet)
+	if verrs := validation.IsValidLabelValue(ownerValue); len(verrs) > 0 {
+		message := fmt.Sprintf("ManifestWork owner reference %q (namespace.name) is not a valid label value: %s; "+
+			"recreate the ManifestWorkReplicaSet with a shorter namespace and/or name so the combined length is at most 63 characters",
+			ownerValue, strings.Join(verrs, "; "))
+		apimeta.SetStatusCondition(&mwrSet.Status.Conditions, getManifestworkApplied(ReasonInvalidManifestWorkName, message))
+		return mwrSet, reconcileStop, nil
+	}
 
 	// Clean up ManifestWorks from placements no longer in the spec
 	currentPlacementNames := sets.New[string]()

--- a/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_reconcile.go
+++ b/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_reconcile.go
@@ -43,6 +43,8 @@ func (d *deployReconciler) reconcile(
 	count, total, succeededCount := 0, 0, 0
 
 	// Report invalid ManifestWork owner labels in status.
+	// TODO: remove this once the owner label uses a hash value instead of
+	// namespace.name (#1596); the 63-char label limit no longer applies then.
 	ownerValue := manifestWorkReplicaSetKey(mwrSet)
 	if verrs := validation.IsValidLabelValue(ownerValue); len(verrs) > 0 {
 		message := fmt.Sprintf("ManifestWork owner reference %q (namespace.name) is not a valid label value: %s; "+

--- a/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_test.go
+++ b/pkg/work/hub/controllers/manifestworkreplicasetcontroller/manifestworkreplicaset_deploy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1748,5 +1749,67 @@ func TestIsConditionReady(t *testing.T) {
 			result := isConditionReady(tt.condition, tt.generation, tt.requireTrue)
 			assert.Equal(t, tt.expected, result, tt.description)
 		})
+	}
+}
+
+func TestDeployReconcileOwnerLabelTooLong(t *testing.T) {
+	// "default." + longName exceeds the 63-char label-value limit, so the owner
+	// label value is invalid and the reconciler should report it on status.
+	longName := "mwrset-" + strings.Repeat("x", 60)
+	mwrSet := helpertest.CreateTestManifestWorkReplicaSet(longName, "default", "place-test")
+
+	fWorkClient := fakeworkclient.NewSimpleClientset(mwrSet)
+	workInformerFactory := workinformers.NewSharedInformerFactoryWithOptions(fWorkClient, 1*time.Second)
+	if err := workInformerFactory.Work().V1alpha1().ManifestWorkReplicaSets().Informer().GetStore().Add(mwrSet); err != nil {
+		t.Fatal(err)
+	}
+	mwLister := workInformerFactory.Work().V1().ManifestWorks().Lister()
+
+	placement, placementDecision := helpertest.CreateTestPlacement("place-test", "default", "cls1")
+	fClusterClient := fakeclusterclient.NewSimpleClientset(placement, placementDecision)
+	clusterInformerFactory := clusterinformers.NewSharedInformerFactoryWithOptions(fClusterClient, 1*time.Second)
+	if err := clusterInformerFactory.Cluster().V1beta1().Placements().Informer().GetStore().Add(placement); err != nil {
+		t.Fatal(err)
+	}
+	if err := clusterInformerFactory.Cluster().V1beta1().PlacementDecisions().Informer().GetStore().Add(placementDecision); err != nil {
+		t.Fatal(err)
+	}
+
+	pmwDeployController := deployReconciler{
+		workApplier:         workapplier.NewWorkApplierWithTypedClient(fWorkClient, mwLister),
+		manifestWorkLister:  mwLister,
+		placeDecisionLister: clusterInformerFactory.Cluster().V1beta1().PlacementDecisions().Lister(),
+		placementLister:     clusterInformerFactory.Cluster().V1beta1().Placements().Lister(),
+	}
+
+	mwrSet, state, err := pmwDeployController.reconcile(context.TODO(), mwrSet)
+	if err != nil {
+		t.Fatal("expected no error so the invalid name is reported via status, got ", err)
+	}
+	if state != reconcileStop {
+		t.Fatal("expected reconcileStop for a permanently invalid owner label, got ", state)
+	}
+
+	cond := apimeta.FindStatusCondition(mwrSet.Status.Conditions, workapiv1alpha1.ManifestWorkReplicaSetConditionManifestworkApplied)
+	if cond == nil {
+		t.Fatal("ManifestworkApplied condition not found ", mwrSet.Status.Conditions)
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Fatal("expected ManifestworkApplied=False, got ", cond)
+	}
+	if cond.Reason != ReasonInvalidManifestWorkName {
+		t.Fatal("expected Reason ReasonInvalidManifestWorkName, got ", cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "63") {
+		t.Fatal("expected message to reference the 63-char limit, got ", cond.Message)
+	}
+
+	// No ManifestWork should have been applied for the invalid owner value.
+	works, err := fWorkClient.WorkV1().ManifestWorks("cls1").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(works.Items) != 0 {
+		t.Fatal("expected no ManifestWork to be applied, got ", len(works.Items))
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The ManifestWorkReplicaSet controller stamps every generated ManifestWork with the ownervlabel `work.open-cluster-management.io/manifestworkreplicaset = "<namespace>.<name>"` and applies it without length validation. When `namespace.name` exceeds the 63-char label-value limit, the API server rejects each ManifestWork apply, but the MWRS status only shows a generic `ManifestworkApplied=False` (`NotAsExpected`/`Processing`), the cause is reachable only in controller logs.

This validates the owner value at the start of `deployReconciler.reconcile`. If it is not a valid label value, it sets `ManifestworkApplied=False` with a new `InvalidManifestWorkName` reason and an actionable message, then stops (namespace and name are immutable, so retrying can never succeed). The reason is defined locally in the controller package, so no `open-cluster-management.io/api` change is needed.

Implements **request 2** of the linked issue. Request 1 (hashing the owner label) will follow in a separate PR.

## Related issue(s)

Part of #1596 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for the owner label value used during ManifestWorkReplicaSet reconciliation.
  * If the label value is invalid (for example, exceeds Kubernetes length limits), reconciliation stops without making changes and updates the `ManifestworkApplied` status condition with a clear error message.
* **Tests**
  * Added a unit test covering the “owner label too long” case to ensure no ManifestWork objects are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->