### PR TITLE
:seedling: fix: remove invalid cooldown for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,8 +35,6 @@ updates:
       prefix: ":seedling:"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 14
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Followup to:
- #1666

ref:
- https://github.com/open-cluster-management-io/ocm/runs/98244789496
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-of-cooldown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated GitHub Actions dependency update scheduling to use the standard seven-day cooldown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->