### PR TITLE
:bug: Apply TLS profile to operator and agent serving endpoints

### DIFF
--- a/pkg/cmd/hub/operator.go
+++ b/pkg/cmd/hub/operator.go
@@ -34,5 +34,16 @@ func NewHubOperatorCmd() *cobra.Command {
 	flags.StringVar(&cmOptions.ImagePullSecretName, "image-pull-secret-name", helpers.ImagePullSecret,
 		"The name of the image pull secret in the operator namespace to sync to hub components")
 	opts.AddFlags(flags)
+	// The cluster-manager operator does not receive --tls-min-version /
+	// --tls-cipher-suites flags from its deployment manifest (unlike the hub
+	// controllers it manages). Instead, it reads the ocm-tls-profile ConfigMap
+	// itself at runtime. ApplyTLSFromConfigMapToCommand installs a
+	// PersistentPreRunE hook that reads that ConfigMap once before
+	// library-go's StartController starts the health/metrics server (port 8443),
+	// so the server uses the cluster TLS profile from the first request.
+	// When the ConfigMap changes, RunClusterManagerOperator's watcher calls
+	// os.Exit(0), Kubernetes restarts the pod, and this hook re-reads the
+	// updated ConfigMap on the next startup.
+	opts.ApplyTLSFromConfigMapToCommand(cmd)
 	return cmd
 }

--- a/pkg/cmd/hub/operator_test.go
+++ b/pkg/cmd/hub/operator_test.go
@@ -99,6 +99,15 @@ func TestHubOperatorFlagDefaults(t *testing.T) {
 	}
 }
 
+func TestHubOperatorTLSFromConfigMapWiring(t *testing.T) {
+	cmd := NewHubOperatorCmd()
+
+	// ApplyTLSFromConfigMapToCommand should have set PersistentPreRunE.
+	if cmd.PersistentPreRunE == nil {
+		t.Error("Expected PersistentPreRunE to be set by ApplyTLSFromConfigMapToCommand")
+	}
+}
+
 func TestHubOperatorCommandExecution(t *testing.T) {
 	cmd := NewHubOperatorCmd()
 

--- a/pkg/cmd/spoke/operator.go
+++ b/pkg/cmd/spoke/operator.go
@@ -50,6 +50,17 @@ func NewKlusterletOperatorCmd() *cobra.Command {
 		"If set, will sync the labels of Klusterlet CR to all agent resources")
 
 	opts.AddFlags(flags)
+	// The klusterlet operator does not receive --tls-min-version /
+	// --tls-cipher-suites flags from its deployment manifest (unlike the spoke
+	// agent deployments it manages). Instead, the ocm-tls-profile ConfigMap is
+	// written by the tls-profile-sync sidecar running in the same pod.
+	// ApplyTLSFromConfigMapToCommand installs a PersistentPreRunE hook that
+	// reads that ConfigMap once before library-go's StartController starts the
+	// health/metrics server (port 8443), so the server uses the cluster TLS
+	// profile from the first request.
+	// When the ConfigMap changes the tls-profile-sync sidecar causes the pod
+	// to restart, and this hook re-reads the updated ConfigMap on the next startup.
+	opts.ApplyTLSFromConfigMapToCommand(cmd)
 
 	return cmd
 }
@@ -78,6 +89,11 @@ func NewKlusterletAgentCmd() *cobra.Command {
 	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates))
 	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
 	features.SpokeMutableFeatureGate.AddFlag(flags)
+	// The klusterlet operator injects --tls-min-version and --tls-cipher-suites
+	// into this agent's deployment manifest from the ocm-tls-profile ConfigMap.
+	// ApplyTLSToCommand wires those CLI flags to the library-go health/metrics
+	// server (port 8443) via a PersistentPreRunE hook so the server enforces
+	// the cluster TLS profile.
 	commonOptions.CommonOpts.ApplyTLSToCommand(cmd)
 	return cmd
 }

--- a/pkg/cmd/spoke/operator.go
+++ b/pkg/cmd/spoke/operator.go
@@ -78,5 +78,6 @@ func NewKlusterletAgentCmd() *cobra.Command {
 	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates))
 	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
 	features.SpokeMutableFeatureGate.AddFlag(flags)
