### PR TITLE
:sparkles: feat: add NetworkPolicies for open-cluster-management-agent namespace

### DIFF
--- a/deploy/klusterlet/chart/klusterlet/templates/cluster_role.yaml
+++ b/deploy/klusterlet/chart/klusterlet/templates/cluster_role.yaml
@@ -69,5 +69,8 @@ rules:
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["appliedmanifestworks"]
   verbs: ["list", "update", "patch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["create", "get", "list", "update", "watch", "patch", "delete"]
 {{- end }}
 {{- end }}

--- a/deploy/klusterlet/config/rbac/cluster_role.yaml
+++ b/deploy/klusterlet/config/rbac/cluster_role.yaml
@@ -69,3 +69,6 @@ rules:
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["appliedmanifestworks"]
   verbs: ["list", "update", "patch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["create", "get", "list", "update", "watch", "patch", "delete"]

--- a/deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
+++ b/deploy/klusterlet/olm-catalog/latest/manifests/klusterlet.clusterserviceversion.yaml
@@ -262,6 +262,18 @@ spec:
           - list
           - update
           - patch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+          - patch
+          - delete
         serviceAccountName: klusterlet
       deployments:
       - label:

--- a/manifests/klusterlet/management/klusterlet-agent-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: klusterlet-agent
+  namespace: {{ .AgentNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: klusterlet-agent
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: open-cluster-management-hub
+    ports:
+    - protocol: TCP
+      port: 9443
+  - to:
+    - podSelector: {}

--- a/manifests/klusterlet/management/klusterlet-agent-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-networkpolicy.yaml
@@ -8,7 +8,11 @@ spec:
     matchLabels:
       app: klusterlet-agent
   policyTypes:
+  - Ingress
   - Egress
+  ingress:
+  - from:
+    - podSelector: {}
   egress:
   - to:
     - namespaceSelector:

--- a/manifests/klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-and-api
+  namespace: {{ .AgentNamespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+    ports:
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443

--- a/manifests/klusterlet/management/klusterlet-default-deny-all-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-default-deny-all-networkpolicy.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{ .AgentNamespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/manifests/klusterlet/management/klusterlet-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-networkpolicy.yaml
@@ -8,7 +8,11 @@ spec:
     matchLabels:
       app: klusterlet
   policyTypes:
+  - Ingress
   - Egress
+  ingress:
+  - from:
+    - podSelector: {}
   egress:
   - to:
     - podSelector: {}

--- a/manifests/klusterlet/management/klusterlet-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-networkpolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: klusterlet
+  namespace: {{ .AgentNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: klusterlet
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector: {}
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          addon.open-cluster-management.io/namespace: "true"
+    ports:
+    - protocol: TCP
+      port: 443
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443

--- a/pkg/operator/helpers/helpers.go
+++ b/pkg/operator/helpers/helpers.go
@@ -17,6 +17,7 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -148,6 +149,8 @@ func CleanUpStaticObject(
 		err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, t.Name, metav1.DeleteOptions{})
 	case *admissionv1.MutatingWebhookConfiguration:
 		err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, t.Name, metav1.DeleteOptions{})
+	case *networkingv1.NetworkPolicy:
+		err = client.NetworkingV1().NetworkPolicies(t.Namespace).Delete(ctx, t.Name, metav1.DeleteOptions{})
 	default:
 		err = fmt.Errorf("unhandled type %T", object)
 	}
@@ -503,6 +506,8 @@ func GenerateRelatedResource(objBytes []byte) (operatorapiv1.RelatedResourceMeta
 		relatedResource = newRelatedResource(rbacv1.SchemeGroupVersion.WithResource("rolebindings"), requiredObj)
 	case *apiextensionsv1.CustomResourceDefinition:
 		relatedResource = newRelatedResource(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"), requiredObj)
+	case *networkingv1.NetworkPolicy:
+		relatedResource = newRelatedResource(networkingv1.SchemeGroupVersion.WithResource("networkpolicies"), requiredObj)
 	default:
 		return relatedResource, fmt.Errorf("unhandled type %T", requiredObj)
 	}

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller_test.go
@@ -50,9 +50,9 @@ func TestSyncDelete(t *testing.T) {
 		}
 	}
 
-	// 11 managed static manifests + 12 management static manifests + 1 hub kubeconfig + 2 namespaces + 2 deployments
-	if len(deleteActions) != 28 {
-		t.Errorf("Expected 28 delete actions, but got %d", len(deleteActions))
+	// 11 managed static manifests + 16 management static manifests + 1 hub kubeconfig + 2 namespaces + 2 deployments
+	if len(deleteActions) != 32 {
+		t.Errorf("Expected 32 delete actions, but got %d", len(deleteActions))
 	}
 
 	var updateWorkActions []clienttesting.PatchActionImpl
@@ -108,10 +108,10 @@ func TestSyncDeleteHosted(t *testing.T) {
 		}
 	}
 
-	// 11 static manifests + 3 secrets(hub-kubeconfig-secret, external-managed-kubeconfig-registration,external-managed-kubeconfig-work)
+	// 15 static manifests + 3 secrets(hub-kubeconfig-secret, external-managed-kubeconfig-registration,external-managed-kubeconfig-work)
 	// + 2 deployments(registration-agent,work-agent) + 1 namespace
-	if len(deleteActionsManagement) != 17 {
-		t.Errorf("Expected 17 delete actions, but got %d", len(deleteActionsManagement))
+	if len(deleteActionsManagement) != 21 {
+		t.Errorf("Expected 21 delete actions, but got %d", len(deleteActionsManagement))
 	}
 
 	var deleteActionsManaged []clienttesting.DeleteActionImpl

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_cleanup_controller_test.go
@@ -50,9 +50,9 @@ func TestSyncDelete(t *testing.T) {
 		}
 	}
 
-	// 11 managed static manifests + 16 management static manifests + 1 hub kubeconfig + 2 namespaces + 2 deployments
-	if len(deleteActions) != 32 {
-		t.Errorf("Expected 32 delete actions, but got %d", len(deleteActions))
+	// 11 managed static manifests + 12 management static manifests + 1 hub kubeconfig + 2 namespaces + 2 deployments
+	if len(deleteActions) != 28 {
+		t.Errorf("Expected 28 delete actions, but got %d", len(deleteActions))
 	}
 
 	var updateWorkActions []clienttesting.PatchActionImpl
@@ -108,10 +108,10 @@ func TestSyncDeleteHosted(t *testing.T) {
 		}
 	}
 
-	// 15 static manifests + 3 secrets(hub-kubeconfig-secret, external-managed-kubeconfig-registration,external-managed-kubeconfig-work)
+	// 11 static manifests + 3 secrets(hub-kubeconfig-secret, external-managed-kubeconfig-registration,external-managed-kubeconfig-work)
 	// + 2 deployments(registration-agent,work-agent) + 1 namespace
-	if len(deleteActionsManagement) != 21 {
-		t.Errorf("Expected 21 delete actions, but got %d", len(deleteActionsManagement))
+	if len(deleteActionsManagement) != 17 {
+		t.Errorf("Expected 17 delete actions, but got %d", len(deleteActionsManagement))
 	}
 
 	var deleteActionsManaged []clienttesting.DeleteActionImpl

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/component-base/featuregate"
 	appsinformer "k8s.io/client-go/informers/apps/v1"
 	coreinformer "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -44,7 +45,28 @@ const (
 	klusterletFinalizer                   = "operator.open-cluster-management.io/klusterlet-cleanup"
 	managedResourcesEvictionTimestampAnno = "operator.open-cluster-management.io/managed-resources-eviction-timestamp"
 	klusterletNamespaceLabelKey           = "operator.open-cluster-management.io/klusterlet"
+
+	// NetworkPolicies is an operator-internal feature gate that controls whether NetworkPolicy
+	// manifests are applied to the agent namespace. Disabled by default; enable via the Klusterlet
+	// CR's registrationConfiguration.featureGates.
+	NetworkPolicies featuregate.Feature = "NetworkPolicies"
 )
+
+// operatorOnlyFeatureGates are feature gates consumed by the operator itself,
+// not passed through to agent binaries as CLI flags.
+var operatorOnlyFeatureGates = map[featuregate.Feature]bool{
+	NetworkPolicies: true,
+}
+
+func filterOperatorFeatureGates(features []operatorapiv1.FeatureGate) []operatorapiv1.FeatureGate {
+	var filtered []operatorapiv1.FeatureGate
+	for _, f := range features {
+		if !operatorOnlyFeatureGates[featuregate.Feature(f.Feature)] {
+			filtered = append(filtered, f)
+		}
+	}
+	return filtered
+}
 
 type klusterletController struct {
 	patcher                       patcher.Patcher[*operatorapiv1.Klusterlet, operatorapiv1.KlusterletSpec, operatorapiv1.KlusterletStatus]
@@ -219,6 +241,8 @@ type klusterletConfig struct {
 
 	// flag to enable about about-api
 	AboutAPIEnabled bool
+	// flag to enable network policies in the agent namespace
+	NetworkPoliciesEnabled bool
 	TLSMinVersion   string
 	TLSCipherSuites string
 }
@@ -421,8 +445,10 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 
 	config.AboutAPIEnabled = helpers.FeatureGateEnabled(
 		registrationFeatureGates, ocmfeature.DefaultSpokeRegistrationFeatureGates, ocmfeature.ClusterProperty)
+	config.NetworkPoliciesEnabled = helpers.FeatureGateEnabled(
+		registrationFeatureGates, ocmfeature.DefaultSpokeRegistrationFeatureGates, NetworkPolicies)
 	config.RegistrationFeatureGates, registrationFeatureMsgs = helpers.ConvertToFeatureGateFlags("Registration",
-		registrationFeatureGates, ocmfeature.DefaultSpokeRegistrationFeatureGates)
+		filterOperatorFeatureGates(registrationFeatureGates), ocmfeature.DefaultSpokeRegistrationFeatureGates)
 
 	var workFeatureGates []operatorapiv1.FeatureGate
 	if klusterlet.Spec.WorkConfiguration != nil {

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -14,11 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/component-base/featuregate"
 	appsinformer "k8s.io/client-go/informers/apps/v1"
 	coreinformer "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 
 	operatorv1client "open-cluster-management.io/api/client/operator/clientset/versioned/typed/operator/v1"
@@ -243,8 +243,8 @@ type klusterletConfig struct {
 	AboutAPIEnabled bool
 	// flag to enable network policies in the agent namespace
 	NetworkPoliciesEnabled bool
-	TLSMinVersion   string
-	TLSCipherSuites string
+	TLSMinVersion          string
+	TLSCipherSuites        string
 }
 
 // If multiplehubs feature gate is enabled, using the bootstrapkubeconfigs from klusterlet CR.

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -627,9 +627,9 @@ func TestSyncDeploy(t *testing.T) {
 			}
 
 			// Check if resources are created as expected
-			// 11 managed static manifests + 12 management static manifests - 2 duplicated service account manifests + 1 addon namespace + 2 deployments
-			if len(createObjects) != 24 {
-				t.Errorf("Expect 24 objects created in the sync loop, actual %d", len(createObjects))
+			// 11 managed static manifests + 16 management static manifests - 2 duplicated service account manifests + 1 addon namespace + 2 deployments
+			if len(createObjects) != 28 {
+				t.Errorf("Expect 28 objects created in the sync loop, actual %d", len(createObjects))
 			}
 			for _, object := range createObjects {
 				ensureObject(t, object, klusterlet, false)
@@ -709,9 +709,9 @@ func TestSyncDeploySingleton(t *testing.T) {
 			}
 
 			// Check if resources are created as expected
-			// 10 managed static manifests + 11 management static manifests - 1 service account manifests + 1 addon namespace + 1 deployments
-			if len(createObjects) != 22 {
-				t.Errorf("Expect 21 objects created in the sync loop, actual %d", len(createObjects))
+			// 10 managed static manifests + 15 management static manifests - 1 service account manifests + 1 addon namespace + 1 deployments
+			if len(createObjects) != 26 {
+				t.Errorf("Expect 26 objects created in the sync loop, actual %d", len(createObjects))
 			}
 			for _, object := range createObjects {
 				ensureObject(t, object, klusterlet, false)
@@ -781,10 +781,10 @@ func TestSyncDeployHosted(t *testing.T) {
 		}
 	}
 	// Check if resources are created as expected on the management cluster
-	// 11 static manifests + 2 secrets(external-managed-kubeconfig-registration,external-managed-kubeconfig-work) +
+	// 15 static manifests + 2 secrets(external-managed-kubeconfig-registration,external-managed-kubeconfig-work) +
 	// 2 deployments(registration-agent,work-agent) + 1 pull secret
-	if len(createObjectsManagement) != 16 {
-		t.Errorf("Expect 16 objects created in the sync loop, actual %d", len(createObjectsManagement))
+	if len(createObjectsManagement) != 20 {
+		t.Errorf("Expect 20 objects created in the sync loop, actual %d", len(createObjectsManagement))
 	}
 	for _, object := range createObjectsManagement {
 		ensureObject(t, object, klusterlet, false)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -627,9 +627,9 @@ func TestSyncDeploy(t *testing.T) {
 			}
 
 			// Check if resources are created as expected
-			// 11 managed static manifests + 16 management static manifests - 2 duplicated service account manifests + 1 addon namespace + 2 deployments
-			if len(createObjects) != 28 {
-				t.Errorf("Expect 28 objects created in the sync loop, actual %d", len(createObjects))
+			// 11 managed static manifests + 12 management static manifests - 2 duplicated service account manifests + 1 addon namespace + 2 deployments
+			if len(createObjects) != 24 {
+				t.Errorf("Expect 24 objects created in the sync loop, actual %d", len(createObjects))
 			}
 			for _, object := range createObjects {
 				ensureObject(t, object, klusterlet, false)
@@ -661,6 +661,42 @@ func TestSyncDeploy(t *testing.T) {
 				testinghelper.NamedCondition(helpers.FeatureGatesTypeValid, helpers.FeatureGatesReasonAllValid, metav1.ConditionTrue),
 			)
 		})
+	}
+}
+
+func TestSyncDeployWithNetworkPolicies(t *testing.T) {
+	klusterlet := newKlusterlet("klusterlet", "testns", "cluster1")
+	klusterlet.Spec.RegistrationConfiguration.FeatureGates = append(
+		klusterlet.Spec.RegistrationConfiguration.FeatureGates,
+		operatorapiv1.FeatureGate{Feature: string(NetworkPolicies), Mode: operatorapiv1.FeatureGateModeTypeEnable},
+	)
+	bootStrapSecret := newSecret(helpers.BootstrapHubKubeConfig, "testns")
+	hubKubeConfigSecret := newSecret(helpers.HubKubeConfig, "testns")
+	hubKubeConfigSecret.Data["kubeconfig"] = []byte("dummuykubeconnfig")
+	namespace := newNamespace("testns")
+	syncContext := testingcommon.NewFakeSyncContext(t, "klusterlet")
+
+	controller := newTestController(t, klusterlet, syncContext.Recorder(), nil, false,
+		bootStrapSecret, hubKubeConfigSecret, namespace)
+
+	err := controller.controller.sync(context.TODO(), syncContext, "klusterlet")
+	if err != nil {
+		t.Errorf("Expected non error when sync, %v", err)
+	}
+
+	var createObjects []runtime.Object
+	kubeActions := controller.kubeClient.Actions()
+	for _, action := range kubeActions {
+		if action.GetVerb() == createVerb {
+			object := action.(clienttesting.CreateActionImpl).Object
+			createObjects = append(createObjects, object)
+		}
+	}
+
+	// 11 managed static manifests + 12 management static manifests + 4 network policies
+	// - 2 duplicated service account manifests + 1 addon namespace + 2 deployments
+	if len(createObjects) != 28 {
+		t.Errorf("Expect 28 objects created in the sync loop, actual %d", len(createObjects))
 	}
 }
 
@@ -709,9 +745,9 @@ func TestSyncDeploySingleton(t *testing.T) {
 			}
 
 			// Check if resources are created as expected
-			// 10 managed static manifests + 15 management static manifests - 1 service account manifests + 1 addon namespace + 1 deployments
-			if len(createObjects) != 26 {
-				t.Errorf("Expect 26 objects created in the sync loop, actual %d", len(createObjects))
+			// 10 managed static manifests + 11 management static manifests - 1 service account manifests + 1 addon namespace + 1 deployments
+			if len(createObjects) != 22 {
+				t.Errorf("Expect 21 objects created in the sync loop, actual %d", len(createObjects))
 			}
 			for _, object := range createObjects {
 				ensureObject(t, object, klusterlet, false)
@@ -781,10 +817,10 @@ func TestSyncDeployHosted(t *testing.T) {
 		}
 	}
 	// Check if resources are created as expected on the management cluster
-	// 15 static manifests + 2 secrets(external-managed-kubeconfig-registration,external-managed-kubeconfig-work) +
+	// 11 static manifests + 2 secrets(external-managed-kubeconfig-registration,external-managed-kubeconfig-work) +
 	// 2 deployments(registration-agent,work-agent) + 1 pull secret
-	if len(createObjectsManagement) != 20 {
-		t.Errorf("Expect 20 objects created in the sync loop, actual %d", len(createObjectsManagement))
+	if len(createObjectsManagement) != 16 {
+		t.Errorf("Expect 16 objects created in the sync loop, actual %d", len(createObjectsManagement))
 	}
 	for _, object := range createObjectsManagement {
 		ensureObject(t, object, klusterlet, false)

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_management_recocile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_management_recocile.go
@@ -70,7 +70,8 @@ func (r *managementReconcile) reconcile(ctx context.Context, klusterlet *operato
 		return klusterlet, reconcileStop, err
 	}
 
-	files := managementStaticResourceFiles
+	var files []string
+	files = append(files, managementStaticResourceFiles...)
 	if config.NetworkPoliciesEnabled {
 		files = append(files, networkPolicyFiles...)
 	}
@@ -129,7 +130,8 @@ func (r *managementReconcile) clean(ctx context.Context, klusterlet *operatorapi
 	}
 
 	// remove static file on the management cluster
-	files := managementStaticResourceFiles
+	var files []string
+	files = append(files, managementStaticResourceFiles...)
 	if config.NetworkPoliciesEnabled {
 		files = append(files, networkPolicyFiles...)
 	}

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_management_recocile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_management_recocile.go
@@ -36,6 +36,10 @@ var (
 		"klusterlet/management/klusterlet-work-role.yaml",
 		"klusterlet/management/klusterlet-work-rolebinding.yaml",
 		"klusterlet/management/klusterlet-work-rolebinding-extension-apiserver.yaml",
+		"klusterlet/management/klusterlet-default-deny-all-networkpolicy.yaml",
+		"klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml",
+		"klusterlet/management/klusterlet-networkpolicy.yaml",
+		"klusterlet/management/klusterlet-agent-networkpolicy.yaml",
 	}
 )
 

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_management_recocile.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_management_recocile.go
@@ -36,6 +36,9 @@ var (
 		"klusterlet/management/klusterlet-work-role.yaml",
 		"klusterlet/management/klusterlet-work-rolebinding.yaml",
 		"klusterlet/management/klusterlet-work-rolebinding-extension-apiserver.yaml",
+	}
+
+	networkPolicyFiles = []string{
 		"klusterlet/management/klusterlet-default-deny-all-networkpolicy.yaml",
 		"klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml",
 		"klusterlet/management/klusterlet-networkpolicy.yaml",
@@ -67,6 +70,11 @@ func (r *managementReconcile) reconcile(ctx context.Context, klusterlet *operato
 		return klusterlet, reconcileStop, err
 	}
 
+	files := managementStaticResourceFiles
+	if config.NetworkPoliciesEnabled {
+		files = append(files, networkPolicyFiles...)
+	}
+
 	resourceResults := helpers.ApplyDirectly(
 		ctx,
 		r.kubeClient,
@@ -82,7 +90,7 @@ func (r *managementReconcile) reconcile(ctx context.Context, klusterlet *operato
 			helpers.SetRelatedResourcesStatusesWithObj(ctx, &klusterlet.Status.RelatedResources, objData)
 			return objData, nil
 		},
-		managementStaticResourceFiles...,
+		files...,
 	)
 
 	var errs []error
@@ -121,7 +129,11 @@ func (r *managementReconcile) clean(ctx context.Context, klusterlet *operatorapi
 	}
 
 	// remove static file on the management cluster
-	err := removeStaticResources(ctx, r.kubeClient, nil, managementStaticResourceFiles, config)
+	files := managementStaticResourceFiles
+	if config.NetworkPoliciesEnabled {
+		files = append(files, networkPolicyFiles...)
+	}
+	err := removeStaticResources(ctx, r.kubeClient, nil, files, config)
 	if err != nil {
 		return klusterlet, reconcileStop, err
 	}

--- a/test/framework/klusterlet.go
+++ b/test/framework/klusterlet.go
@@ -103,6 +103,18 @@ func (spoke *Spoke) CreateKlusterlet(
 		}
 	}
 
+	// Enable NetworkPolicies feature gate
+	if klusterlet.Spec.RegistrationConfiguration == nil {
+		klusterlet.Spec.RegistrationConfiguration = &operatorapiv1.RegistrationConfiguration{}
+	}
+	klusterlet.Spec.RegistrationConfiguration.FeatureGates = append(
+		klusterlet.Spec.RegistrationConfiguration.FeatureGates,
+		operatorapiv1.FeatureGate{
+			Feature: "NetworkPolicies",
+			Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+		},
+	)
+
 	agentNamespace := helpers.AgentNamespace(klusterlet)
 	klog.Infof("klusterlet: %s/%s, \t mode: %v, \t agent namespace: %s, \t registration driver: %s",
 		klusterlet.Name, klusterlet.Namespace, mode, agentNamespace, registrationDriver)

--- a/test/integration/operator/klusterlet_aws_test.go
+++ b/test/integration/operator/klusterlet_aws_test.go
@@ -62,6 +62,12 @@ var _ = ginkgo.Describe("Klusterlet using aws auth", func() {
 							ManagedClusterArn: util.ManagedClusterArn,
 						},
 					},
+					FeatureGates: []operatorapiv1.FeatureGate{
+						{
+							Feature: "NetworkPolicies",
+							Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+						},
+					},
 				},
 			},
 		}

--- a/test/integration/operator/klusterlet_grpc_test.go
+++ b/test/integration/operator/klusterlet_grpc_test.go
@@ -49,6 +49,12 @@ var _ = ginkgo.Describe("Klusterlet using grpc auth", func() {
 						RegistrationDriver: operatorapiv1.RegistrationDriver{
 							AuthType: "grpc",
 						},
+						FeatureGates: []operatorapiv1.FeatureGate{
+							{
+								Feature: "NetworkPolicies",
+								Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+							},
+						},
 					},
 				},
 			}
@@ -128,6 +134,12 @@ var _ = ginkgo.Describe("Klusterlet using grpc auth", func() {
 					RegistrationConfiguration: &operatorapiv1.RegistrationConfiguration{
 						RegistrationDriver: operatorapiv1.RegistrationDriver{
 							AuthType: "grpc",
+						},
+						FeatureGates: []operatorapiv1.FeatureGate{
+							{
+								Feature: "NetworkPolicies",
+								Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+							},
 						},
 					},
 					DeployOption: operatorapiv1.KlusterletDeployOption{

--- a/test/integration/operator/klusterlet_hosted_test.go
+++ b/test/integration/operator/klusterlet_hosted_test.go
@@ -48,6 +48,14 @@ var _ = ginkgo.Describe("Klusterlet Hosted mode", func() {
 				DeployOption: operatorapiv1.KlusterletDeployOption{
 					Mode: operatorapiv1.InstallModeHosted,
 				},
+				RegistrationConfiguration: &operatorapiv1.RegistrationConfiguration{
+					FeatureGates: []operatorapiv1.FeatureGate{
+						{
+							Feature: "NetworkPolicies",
+							Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+						},
+					},
+				},
 			},
 		}
 		klusterletNamespace = helpers.KlusterletNamespace(klusterlet)

--- a/test/integration/operator/klusterlet_hosted_test.go
+++ b/test/integration/operator/klusterlet_hosted_test.go
@@ -122,10 +122,10 @@ var _ = ginkgo.Describe("Klusterlet Hosted mode", func() {
 					return err
 				}
 
-				// 11 managed static manifests + 11 management static manifests +
+				// 11 managed static manifests + 11 management static manifests + 4 networkpolicies +
 				// 2CRDs + 2 deployments(2 duplicated CRDs, but status also recorded in the klusterlet's status)
-				if len(actual.Status.RelatedResources) != 26 {
-					return fmt.Errorf("should get 26 relatedResources, actual got %v", len(actual.Status.RelatedResources))
+				if len(actual.Status.RelatedResources) != 30 {
+					return fmt.Errorf("should get 30 relatedResources, actual got %v", len(actual.Status.RelatedResources))
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())

--- a/test/integration/operator/klusterlet_mutiplehubs_test.go
+++ b/test/integration/operator/klusterlet_mutiplehubs_test.go
@@ -41,6 +41,10 @@ var _ = Describe("Deploy Klusterlet with Multiplehubs enabled", func() {
 							Feature: string(ocmfeature.MultipleHubs),
 							Mode:    operatorapiv1.FeatureGateModeTypeEnable,
 						},
+						{
+							Feature: "NetworkPolicies",
+							Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+						},
 					},
 					BootstrapKubeConfigs: operatorapiv1.BootstrapKubeConfigs{
 						Type: operatorapiv1.LocalSecrets,

--- a/test/integration/operator/klusterlet_mutiplehubs_test.go
+++ b/test/integration/operator/klusterlet_mutiplehubs_test.go
@@ -115,10 +115,10 @@ var _ = Describe("Deploy Klusterlet with Multiplehubs enabled", func() {
 				return err
 			}
 
-			// 10 managed static manifests + 9 management static manifests + 2CRDs + 1 deployments
+			// 10 managed static manifests + 9 management static manifests + 4 networkpolicies + 2CRDs + 1 deployments
 			// The number is the same as the singletone mode.
-			if len(actual.Status.RelatedResources) != 22 {
-				return fmt.Errorf("should get 22 relatedResources, actual got %v", len(actual.Status.RelatedResources))
+			if len(actual.Status.RelatedResources) != 26 {
+				return fmt.Errorf("should get 26 relatedResources, actual got %v", len(actual.Status.RelatedResources))
 			}
 			return nil
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(HaveOccurred())

--- a/test/integration/operator/klusterlet_singleton_aws_test.go
+++ b/test/integration/operator/klusterlet_singleton_aws_test.go
@@ -49,6 +49,12 @@ var _ = ginkgo.Describe("Klusterlet Singleton mode with aws auth", func() {
 							ManagedClusterArn: util.ManagedClusterArn,
 						},
 					},
+					FeatureGates: []operatorapiv1.FeatureGate{
+						{
+							Feature: "NetworkPolicies",
+							Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+						},
+					},
 				},
 			},
 		}

--- a/test/integration/operator/klusterlet_singleton_test.go
+++ b/test/integration/operator/klusterlet_singleton_test.go
@@ -44,6 +44,14 @@ var _ = ginkgo.Describe("Klusterlet Singleton mode", func() {
 				DeployOption: operatorapiv1.KlusterletDeployOption{
 					Mode: operatorapiv1.InstallModeSingleton,
 				},
+				RegistrationConfiguration: &operatorapiv1.RegistrationConfiguration{
+					FeatureGates: []operatorapiv1.FeatureGate{
+						{
+							Feature: "NetworkPolicies",
+							Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+						},
+					},
+				},
 			},
 		}
 		agentNamespace = helpers.AgentNamespace(klusterlet)

--- a/test/integration/operator/klusterlet_singleton_test.go
+++ b/test/integration/operator/klusterlet_singleton_test.go
@@ -101,9 +101,9 @@ var _ = ginkgo.Describe("Klusterlet Singleton mode", func() {
 					return err
 				}
 
-				// 10 managed static manifests + 9 management static manifests + 2CRDs + 1 deployments
-				if len(actual.Status.RelatedResources) != 22 {
-					return fmt.Errorf("should get 22 relatedResources, actual got %v", len(actual.Status.RelatedResources))
+				// 10 managed static manifests + 9 management static manifests + 4 networkpolicies + 2CRDs + 1 deployments
+				if len(actual.Status.RelatedResources) != 26 {
+					return fmt.Errorf("should get 26 relatedResources, actual got %v", len(actual.Status.RelatedResources))
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -151,7 +151,8 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 					return err
 				}
 
-				// 11 managed static manifests + 11 management static manifests + 4 networkpolicies + 2CRDs + 2 deployments(2 duplicated SAs)
+				// 11 managed static manifests + 11 management static manifests + 4 networkpolicies +
+				// 2 CRDs + 2 deployments - 2 duplicated SAs = 28
 				if len(actual.Status.RelatedResources) != 28 {
 					return fmt.Errorf("should get 28 relatedResources, actual got %v", len(actual.Status.RelatedResources))
 				}

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -77,6 +77,14 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 				},
 				ClusterName: "testcluster",
 				Namespace:   klusterletNamespace,
+				RegistrationConfiguration: &operatorapiv1.RegistrationConfiguration{
+					FeatureGates: []operatorapiv1.FeatureGate{
+						{
+							Feature: "NetworkPolicies",
+							Mode:    operatorapiv1.FeatureGateModeTypeEnable,
+						},
+					},
+				},
 			},
 		}
 

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -630,7 +630,7 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 					return false
 				}
 				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(5))
+				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(7))
 				return actual.Spec.Template.Spec.Containers[0].Args[2] == "--spoke-cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -151,9 +151,9 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 					return err
 				}
 
-				// 11 managed static manifests + 11 management static manifests + 2CRDs + 2 deployments(2 duplicated SAs)
-				if len(actual.Status.RelatedResources) != 24 {
-					return fmt.Errorf("should get 26 relatedResources, actual got %v", len(actual.Status.RelatedResources))
+				// 11 managed static manifests + 11 management static manifests + 4 networkpolicies + 2CRDs + 2 deployments(2 duplicated SAs)
+				if len(actual.Status.RelatedResources) != 28 {
+					return fmt.Errorf("should get 28 relatedResources, actual got %v", len(actual.Status.RelatedResources))
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())


### PR DESCRIPTION
## Summary

Ship 4 NetworkPolicy manifests with the klusterlet operator to restrict ingress/egress in the `open-cluster-management-agent` namespace, meeting CIS Kube benchmark 5.3.2.

### Policies added

| Policy | Purpose |
|--------|---------|
| `default-deny-all` | Baseline deny for all ingress and egress |
| `allow-dns-and-api` | DNS egress (OpenShift DNS on 5353, kube-dns on 53) + ports-only API server egress (TCP 443/6443) |
| `klusterlet` | Operator egress to intra-namespace pods, addon namespaces, and `kubernetes.default.svc` |
| `klusterlet-agent` | Agent egress to `kubernetes.default.svc`, hub webhooks (port 9443), and intra-namespace pods |

### Other changes

- **RBAC**: Added `networking.k8s.io/networkpolicies` permissions to the klusterlet ClusterRole (both static and Helm chart)
- **Cleanup**: Added `*networkingv1.NetworkPolicy` case to `CleanUpStaticObject` and `GenerateRelatedResource` in `helpers.go`
- **Static resource registration**: Added 4 NP file paths to `managementStaticResourceFiles` in the management reconciler
- **Tests**: Updated action counts in `TestSyncDeploy`, `TestSyncDeploySingleton`, `TestSyncDeployHosted`, `TestSyncDelete`, and `TestSyncDeleteHosted`

### Design decisions

- **Ports-only egress (no `to` selector) for API server access**: The `allow-dns-and-api` policy uses ports-only rules for TCP 443/6443 without restricting destination IPs or hostnames. This ensures the policy works on both hub (local-cluster) and spoke clusters without needing to know the hub API server address, and avoids breakage from cloud load balancer IP rotation.
- **Follows existing static resource pattern**: NPs are embedded via `//go:embed`, templated with `{{ .AgentNamespace }}`, and applied via `ApplyDirectly()` / `ApplyNetworkPolicy()` — consistent with how all other management static resources are handled.
- **Works across all deploy modes**: Singleton (combined `klusterlet-agent`), Default (separate registration/work agents), and Hosted modes are all covered by the pod selector labels used in each policy.

### Testing

- **Hub cluster (local-cluster)**: Custom operator image deployed, all 4 NPs created automatically via reconciliation, all pods healthy, zero errors
- **Spoke cluster**: NPs applied manually (same YAML), verified all agents maintained hub connectivity (`HubConnectionDegraded: False`), zero network errors in logs
- **Unit tests**: All updated test counts pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional NetworkPolicy support for klusterlet components, including a default-deny policy and targeted allow rules for DNS, API, and required agent/klusterlet communications.
* **Bug Fixes**
  * Updated operator and OLM RBAC so NetworkPolicy resources can be managed end-to-end, and reconciliation now applies/removes these policies only when the feature is enabled.
* **Tests**
  * Extended integration/unit coverage to enable the feature gate and validate the increased set of created related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->