### PR TITLE
:bug: fix: make NetworkPolicy manifests vendor-neutral

### DIFF
--- a/manifests/klusterlet/management/klusterlet-agent-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-networkpolicy.yaml
@@ -14,18 +14,10 @@ spec:
   - from:
     - podSelector: {}
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: default
-    ports:
+  - ports:
     - protocol: TCP
       port: 443
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: open-cluster-management-hub
-    ports:
+  - ports:
     - protocol: TCP
       port: 9443
   - to:

--- a/manifests/klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-allow-dns-networkpolicy.yaml
@@ -8,27 +8,15 @@ spec:
   policyTypes:
   - Egress
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-dns
-    ports:
-    - protocol: UDP
-      port: 5353
-    - protocol: TCP
-      port: 5353
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-    ports:
+  - ports:
     - protocol: UDP
       port: 53
     - protocol: TCP
       port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
   - ports:
     - protocol: TCP
       port: 443

--- a/manifests/klusterlet/management/klusterlet-networkpolicy.yaml
+++ b/manifests/klusterlet/management/klusterlet-networkpolicy.yaml
@@ -16,17 +16,6 @@ spec:
   egress:
   - to:
     - podSelector: {}
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          addon.open-cluster-management.io/namespace: "true"
-    ports:
-    - protocol: TCP
-      port: 443
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: default
-    ports:
+  - ports:
     - protocol: TCP
       port: 443


### PR DESCRIPTION
## Summary

Follow-up to #1627 to make the NetworkPolicy manifests vendor-neutral.

PR #1627 introduced NetworkPolicies for the `open-cluster-management-agent` namespace behind a `NetworkPolicies` feature gate. The initial implementation used `namespaceSelector` rules that targeted platform-specific namespaces (`openshift-dns`, `kube-system` with `k8s-app: kube-dns` podSelector) and hardcoded namespace names (`default`, `open-cluster-management-hub`). This PR removes those selectors and replaces them with ports-only rules so the policies work on any Kubernetes distribution.

### What changed compared to #1627

| File | Before (PR #1627) | After (this PR) |
|------|-------------------|-----------------|
| `allow-dns-and-api` | Two DNS egress rules: one targeting `openshift-dns` namespace on port 5353 (OpenShift-specific), another targeting `kube-system` pods labeled `k8s-app: kube-dns` on port 53 | Single ports-only DNS rule allowing both port 53 and 5353 (UDP/TCP) without any namespace or pod selector |
| `klusterlet-agent` | Egress to `default` namespace on port 443 and `open-cluster-management-hub` namespace on port 9443 via `namespaceSelector` | Ports-only rules for 443 and 9443 — same ports, no destination selectors |
| `klusterlet` | Egress to `addon.open-cluster-management.io/namespace` labeled namespaces and `default` namespace on port 443 via `namespaceSelector` | Single ports-only rule for port 443 |

All port-based restrictions are preserved; only the platform-specific destination selectors are removed. The `default-deny-all` policy and intra-namespace `podSelector: {}` rules are unchanged.

## Related issue(s)

Follow-up to #1627.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules for management and agent components.
  * Standardized egress permissions for HTTPS traffic on TCP port 443.
  * Updated DNS access to explicitly allow UDP and TCP traffic on ports 53 and 5353.
  * Adjusted destination handling to support required pod-to-pod and service communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->