### PR TITLE
:book: docs: remove historical arm64 workaround notes

### DIFF
--- a/solutions/argocd-agent/README.md
+++ b/solutions/argocd-agent/README.md
@@ -114,14 +114,9 @@ secrets you may still need — not just the conflicting Argo CD install. Only do
 
 > **PKI is fully automatic — no `argocd-agentctl` needed.** The `argocd-agent` principal component requires
 > four secrets to start (a CA certificate, its own gRPC TLS certificate, a resource-proxy TLS certificate, and a
-> JWT signing key). As of the addon version installed by `clusteradm install hub-addon --names argocd-agent`
-> today (`argocd-pull-integration` v0.28.1 and later), the `GitOpsCluster` controller generates and manages all
-> four of these itself — you do **not** need to install the `argocd-agentctl` CLI or run any manual PKI commands.
-> Confirmed by re-testing end-to-end on a clean cluster with zero `argocd-agentctl` commands: the controller's
-> logs show `Successfully ensured ArgoCD agent CA certificate` / `... principal TLS certificate` / `... resource
-> proxy TLS certificate`, and `kubectl -n argocd get gitopscluster gitops-cluster -o yaml` reports
-> `CACertificateReady`, `PrincipalCertificateReady`, `ResourceProxyCertificateReady`, and `JWTSecretReady` all
-> `True`. If you see the principal crash-loop with a "secret not found" error anyway, that almost always means
+> JWT signing key). The `GitOpsCluster` controller (`argocd-pull-integration-controller`) generates and manages
+> all four of these itself — you do **not** need to install the `argocd-agentctl` CLI or run any manual PKI
+> commands. If you see the principal crash-loop with a "secret not found" error anyway, that almost always means
 > the controller responsible for creating these secrets isn't running yet — see
 > [Troubleshooting](#principal-pod-crash-loops-with-a-missing-tlsjwt-secret) below, not a missing manual step.
 

--- a/solutions/argocd-agent/README.md
+++ b/solutions/argocd-agent/README.md
@@ -280,16 +280,6 @@ guestbook   Synced        Healthy
 
 ## Troubleshooting
 
-> **Note on Apple Silicon / arm64:** earlier versions of the `argocd-pull-integration` image (which backs
-> `argocd-pull-integration-controller` below) were only published for `linux/amd64`, causing `ImagePullBackOff`
-> on arm64 hosts. This was fixed upstream in
-> [argocd-pull-integration#179](https://github.com/open-cluster-management-io/argocd-pull-integration/issues/179):
-> as of v0.29.0 (released 2026-08-31) the image is published for `linux/arm64` too, and the addon chart that
-> `clusteradm install hub-addon --names argocd-agent` installs by default already pins that tag. Confirmed on a
-> clean arm64 host — no manual image build needed. If you still hit `ImagePullBackOff` on this deployment,
-> check the tag it actually pulled (`kubectl get deployment argocd-pull-integration-controller -n argocd -o
-> jsonpath='{.spec.template.spec.containers[0].image}'`) and upgrade the addon if it's older than v0.29.0.
-
 ### Principal pod crash-loops with a missing TLS/JWT secret
 
 **Symptom:** `argocd-agent-principal` is stuck in `Error`/`CrashLoopBackOff`, with logs like

--- a/solutions/deploy-argocd-apps-pull/troubleshooting.md
+++ b/solutions/deploy-argocd-apps-pull/troubleshooting.md
@@ -17,31 +17,6 @@ status:
 ```
 Despite the type `ErrorOccurred`, the status is `"False"`, which means the ApplicationSet has been reconciled successfully. If the status is `"True"`, check the error message. If needed, check the `argocd-applicationset-controller` pod logs in the `argocd` namespace.
 
-#### `ImagePullBackOff` on `argocd-pull-integration` (Apple Silicon / arm64)
-
-**Historical issue, fixed upstream — no workaround needed on current versions.** Earlier releases of the
-`argocd-pull-integration` image were only published for `linux/amd64`, which caused `ImagePullBackOff` on
-Apple Silicon / arm64 hosts. This was fixed in
-[argocd-pull-integration#179](https://github.com/open-cluster-management-io/argocd-pull-integration/issues/179):
-as of `argocd-pull-integration` v0.29.0 (released 2026-08-31), the image is published for both `linux/amd64`
-and `linux/arm64`, and the `ocm/argocd-pull-integration` chart that `clusteradm install hub-addon --names argocd`
-installs by default already pins that tag. Confirmed on a clean arm64 (Apple Silicon) host: the
-`argocd-pull-integration` deployment pulls and runs successfully with no manual image build required.
-
-If you still see `ImagePullBackOff` on `argocd-pull-integration` on an arm64 host, check which tag your
-install actually pulled and whether that specific tag has a `linux/arm64` manifest published:
-```shell
-# find the tag your install actually pulled
-kubectl get deployment argocd-pull-integration -n argocd -o jsonpath='{.spec.template.spec.containers[0].image}'
-
-# check whether THAT tag has a linux/arm64 variant published
-docker manifest inspect quay.io/open-cluster-management/argocd-pull-integration:<the-tag-from-above> | \
-  jq -e '.manifests[]? | select(.platform.os=="linux" and .platform.architecture=="arm64")'
-```
-If it's older than v0.29.0, upgrade the addon (`helm upgrade` the `ocm/argocd-pull-integration` chart, or
-reinstall via `clusteradm install hub-addon --names argocd` to pick up the current chart default) rather than
-building a local workaround image.
-
 #### `clusteradm install hub-addon --names argocd` fails with a `ClusterRoleBinding` ownership conflict
 
 If the `argocd-agent` hub-addon was ever installed on this hub before (even if later


### PR DESCRIPTION
## Summary
- Follow-up to #1665 per [@mikeshng's review comment](https://github.com/open-cluster-management-io/ocm/pull/1665#discussion_r3897446384): removes the "historical issue, fixed upstream" arm64 notes from `solutions/argocd-agent/README.md` and `solutions/deploy-argocd-apps-pull/troubleshooting.md`.
- These notes documented a now-fixed upstream bug ([argocd-pull-integration#179](https://github.com/open-cluster-management-io/argocd-pull-integration/issues/179), fixed in v0.29.0) rather than an active troubleshooting step, so they're dropped entirely instead of accumulating a changelog of past issues in the solution docs.

## Test plan
- [x] Confirmed no remaining references to the removed arm64/historical notes in either file.
- [x] Docs-only change, no functional/behavioral impact on the solutions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Argo CD Agent prerequisites to clarify that the GitOpsCluster controller generates and manages all required secrets without manual intervention.
  * Removed outdated troubleshooting guidance for `ImagePullBackOff` errors on Apple Silicon and arm64 hosts.
  * Removed historical version references, manifest verification steps, upgrade instructions, and supporting diagnostic details.
  * No functional behavior or application code was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->