### PR TITLE
:seedling: Improve diagnostic message when hosted addon lease is not found

### DIFF
--- a/pkg/registration/spoke/addon/lease_controller.go
+++ b/pkg/registration/spoke/addon/lease_controller.go
@@ -125,11 +125,18 @@ func (c *managedClusterAddOnLeaseController) syncSingle(ctx context.Context,
 	var condition metav1.Condition
 	switch {
 	case errors.IsNotFound(err):
+		message := fmt.Sprintf("The status of %s add-on is unknown.", addOn.Name)
+		if isAddonRunningOutsideManagedCluster(addOn) {
+			// No lease on the declared hosting cluster usually means it doesn't match the klusterlet's actual hosting cluster.
+			hostingCluster := addOn.Annotations[addonv1beta1.HostingClusterNameAnnotationKey]
+			message = fmt.Sprintf("%s No lease found on hosting cluster %q; verify it matches the cluster "+
+				"where this managed cluster's klusterlet actually runs.", message, hostingCluster)
+		}
 		condition = metav1.Condition{
 			Type:    addonv1beta1.ManagedClusterAddOnConditionAvailable,
 			Status:  metav1.ConditionUnknown,
 			Reason:  "ManagedClusterAddOnLeaseNotFound",
-			Message: fmt.Sprintf("The status of %s add-on is unknown.", addOn.Name),
+			Message: message,
 		}
 	case err != nil:
 		return err

--- a/pkg/registration/spoke/addon/lease_controller_test.go
+++ b/pkg/registration/spoke/addon/lease_controller_test.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -329,6 +330,45 @@ func TestSync(t *testing.T) {
 				}
 				if addOnCond.Status != metav1.ConditionTrue {
 					t.Errorf("expected addon available condition is available, but failed")
+				}
+			},
+		},
+		{
+			name:     "no addon lease on management cluster names the hosting cluster in the message",
+			queueKey: "test/test",
+			addOns: []runtime.Object{&addonv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testinghelpers.TestManagedClusterName,
+					Name:      "test",
+					Annotations: map[string]string{
+						addonv1beta1.HostingClusterNameAnnotationKey: "cluster1",
+					},
+				},
+				Spec: addonv1beta1.ManagedClusterAddOnSpec{},
+				Status: addonv1beta1.ManagedClusterAddOnStatus{
+					Namespace: "test",
+				},
+			}},
+			hubLeases:        []runtime.Object{},
+			managementLeases: []runtime.Object{},
+			validateActions: func(t *testing.T, ctx *testingcommon.FakeSyncContext, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "patch")
+				patch := actions[0].(clienttesting.PatchAction).GetPatch()
+				addOn := &addonv1beta1.ManagedClusterAddOn{}
+				err := json.Unmarshal(patch, addOn)
+				if err != nil {
+					t.Fatal(err)
+				}
+				addOnCond := meta.FindStatusCondition(addOn.Status.Conditions, "Available")
+				if addOnCond == nil {
+					t.Errorf("expected addon available condition, but failed")
+					return
+				}
+				if addOnCond.Status != metav1.ConditionUnknown {
+					t.Errorf("expected addon available condition is unknown, but failed")
+				}
+				if !strings.Contains(addOnCond.Message, "cluster1") {
+					t.Errorf("expected message to name the declared hosting cluster, got: %s", addOnCond.Message)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
Name the declared hosting-cluster-name in the Available=Unknown message when a hosted add-on's Lease isn't found, so a mismatch with the target's actual klusterlet location is diagnosable instead of silent.

## Related issue(s)

This PR is related to https://github.com/open-cluster-management-io/enhancements/issues/188

It doesn't fix the core issue but a slight improvement for now. 
The https://github.com/open-cluster-management-io/enhancements/issues/188 enhancement issue is still valid and the enhancement proposal is still being worked on.

CC @qiujian16 @kahirokunn 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved add-on status messages when a lease is missing.
  * For add-ons hosted outside the managed cluster, the message now identifies the configured hosting cluster and advises verifying the klusterlet’s cluster association.
  * Existing generic messaging remains unchanged for other missing-lease scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->