+	commonOptions.CommonOpts.ApplyTLSToCommand(cmd)
 	return cmd
 }

--- a/pkg/cmd/spoke/operator_test.go
+++ b/pkg/cmd/spoke/operator_test.go
@@ -98,6 +98,29 @@ func TestKlusterletOperatorDeprecatedFlag(t *testing.T) {
 	}
 }
 
+func TestKlusterletAgentTLSWiring(t *testing.T) {
+	// Reset feature gate for this test
+	old := features.SpokeMutableFeatureGate
+	features.SpokeMutableFeatureGate = featuregate.NewFeatureGate()
+	t.Cleanup(func() { features.SpokeMutableFeatureGate = old })
+
+	cmd := NewKlusterletAgentCmd()
+
+	// ApplyTLSToCommand should have set PersistentPreRunE
+	if cmd.PersistentPreRunE == nil {
+		t.Error("Expected PersistentPreRunE to be set by ApplyTLSToCommand")
+	}
+
+	// TLS flags should be registered via common options
+	flags := cmd.Flags()
+	if flags.Lookup("tls-min-version") == nil {
+		t.Error("Expected --tls-min-version flag to be registered")
+	}
+	if flags.Lookup("tls-cipher-suites") == nil {
+		t.Error("Expected --tls-cipher-suites flag to be registered")
+	}
+}
+
 func TestNewKlusterletAgentCmd(t *testing.T) {
 	// Reset feature gate for this test
 	old := features.SpokeMutableFeatureGate

--- a/pkg/cmd/spoke/operator_test.go
+++ b/pkg/cmd/spoke/operator_test.go
@@ -81,6 +81,15 @@ func TestKlusterletOperatorFlags(t *testing.T) {
 	}
 }
 
+func TestKlusterletOperatorTLSFromConfigMapWiring(t *testing.T) {
+	cmd := NewKlusterletOperatorCmd()
+
+	// ApplyTLSFromConfigMapToCommand should have set PersistentPreRunE.
+	if cmd.PersistentPreRunE == nil {
+		t.Error("Expected PersistentPreRunE to be set by ApplyTLSFromConfigMapToCommand")
+	}
+}
+
 func TestKlusterletOperatorDeprecatedFlag(t *testing.T) {
 	cmd := NewKlusterletOperatorCmd()
 	flags := cmd.Flags()

--- a/pkg/cmd/spoke/registration.go
+++ b/pkg/cmd/spoke/registration.go
@@ -34,6 +34,11 @@ func NewRegistrationAgent() *cobra.Command {
 
 	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates))
 	features.SpokeMutableFeatureGate.AddFlag(flags)
+	// The klusterlet operator injects --tls-min-version and --tls-cipher-suites
+	// into this agent's deployment manifest from the ocm-tls-profile ConfigMap.
+	// ApplyTLSToCommand wires those CLI flags to the library-go health/metrics
+	// server (port 8443) via a PersistentPreRunE hook so the server enforces
+	// the cluster TLS profile.
 	commonOptions.CommonOpts.ApplyTLSToCommand(cmd)
 	return cmd
 }

--- a/pkg/cmd/spoke/registration.go
+++ b/pkg/cmd/spoke/registration.go
@@ -34,5 +34,6 @@ func NewRegistrationAgent() *cobra.Command {
 
 	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeRegistrationFeatureGates))
 	features.SpokeMutableFeatureGate.AddFlag(flags)
+	commonOptions.CommonOpts.ApplyTLSToCommand(cmd)
 	return cmd
 }

--- a/pkg/cmd/spoke/registration_test.go
+++ b/pkg/cmd/spoke/registration_test.go
@@ -86,3 +86,26 @@ func TestRegistrationAgentCommandType(t *testing.T) {
 		t.Error("NewRegistrationAgent() should return *cobra.Command")
 	}
 }
