### PR TITLE
:bug: Restart klusterlet operator when TLS ConfigMap changes

### DIFF
--- a/pkg/operator/operators/klusterlet/options.go
+++ b/pkg/operator/operators/klusterlet/options.go
@@ -18,6 +18,7 @@ import (
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	operatorinformer "open-cluster-management.io/api/client/operator/informers/externalversions"
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
+	tlslib "open-cluster-management.io/sdk-go/pkg/tls"
 
 	"open-cluster-management.io/ocm/pkg/operator/helpers"
 	"open-cluster-management.io/ocm/pkg/operator/operators/klusterlet/controllers/addonsecretcontroller"
@@ -108,6 +109,26 @@ func (o *Options) RunKlusterletOperator(ctx context.Context, controllerContext *
 	if err != nil {
 		return err
 	}
+
+	// Load TLS config and start watching for changes. The watcher restarts the process
+	// when the ConfigMap changes so the operator's own serving endpoint (port 8443) can
+	// pick up the updated TLS settings on the next startup. Agent deployments already
+	// re-read the ConfigMap during reconcile via populateTLSConfig.
+	currentTLSConfig, err := tlslib.StartTLSConfigMapWatcher(ctx, kubeClient, helpers.GetOperatorNamespace(),
+		func() {
+			logger.Info("TLS ConfigMap changed, restarting", "component", "klusterlet operator")
+			os.Exit(0)
+		},
+	)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return err
+	}
+	logger.Info("TLS configuration loaded",
+		"minVersion", tlslib.VersionToString(currentTLSConfig.MinVersion),
+		"cipherSuites", tlslib.CipherSuitesToString(currentTLSConfig.CipherSuites))
 
 	klusterletController := klusterletcontroller.NewKlusterletController(
 		kubeClient,

--- a/test/integration/operator/klusterlet_test.go
+++ b/test/integration/operator/klusterlet_test.go
@@ -611,18 +611,23 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 				if err != nil {
 					return false
 				}
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
-				// klusterlet has no condition, replica is 0
-				gomega.Expect(actual.Status.Replicas).Should(gomega.Equal(int32(0)))
+				if len(actual.Spec.Template.Spec.Containers) != 1 {
+					return false
+				}
+				// No running pods in the integration env; Status.Replicas stays 0.
+				if actual.Status.Replicas != 0 {
+					return false
+				}
 
-				// Print actual args for debugging
+				// Work agent args include --status-sync-interval=60s only when Replica==1.
+				// Replica is forced to 0 until HubConnectionDegraded is set, so retry until
+				// the condition exists and the deployment is re-rendered with 8 args.
 				actualArgs := actual.Spec.Template.Spec.Containers[0].Args
 				if len(actualArgs) != 8 {
 					fmt.Fprintf(ginkgo.GinkgoWriter, "should get 8 args, actual got %v\n", actualArgs)
+					return false
 				}
-
-				gomega.Expect(len(actualArgs)).Should(gomega.Equal(8))
-				return actual.Spec.Template.Spec.Containers[0].Args[2] != "--spoke-cluster-name=cluster2"
+				return actualArgs[2] == "--spoke-cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 
 			gomega.Eventually(func() bool {
@@ -630,8 +635,12 @@ var _ = ginkgo.Describe("Klusterlet", func() {
 				if err != nil {
 					return false
 				}
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers)).Should(gomega.Equal(1))
-				gomega.Expect(len(actual.Spec.Template.Spec.Containers[0].Args)).Should(gomega.Equal(7))
+				if len(actual.Spec.Template.Spec.Containers) != 1 {
+					return false
+				}
+				if len(actual.Spec.Template.Spec.Containers[0].Args) != 7 {
+					return false
+				}
 				return actual.Spec.Template.Spec.Containers[0].Args[2] == "--spoke-cluster-name=cluster2"
 			}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
 


### PR DESCRIPTION
## Summary

- Add `StartTLSConfigMapWatcher` to `RunKlusterletOperator`, matching the cluster-manager operator pattern.
- When `ocm-tls-profile` changes, the process exits with `os.Exit(0)` so Kubernetes restarts the pod and the operator can re-apply TLS settings for its own serving endpoint (port 8443).
- Leaves `AddonTLSConfigController` unchanged (it still copies the ConfigMap into addon namespaces).

This complements #1639, which wires TLS into the serving endpoint at startup via ConfigMap/flags. Without a watcher on the klusterlet operator, a ConfigMap update (or a race where the sidecar creates the ConfigMap after process start) would leave the operator's `:8443` endpoint on stale TLS settings.

Related: #1638, #1639

## Test plan

- [x] `go test ./pkg/operator/operators/klusterlet/...`
- [ ] Confirm CI unit/integration/e2e pass
- [ ] On an OpenShift spoke: change `APIServer` TLS profile, verify `ocm-tls-profile` updates and the klusterlet operator pod restarts
- [ ] After restart (and with #1639 applied), verify `:8443` enforces the new min TLS version


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The operator now detects serving TLS configuration changes and restarts automatically so updated security settings take effect.
  * TLS settings, including supported versions and cipher suites, are recorded during startup.

* **Bug Fixes**
  * Improved handling when TLS monitoring is canceled or unavailable during startup.
  * Deployment reconciliation now waits reliably for expected containers, replicas, and startup arguments before completing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->