### PR TITLE
🐛 keep registration annotations flag ordering consistent on each reconcile

### DIFF
--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -3,6 +3,7 @@ package klusterletcontroller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -56,6 +57,19 @@ const (
 // not passed through to agent binaries as CLI flags.
 var operatorOnlyFeatureGates = map[featuregate.Feature]bool{
 	NetworkPolicies: true,
+}
+
+// buildClusterAnnotationsString renders the ClusterAnnotations map into the
+// comma-separated "key1=value1,key2=value2" form consumed by the registration
+// agent's --cluster-annotations flag. Keys are sorted deterministically.
+func buildClusterAnnotationsString(annotations map[string]string) string {
+	filtered := commonhelpers.FilterClusterAnnotations(annotations)
+	arr := make([]string, 0, len(filtered))
+	for k, v := range filtered {
+		arr = append(arr, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(arr)
+	return strings.Join(arr, ",")
 }
 
 func filterOperatorFeatureGates(features []operatorapiv1.FeatureGate) []operatorapiv1.FeatureGate {
@@ -422,12 +436,7 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 				klusterlet.Spec.RegistrationConfiguration.ClusterClaimConfiguration.ReservedClusterClaimSuffixes, ",")
 		}
 
-		// construct cluster annotations string, the final format is "key1=value1,key2=value2"
-		var annotationsArray []string
-		for k, v := range commonhelpers.FilterClusterAnnotations(klusterlet.Spec.RegistrationConfiguration.ClusterAnnotations) {
-			annotationsArray = append(annotationsArray, fmt.Sprintf("%s=%s", k, v))
-		}
-		config.ClusterAnnotationsString = strings.Join(annotationsArray, ",")
+		config.ClusterAnnotationsString = buildClusterAnnotationsString(klusterlet.Spec.RegistrationConfiguration.ClusterAnnotations)
 
 		// Set AddOnKubeClientRegistrationAuth from the Klusterlet spec
 		if klusterlet.Spec.RegistrationConfiguration.AddOnKubeClientRegistrationDriver != nil &&

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -1917,3 +1917,70 @@ func TestCleanWithMultipleKlusterletAgentNamespaces(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildClusterAnnotationsString verifies that the annotations flag string has consistent ordering across multiple runs.
+func TestBuildClusterAnnotationsString(t *testing.T) {
+	const prefix = "agent.open-cluster-management.io"
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        string
+	}{
+		{
+			name:        "nil map",
+			annotations: nil,
+			want:        "",
+		},
+		{
+			name:        "empty map",
+			annotations: map[string]string{},
+			want:        "",
+		},
+		{
+			name:        "single key",
+			annotations: map[string]string{prefix + "/foo": "bar"},
+			want:        prefix + "/foo=bar",
+		},
+		{
+			name: "keys sorted lexicographically",
+			annotations: map[string]string{
+				prefix + "/c": "3",
+				prefix + "/a": "1",
+				prefix + "/b": "2",
+			},
+			want: prefix + "/a=1," + prefix + "/b=2," + prefix + "/c=3",
+		},
+		{
+			name: "non-prefixed keys are filtered out",
+			annotations: map[string]string{
+				prefix + "/keep":     "yes",
+				"other.example/drop": "no",
+			},
+			want: prefix + "/keep=yes",
+		},
+		{
+			name: "many keys stable across many invocations",
+			annotations: map[string]string{
+				prefix + "/a": "1",
+				prefix + "/b": "2",
+				prefix + "/c": "3",
+				prefix + "/d": "4",
+				prefix + "/e": "5",
+				prefix + "/f": "6",
+			},
+			want: prefix + "/a=1," + prefix + "/b=2," + prefix + "/c=3," + prefix + "/d=4," + prefix + "/e=5," + prefix + "/f=6",
+		},
+	}
+
+	const iterations = 1000
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := range iterations {
+				got := buildClusterAnnotationsString(tt.annotations)
+				if got != tt.want {
+					t.Fatalf("iteration %d: got %q, want %q (non-deterministic output regresses cluster-annotations flag)", i, got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Observed in OCM version: 1.3.1 
  
### Symptoms
  - klusterlet-registration-agent pod is recreated (net-new pod, not container restart) frequently.
  - klusterlet-work-agent shows the same recreation pattern.
  - Pods are healthy while they run; each is killed by a fresh Deployment rollout.

### Evidence

Registration Deployment has been rolled over 10,000 times in 9 days:

```bash
$ kubectl -n open-cluster-management-agent get deploy klusterlet-registration-agent -o yaml \
   | grep -E 'revision|generation|creationTimestamp'
creationTimestamp: "2026-07-21T11:50:06Z"
generation: 10929
deployment.kubernetes.io/revision: "10909"
```

Two ReplicaSets exist and alternate:

```bash
$ kubectl -n open-cluster-management-agent get rs
NAME                                       DESIRED   CURRENT   READY   AGE
klusterlet-registration-agent-7555bfbc78   0         0         0       9d
klusterlet-registration-agent-85cf6cb966   1         1         1       9d
klusterlet-work-agent-598cc884b9           0         0         0       9d
klusterlet-work-agent-79c55d4dc7           1         1         1       9d
```

Their PodTemplates are identical except for the order of `--cluster-annotations`:

RS ...-7555bfbc78: `--cluster-annotations=agent.open-cluster-management.io/annotation-b=b-value,agent.open-cluster-management.io/annotation-a=true`
RS ...-85cf6cb966: `-cluster-annotations=agent.open-cluster-management.io/annotation-a=true,agent.open-cluster-management.io/annotation-b=b-value`

Corresponding Klusterlet CR:

```yaml
spec:
  registrationConfiguration:
    clusterAnnotations:
      agent.open-cluster-management.io/annotation-a: "true"
      agent.open-cluster-management.io/annotation-b: "b-value"
```

### Root cause

ClusterAnnotations is a map[string]string. Go randomizes map iteration order, so ClusterAnnotationsString is non-deterministic across reconciles whenever the map has ≥2 keys. That string is templated into the Deployment PodSpec, which changes the pod-template-hash on every reconcile — new ReplicaSet, rollout, old pod killed.

### Fix

- add a `strings.Sort()` call before joining to guarantee consistent ordering on each reconcile.
- add unit tests that construct the flag with multiple annotations 1000 times and assert ordering is unchanged. Confirmed the tests fail without the fix in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cluster annotation values are now rendered in a consistent, predictable order.
  - Non-applicable annotations are excluded from the generated configuration.
  - This improves configuration stability and prevents unnecessary changes caused by varying annotation order.

- **Tests**
  - Added coverage for empty, single-entry, multiple-entry, filtered, and repeated annotation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->