+
+func TestRegistrationAgentTLSWiring(t *testing.T) {
+	// Reset feature gate for this test
+	old := features.SpokeMutableFeatureGate
+	features.SpokeMutableFeatureGate = featuregate.NewFeatureGate()
+	t.Cleanup(func() { features.SpokeMutableFeatureGate = old })
+
+	cmd := NewRegistrationAgent()
+
+	// ApplyTLSToCommand should have set PersistentPreRunE
+	if cmd.PersistentPreRunE == nil {
+		t.Error("Expected PersistentPreRunE to be set by ApplyTLSToCommand")
+	}
+
+	// TLS flags should be registered via common options
+	flags := cmd.Flags()
+	if flags.Lookup("tls-min-version") == nil {
+		t.Error("Expected --tls-min-version flag to be registered")
+	}
+	if flags.Lookup("tls-cipher-suites") == nil {
+		t.Error("Expected --tls-cipher-suites flag to be registered")
+	}
+}

--- a/pkg/cmd/spoke/work.go
+++ b/pkg/cmd/spoke/work.go
@@ -32,6 +32,7 @@ func NewWorkAgent() *cobra.Command {
 	agentOption.AddFlags(flags)
 	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
 	features.SpokeMutableFeatureGate.AddFlag(flags)
+	commonOptions.CommonOpts.ApplyTLSToCommand(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/spoke/work.go
+++ b/pkg/cmd/spoke/work.go
@@ -32,6 +32,11 @@ func NewWorkAgent() *cobra.Command {
 	agentOption.AddFlags(flags)
 	utilruntime.Must(features.SpokeMutableFeatureGate.Add(ocmfeature.DefaultSpokeWorkFeatureGates))
 	features.SpokeMutableFeatureGate.AddFlag(flags)
+	// The klusterlet operator injects --tls-min-version and --tls-cipher-suites
+	// into this agent's deployment manifest from the ocm-tls-profile ConfigMap.
+	// ApplyTLSToCommand wires those CLI flags to the library-go health/metrics
+	// server (port 8443) via a PersistentPreRunE hook so the server enforces
+	// the cluster TLS profile.
 	commonOptions.CommonOpts.ApplyTLSToCommand(cmd)
 
 	return cmd

--- a/pkg/cmd/spoke/work_test.go
+++ b/pkg/cmd/spoke/work_test.go
@@ -83,3 +83,26 @@ func TestWorkAgentCommandType(t *testing.T) {
 		t.Error("NewWorkAgent() should return *cobra.Command")
 	}
 }
+
+func TestWorkAgentTLSWiring(t *testing.T) {
+	// Reset feature gate for this test
+	old := features.SpokeMutableFeatureGate
+	features.SpokeMutableFeatureGate = featuregate.NewFeatureGate()
+	t.Cleanup(func() { features.SpokeMutableFeatureGate = old })
+
+	cmd := NewWorkAgent()
+
+	// ApplyTLSToCommand should have set PersistentPreRunE
+	if cmd.PersistentPreRunE == nil {
+		t.Error("Expected PersistentPreRunE to be set by ApplyTLSToCommand")
+	}
+
+	// TLS flags should be registered via common options
+	flags := cmd.Flags()
+	if flags.Lookup("tls-min-version") == nil {
+		t.Error("Expected --tls-min-version flag to be registered")
+	}
+	if flags.Lookup("tls-cipher-suites") == nil {
+		t.Error("Expected --tls-cipher-suites flag to be registered")
+	}
+}

--- a/pkg/common/options/options.go
+++ b/pkg/common/options/options.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/clock"
 
 	tlslib "open-cluster-management.io/sdk-go/pkg/tls"
@@ -73,16 +75,42 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	}
 }
 
-// ApplyTLSToCommand installs a PersistentPreRunE hook that writes a minimal
-// GenericOperatorConfig YAML to a temp file in /tmp (which is mounted as an
-// emptyDir in all hub controller deployments, so writing is safe even with
-// readOnlyRootFilesystem: true) and sets library-go's --config flag to point
-// at it. This runs before cmd.Run so all library-go boilerplate (signal
-// handling, logging, profiling) is fully preserved.
-//
+// writeTLSServingConfig writes a minimal GenericOperatorConfig YAML to a temp
+// file in /tmp and sets library-go's --config flag to point at it.
+// /tmp is mounted as an emptyDir in all operator/agent deployments so writing
+// is safe even with readOnlyRootFilesystem: true.
 // Inside cmd.Run, StartController calls Config() which reads the file; the TLS
