### PR TITLE
:book: docs: fix typo serivce -> service

### DIFF
--- a/solutions/run-multicluster-servicemesh/README.md
+++ b/solutions/run-multicluster-servicemesh/README.md
@@ -59,7 +59,7 @@ istiod-1-16-7-67b8bf75f8-qk4rd           1/1     Running   0          32s
 
 ## Federate Service Meshes from Hub
 
-From the hub cluster, federate the serivce meshes created in last step by creating meshfederation resource:
+From the hub cluster, federate the service meshes created in last step by creating meshfederation resource:
 
 ```bash
 kubectl config use-context kind-hub


### PR DESCRIPTION
One-word typo fix in `solutions/run-multicluster-servicemesh/README.md:62`: "federate the serivce" → "service".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the service mesh federation instructions.
  * No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->