### PR TITLE
:seedling: chore: dynamically fetch Go version in workflows

### DIFF
--- a/.github/workflows/cloudevents-integration.yml
+++ b/.github/workflows/cloudevents-integration.yml
@@ -13,10 +13,6 @@ on:
       - main
       - release-*
 
-env:
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
-
 permissions:
   contents: read
 
@@ -30,6 +26,6 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: integration
         run: make test-cloudevents-work-grpc-integration

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,10 +15,7 @@ on:
       - release-*
 
 env:
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
   USE_EXISTING_CLUSTER: false # set to true to use an existing kind cluster for debugging with act
-  KUBERNETES_VERSION: 'v1.29.2'
 
 permissions:
   contents: read
@@ -37,10 +34,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup kind
         if: ${{ env.USE_EXISTING_CLUSTER != 'true' }}
-        run: kind create cluster --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
+        run: kind create cluster --wait 300s
       - name: Set KUBECONFIG
         run: |
           mkdir -p /home/runner/.kube
@@ -64,10 +61,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup kind
         if: ${{ env.USE_EXISTING_CLUSTER != 'true' }}
-        run: kind create cluster --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
+        run: kind create cluster --wait 300s
       - name: Set KUBECONFIG
         run: |
           mkdir -p /home/runner/.kube
@@ -91,10 +88,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup kind
         if: ${{ env.USE_EXISTING_CLUSTER != 'true' }}
-        run: kind create cluster --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
+        run: kind create cluster --wait 300s
       - name: Set KUBECONFIG
         run: |
           mkdir -p /home/runner/.kube
@@ -118,10 +115,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Setup kind
         if: ${{ env.USE_EXISTING_CLUSTER != 'true' }}
-        run: kind create cluster --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
+        run: kind create cluster --wait 300s
       - name: Set KUBECONFIG
         run: |
           mkdir -p /home/runner/.kube

--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -11,11 +11,6 @@ on:
       - main
   workflow_dispatch: {}
 
-env:
-  # Common versions
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
-
 permissions:
   contents: read
   id-token: write
@@ -31,7 +26,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: unit
         run: make test
@@ -57,7 +52,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -12,10 +12,6 @@ on:
       - main
       - release-*
 
-env:
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
-
 permissions:
   contents: read
 
@@ -29,7 +25,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: verify
         run: make verify
       - name: verify-deps
@@ -48,7 +44,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: build
         run: make build
 
@@ -61,7 +57,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: unit
         run: make test
       - name: report coverage
@@ -83,6 +79,6 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: integration
         run: make test-integration

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*.*.*'
 env:
-  # Common versions
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/ocm/ocm/go'
   GITHUB_REF: ${{ github.ref }}
 
@@ -57,7 +54,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go/src/open-cluster-management.io/ocm/go.mod
           cache: false
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3


### PR DESCRIPTION
Currently the GitHub workflows rely on a static value for the Go version. It's more maintainable to specify that Go be fetched from the `go.mod` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated workflows now use the Go version declared in the project configuration for consistent builds and checks.
  * End-to-end test environments now rely on Kind’s default Kubernetes node image.
  * Removed redundant Go and Kubernetes version settings from workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->