-// values survive SetRecommendedHTTPServingInfoDefaults because DefaultString only
-// sets fields that are empty.
+// values survive SetRecommendedHTTPServingInfoDefaults because DefaultString
+// only sets fields that are empty.
+func writeTLSServingConfig(cmd *cobra.Command, minVersion, cipherSuites string) error {
+	content := "apiVersion: operator.openshift.io/v1alpha1\nkind: GenericOperatorConfig\nservingInfo:\n"
+	if minVersion != "" {
+		content += "  minTLSVersion: " + minVersion + "\n"
+	}
+	if cipherSuites != "" {
+		content += "  cipherSuites:\n"
+		for _, c := range strings.Split(cipherSuites, ",") {
+			content += "  - " + strings.TrimSpace(c) + "\n"
+		}
+	}
+	f, err := os.CreateTemp("/tmp", "ocm-controller-tls-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create TLS config file: %w", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return fmt.Errorf("failed to write TLS config: %w", err)
+	}
+	f.Close()
+	return cmd.Flags().Set("config", f.Name())
+}
+
+// ApplyTLSToCommand installs a PersistentPreRunE hook that reads --tls-min-version
+// and --tls-cipher-suites CLI flags and writes a minimal GenericOperatorConfig
+// YAML to a temp file, then sets library-go's --config flag to point at it.
+// This runs before cmd.Run so all library-go boilerplate is fully preserved.
+// Use this for components whose deployments receive TLS flags from their operator.
 func (o *Options) ApplyTLSToCommand(cmd *cobra.Command) {
 	prev := cmd.PersistentPreRunE
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
@@ -100,28 +128,85 @@ func (o *Options) ApplyTLSToCommand(cmd *cobra.Command) {
 		if _, err := tlslib.ConfigFromFlags(o.TLSMinVersion, o.TLSCipherSuites); err != nil {
 			return fmt.Errorf("invalid TLS flags: %w", err)
 		}
-		content := "apiVersion: operator.openshift.io/v1alpha1\nkind: GenericOperatorConfig\nservingInfo:\n"
-		if o.TLSMinVersion != "" {
-			content += "  minTLSVersion: " + o.TLSMinVersion + "\n"
-		}
-		if o.TLSCipherSuites != "" {
-			content += "  cipherSuites:\n"
-			for _, c := range strings.Split(o.TLSCipherSuites, ",") {
-				content += "  - " + strings.TrimSpace(c) + "\n"
+		return writeTLSServingConfig(cmd, o.TLSMinVersion, o.TLSCipherSuites)
+	}
+}
+
+// operatorNamespace returns the namespace the operator is running in.
+// It checks the --namespace flag first, then falls back to the service account
+// namespace file. Returns empty string if neither is available (e.g., local dev).
+func operatorNamespace(cmd *cobra.Command) string {
+	if f := cmd.Flags().Lookup("namespace"); f != nil && f.Changed {
+		return f.Value.String()
+	}
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(nsBytes))
+}
+
+// applyTLSFromConfigMap reads the ocm-tls-profile ConfigMap using the given
+// kube client and namespace, and if found, writes the TLS serving config file.
+// Returns nil if the ConfigMap is not found (graceful no-op).
+// Extracted for testability.
+func applyTLSFromConfigMap(ctx context.Context, kubeClient kubernetes.Interface, namespace string, cmd *cobra.Command) error {
+	tlsCfg, err := tlslib.LoadTLSConfigFromConfigMap(ctx, kubeClient, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to load TLS config from ConfigMap: %w", err)
+	}
+	if tlsCfg == nil {
+		// ConfigMap not found or empty -- skip gracefully, use library-go defaults.
+		return nil
+	}
+	minVersion := tlslib.VersionToString(tlsCfg.MinVersion)
+	cipherSuites := ""
+	if len(tlsCfg.CipherSuites) > 0 {
+		cipherSuites = tlslib.CipherSuitesToString(tlsCfg.CipherSuites)
+	}
+	return writeTLSServingConfig(cmd, minVersion, cipherSuites)
+}
+
+// ApplyTLSFromConfigMapToCommand installs a PersistentPreRunE hook that reads
+// the ocm-tls-profile ConfigMap directly (using the in-cluster service account)
+// and writes a minimal GenericOperatorConfig YAML so library-go's GenericAPIServer
+// (port 8443) uses the correct TLS settings from the cluster TLS profile.
+//
+// This is intended for operator binaries that do not receive --tls-min-version
+// and --tls-cipher-suites flags from their deployment manifests (because nobody
+// injects them externally), but do have access to the ocm-tls-profile ConfigMap
+// in their namespace at startup.
+//
+// If the ConfigMap is not found or the in-cluster config is unavailable (e.g.,
+// running locally), the hook is a no-op and library-go's defaults apply.
+func (o *Options) ApplyTLSFromConfigMapToCommand(cmd *cobra.Command) {
+	prev := cmd.PersistentPreRunE
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if prev != nil {
+			if err := prev(cmd, args); err != nil {
+				return err
 			}
 		}
-		// Use /tmp explicitly: it is mounted as an emptyDir in all hub controller
-		// deployments so the path is writable even with readOnlyRootFilesystem: true.
-		f, err := os.CreateTemp("/tmp", "ocm-controller-tls-*.yaml")
+		// Skip if --config already set by the user.
+		if cmd.Flags().Changed("config") {
+			return nil
+		}
+		// Get the operator namespace.
+		namespace := operatorNamespace(cmd)
+		if namespace == "" {
+			// Not running in cluster (local dev) -- skip gracefully.
+			return nil
+		}
+		// Build an in-cluster kube client.
+		cfg, err := rest.InClusterConfig()
 		if err != nil {
-			return fmt.Errorf("failed to create TLS config file: %w", err)
+			// Not running in cluster -- skip gracefully.
+			return nil
 		}
-		if _, err := f.WriteString(content); err != nil {
-			f.Close()
-			os.Remove(f.Name())
-			return fmt.Errorf("failed to write TLS config: %w", err)
+		kubeClient, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create kube client for TLS ConfigMap: %w", err)
 		}
-		f.Close()
-		return cmd.Flags().Set("config", f.Name())
+		return applyTLSFromConfigMap(context.Background(), kubeClient, namespace, cmd)
 	}
 }

--- a/pkg/common/options/options_test.go
+++ b/pkg/common/options/options_test.go
@@ -11,9 +11,12 @@ import (
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clocktesting "k8s.io/utils/clock/testing"
+
+	tlslib "open-cluster-management.io/sdk-go/pkg/tls"
 
 	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
 	"open-cluster-management.io/ocm/pkg/registration/register"
@@ -355,5 +358,153 @@ func TestApplyTLSToCommand(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestApplyTLSFromConfigMap(t *testing.T) {
+	cases := []struct {
+		name           string
+		configMap      *corev1.ConfigMap
+		wantConfigSet  bool
+		wantMinVersion string
+		wantCiphers    []string
+	}{
+		{
+			name:          "ConfigMap not found -- no-op",
+			configMap:     nil,
+			wantConfigSet: false,
+		},
+		{
+			name: "ConfigMap with VersionTLS13",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tlslib.ConfigMapName,
+					Namespace: "test-ns",
+				},
+				Data: map[string]string{
+					tlslib.ConfigMapKeyMinVersion: "VersionTLS13",
+				},
+			},
+			wantConfigSet:  true,
+			wantMinVersion: "VersionTLS13",
+		},
+		{
+			name: "ConfigMap with VersionTLS12 and cipher suites",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tlslib.ConfigMapName,
+					Namespace: "test-ns",
+				},
+				Data: map[string]string{
+					tlslib.ConfigMapKeyMinVersion:   "VersionTLS12",
+					tlslib.ConfigMapKeyCipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+				},
+			},
+			wantConfigSet:  true,
+			wantMinVersion: "VersionTLS12",
+			wantCiphers:    []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+		},
+		{
+			name: "empty ConfigMap data -- uses default VersionTLS12",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tlslib.ConfigMapName,
+					Namespace: "test-ns",
+				},
+				Data: map[string]string{},
+			},
+			wantConfigSet:  true,
+			wantMinVersion: "VersionTLS12",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var objects []runtime.Object
+			if c.configMap != nil {
+				objects = append(objects, c.configMap)
+			}
+			kubeClient := kubefake.NewSimpleClientset(objects...)
+
+			cmd := &cobra.Command{Use: "test"}
+			var configFile string
+			cmd.Flags().StringVar(&configFile, "config", "", "")
+
+			err := applyTLSFromConfigMap(context.Background(), kubeClient, "test-ns", cmd)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !c.wantConfigSet {
+				if configFile != "" {
+					t.Errorf("expected --config to be empty, got %q", configFile)
+				}
+				return
+			}
+
+			if configFile == "" {
+				t.Fatal("expected --config to be set, but it is empty")
+			}
+			defer os.Remove(configFile)
+
+			content, err := os.ReadFile(configFile)
+			if err != nil {
+				t.Fatalf("failed to read generated config file: %v", err)
+			}
+			s := string(content)
+
+			if c.wantMinVersion != "" && !strings.Contains(s, "minTLSVersion: "+c.wantMinVersion) {
+				t.Errorf("expected config to contain minTLSVersion %q, got:\n%s", c.wantMinVersion, s)
+			}
+			for _, cipher := range c.wantCiphers {
+				if !strings.Contains(s, cipher) {
+					t.Errorf("expected config to contain cipher %q, got:\n%s", cipher, s)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyTLSFromConfigMapPersistentPreRunE(t *testing.T) {
+	// Verify that ApplyTLSFromConfigMapToCommand sets PersistentPreRunE.
+	opts := NewOptions()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("config", "", "")
+	cmd.Flags().String("namespace", "", "")
+
+	if cmd.PersistentPreRunE != nil {
+		t.Fatal("expected PersistentPreRunE to be nil before ApplyTLSFromConfigMapToCommand")
+	}
+	opts.ApplyTLSFromConfigMapToCommand(cmd)
+	if cmd.PersistentPreRunE == nil {
+		t.Error("expected PersistentPreRunE to be set by ApplyTLSFromConfigMapToCommand")
+	}
+}
+
+func TestApplyTLSFromConfigMapSkipsWhenConfigAlreadySet(t *testing.T) {
+	// When --config is already set, the hook should be a no-op even if the
+	// ConfigMap exists.  This guards against overwriting user-supplied config.
+	// We test the hook directly: without in-cluster credentials the hook
+	// exits early (no namespace) -- so set the namespace flag explicitly and
+	// run the hook with --config pre-set.  The hook should return nil without
+	// creating a new temp file.
+	opts := NewOptions()
+	cmd := &cobra.Command{Use: "test"}
+	var configFile string
+	cmd.Flags().StringVar(&configFile, "config", "/existing/config.yaml", "")
+	cmd.Flags().String("namespace", "test-ns", "")
+	if err := cmd.Flags().Set("config", "/existing/config.yaml"); err != nil {
+		t.Fatal(err)
+	}
+
+	opts.ApplyTLSFromConfigMapToCommand(cmd)
+
+	// Run the hook -- it should detect --config is already set and return immediately.
+	if err := cmd.PersistentPreRunE(cmd, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// --config must remain unchanged.
+	if configFile != "/existing/config.yaml" {
+		t.Errorf("expected --config to remain %q, got %q", "/existing/config.yaml", configFile)
 	}
 }


### PR DESCRIPTION
The operator and agent binaries serve health/metrics on port 8443 via library-go's GenericAPIServer but do not apply the TLS profile from the ocm-tls-profile ConfigMap. Port 8443 accepts TLSv1.2 even when the cluster requires TLSv1.3.

- Add `ApplyTLSToCommand` to spoke agent commands (they receive TLS flags from deployment templates but were not wiring them to the serving endpoint)
- Add `ApplyTLSFromConfigMapToCommand` for operator commands (they read the ConfigMap directly since no external component injects TLS flags into their deployments)

Fixes #1638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic TLS profile configuration for hub and spoke operators from the cluster TLS profile.
  * Applied TLS settings to spoke agent, registration, and work-agent health and metrics servers.
  * TLS settings are refreshed when components restart after profile updates.

* **Bug Fixes**
  * Preserved explicitly provided TLS configuration and handled unavailable in-cluster configuration gracefully.

* **Tests**
  * Added coverage for TLS flags, profile loading, defaults, and configuration hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->