### PR TITLE
:bug: fix(registration): infer hosted addon mode from install namespace

### DIFF
--- a/pkg/registration/spoke/addon/configuration.go
+++ b/pkg/registration/spoke/addon/configuration.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/klog/v2"
 
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	clusterv1listers "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	addonwebhook "open-cluster-management.io/ocm/pkg/addon/webhook/v1beta1"
 	"open-cluster-management.io/ocm/pkg/registration/register/csr"
@@ -18,6 +20,13 @@ import (
 
 const (
 	defaultAddOnInstallationNamespace = "open-cluster-management-agent-addon"
+
+	// ManagedCluster annotations that gate hosted-mode addon deployment (aligned with
+	// multicloud-operators-foundation HostedClusterInfo and klusterlet-addon-controller).
+	annotationEnableHostedModeAddons       = "addon.open-cluster-management.io/enable-hosted-mode-addons"
+	annotationKlusterletDeployMode         = "import.open-cluster-management.io/klusterlet-deploy-mode"
+	annotationKlusterletHostingClusterName = "import.open-cluster-management.io/hosting-cluster-name"
+	klusterletDeployModeHosted             = "Hosted"
 )
 
 // registrationConfig contains necessary information for addon registration
@@ -57,13 +66,127 @@ func getAddOnInstallationNamespace(addOn *addonv1beta1.ManagedClusterAddOn) stri
 	return installationNamespace
 }
 
-// isAddonRunningOutsideManagedCluster returns whether the addon agent is running on the managed cluster
-func isAddonRunningOutsideManagedCluster(addOn *addonv1beta1.ManagedClusterAddOn) bool {
-	hostingCluster, ok := addOn.Annotations[addonv1beta1.HostingClusterNameAnnotationKey]
-	if ok && len(hostingCluster) != 0 {
+// isAddonRunningOutsideManagedCluster returns whether the addon agent is running outside the managed cluster
+// (hosted mode). Signals are evaluated in order:
+//  1. ManagedClusterAddOn addon.open-cluster-management.io/hosting-cluster-name annotation
+//  2. Install namespace klusterlet-{managed cluster name} (observed per-addon deployment location)
+func isAddonRunningOutsideManagedCluster(
+	addOn *addonv1beta1.ManagedClusterAddOn,
+	managedCluster *clusterv1.ManagedCluster,
+	logger klog.Logger,
+) bool {
+	addonName, clusterName := addonNamespacedName(addOn)
+	installNamespace := getAddOnInstallationNamespace(addOn)
+
+	if hasAddonHostingClusterNameAnnotation(addOn.GetAnnotations()) {
+		logHostedModeDecision(logger, addonName, clusterName, true,
+			"managedClusterAddOn hosting-cluster-name annotation",
+			"hostingCluster", addOn.Annotations[addonv1beta1.HostingClusterNameAnnotationKey],
+			"installNamespace", installNamespace)
 		return true
 	}
+	if isAddonInstalledInKlusterletNamespace(addOn) {
+		logHostedModeDecision(logger, addonName, clusterName, true,
+			"klusterlet install namespace fallback",
+			"installNamespace", installNamespace,
+			"expectedNamespace", fmt.Sprintf("klusterlet-%s", addOn.Namespace))
+		return true
+	}
+	logHostedModeDecision(logger, addonName, clusterName, false,
+		"addon runs on managed cluster",
+		"installNamespace", installNamespace)
 	return false
+}
+
+// isAddonInstalledInKlusterletNamespace reports whether this addon is deployed into the hosted-mode
+// namespace on the management cluster (klusterlet-{managed cluster name}).
+func isAddonInstalledInKlusterletNamespace(addOn *addonv1beta1.ManagedClusterAddOn) bool {
+	if addOn == nil {
+		return false
+	}
+	installNamespace := getAddOnInstallationNamespace(addOn)
+	return installNamespace == fmt.Sprintf("klusterlet-%s", addOn.Namespace)
+}
+
+func hasAddonHostingClusterNameAnnotation(annotations map[string]string) bool {
+	if len(annotations) == 0 {
+		return false
+	}
+	hostingCluster, ok := annotations[addonv1beta1.HostingClusterNameAnnotationKey]
+	return ok && len(hostingCluster) != 0
+}
+
+func managedClusterEnablesHostedAddons(cluster *clusterv1.ManagedCluster) bool {
+	if cluster == nil || len(cluster.Annotations) == 0 {
+		return false
+	}
+	annotations := cluster.Annotations
+	if !strings.EqualFold(annotations[annotationEnableHostedModeAddons], "true") {
+		return false
+	}
+	if annotations[annotationKlusterletDeployMode] != klusterletDeployModeHosted {
+		return false
+	}
+	return len(annotations[annotationKlusterletHostingClusterName]) > 0
+}
+
+// hostingClusterNameForAddon returns the hosting cluster name from the addon annotation, or from the
+// ManagedCluster import hosting-cluster-name annotation when the addon runs in hosted mode via fallback.
+func hostingClusterNameForAddon(
+	addOn *addonv1beta1.ManagedClusterAddOn,
+	managedCluster *clusterv1.ManagedCluster,
+	logger klog.Logger,
+) string {
+	addonName, clusterName := addonNamespacedName(addOn)
+
+	if hasAddonHostingClusterNameAnnotation(addOn.GetAnnotations()) {
+		return addOn.Annotations[addonv1beta1.HostingClusterNameAnnotationKey]
+	}
+	if isAddonInstalledInKlusterletNamespace(addOn) && managedClusterEnablesHostedAddons(managedCluster) {
+		hostingCluster := managedCluster.Annotations[annotationKlusterletHostingClusterName]
+		logHostedModeDecision(logger, addonName, clusterName, true,
+			"managedCluster import hosting-cluster-name fallback",
+			"hostingCluster", hostingCluster,
+			"installNamespace", getAddOnInstallationNamespace(addOn))
+		return hostingCluster
+	}
+	return ""
+}
+
+func addonNamespacedName(addOn *addonv1beta1.ManagedClusterAddOn) (name, namespace string) {
+	if addOn == nil {
+		return "", ""
+	}
+	return addOn.Name, addOn.Namespace
+}
+
+func logHostedModeDecision(logger klog.Logger, addonName, clusterName string, outsideManagedCluster bool, reason string, keysAndValues ...interface{}) {
+	if !logger.Enabled() {
+		return
+	}
+	args := []interface{}{
+		"addon", addonName,
+		"cluster", clusterName,
+		"outsideManagedCluster", outsideManagedCluster,
+		"reason", reason,
+	}
+	args = append(args, keysAndValues...)
+	if outsideManagedCluster {
+		logger.Info("determined addon hosted mode", args...)
+		return
+	}
+	logger.V(4).Info("determined addon hosted mode", args...)
+}
+
+func getManagedClusterFromLister(lister clusterv1listers.ManagedClusterLister, clusterName string) *clusterv1.ManagedCluster {
+	if lister == nil {
+		return nil
+	}
+	cluster, err := lister.Get(clusterName)
+	if err != nil {
+		return nil
+	}
+	return cluster
 }
 
 // getRegistrationConfigs reads registrations and returns a map of registrationConfig whose

--- a/pkg/registration/spoke/addon/configuration_test.go
+++ b/pkg/registration/spoke/addon/configuration_test.go
@@ -1,7 +1,10 @@
 package addon
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/go-logr/logr"
 
 	certificates "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	testinghelpers "open-cluster-management.io/ocm/pkg/registration/helpers/testing"
 	"open-cluster-management.io/ocm/pkg/registration/register/csr"
@@ -288,7 +292,7 @@ func TestGetRegistrationConfigs(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			installOption := addonInstallOption{
-				AgentRunningOutsideManagedCluster: isAddonRunningOutsideManagedCluster(c.addon),
+				AgentRunningOutsideManagedCluster: isAddonRunningOutsideManagedCluster(c.addon, nil, logr.Discard()),
 				InstallationNamespace:             getAddOnInstallationNamespace(c.addon),
 			}
 			logger := klog.NewKlogr()
@@ -305,6 +309,120 @@ func TestGetRegistrationConfigs(t *testing.T) {
 				if _, ok := configs[config.hash]; !ok {
 					t.Errorf("unexpected registrationConfig: %v, got %v", dump.Pretty(configs), dump.Pretty(c.configs))
 				}
+			}
+		})
+	}
+}
+
+func TestIsAddonRunningOutsideManagedCluster(t *testing.T) {
+	hostedAddon := &addonv1beta1.ManagedClusterAddOn{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "work-manager",
+			Namespace: testinghelpers.TestManagedClusterName,
+		},
+	}
+	hostedCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testinghelpers.TestManagedClusterName,
+			Annotations: map[string]string{
+				annotationEnableHostedModeAddons:       "true",
+				annotationKlusterletDeployMode:         klusterletDeployModeHosted,
+				annotationKlusterletHostingClusterName: "local-cluster",
+			},
+		},
+	}
+
+	cases := []struct {
+		name           string
+		addon          *addonv1beta1.ManagedClusterAddOn
+		managedCluster *clusterv1.ManagedCluster
+		want           bool
+	}{
+		{
+			name:           "no hosting annotations",
+			addon:          hostedAddon,
+			managedCluster: &clusterv1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: testinghelpers.TestManagedClusterName}},
+			want:           false,
+		},
+		{
+			name: "addon hosting annotation",
+			addon: &addonv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "work-manager",
+					Namespace: testinghelpers.TestManagedClusterName,
+					Annotations: map[string]string{
+						addonv1beta1.HostingClusterNameAnnotationKey: "local-cluster",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "klusterlet install namespace fallback",
+			addon: &addonv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "work-manager",
+					Namespace: testinghelpers.TestManagedClusterName,
+				},
+				Status: addonv1beta1.ManagedClusterAddOnStatus{
+					Namespace: fmt.Sprintf("klusterlet-%s", testinghelpers.TestManagedClusterName),
+				},
+			},
+			want: true,
+		},
+		{
+			name:           "managed cluster hosted gate alone is insufficient without klusterlet install namespace",
+			addon:          hostedAddon,
+			managedCluster: hostedCluster,
+			want:           false,
+		},
+		{
+			name: "spoke addon on hosted cluster is not outside managed cluster",
+			addon: &addonv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-proxy",
+					Namespace: testinghelpers.TestManagedClusterName,
+				},
+				Status: addonv1beta1.ManagedClusterAddOnStatus{
+					Namespace: defaultAddOnInstallationNamespace,
+				},
+			},
+			managedCluster: hostedCluster,
+			want:           false,
+		},
+		{
+			name:  "addon hosting cluster name on managed cluster alone is insufficient",
+			addon: hostedAddon,
+			managedCluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testinghelpers.TestManagedClusterName,
+					Annotations: map[string]string{
+						addonv1beta1.HostingClusterNameAnnotationKey: "local-cluster",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:  "import hosting cluster name without hosted addon gate is insufficient",
+			addon: hostedAddon,
+			managedCluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testinghelpers.TestManagedClusterName,
+					Annotations: map[string]string{
+						annotationKlusterletHostingClusterName: "local-cluster",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isAddonRunningOutsideManagedCluster(c.addon, c.managedCluster, logr.Discard())
+			if got != c.want {
+				t.Errorf("expected %v, got %v", c.want, got)
 			}
 		})
 	}

--- a/pkg/registration/spoke/addon/lease_controller.go
+++ b/pkg/registration/spoke/addon/lease_controller.go
@@ -12,12 +12,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	coordv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
 	addoninformerv1beta1 "open-cluster-management.io/api/client/addon/informers/externalversions/addon/v1beta1"
 	addonlisterv1beta1 "open-cluster-management.io/api/client/addon/listers/addon/v1beta1"
+	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions/cluster/v1"
+	clusterv1listers "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
 	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
 	"open-cluster-management.io/sdk-go/pkg/patcher"
 )
@@ -36,6 +39,7 @@ type managedClusterAddOnLeaseController struct {
 	patcher     patcher.Patcher[
 		*addonv1beta1.ManagedClusterAddOn, addonv1beta1.ManagedClusterAddOnSpec, addonv1beta1.ManagedClusterAddOnStatus]
 	addOnLister           addonlisterv1beta1.ManagedClusterAddOnLister
+	hubClusterLister      clusterv1listers.ManagedClusterLister
 	managementLeaseClient coordv1client.CoordinationV1Interface
 	spokeLeaseClient      coordv1client.CoordinationV1Interface
 }
@@ -44,6 +48,7 @@ type managedClusterAddOnLeaseController struct {
 func NewManagedClusterAddOnLeaseController(clusterName string,
 	addOnClient addonclient.Interface,
 	addOnInformer addoninformerv1beta1.ManagedClusterAddOnInformer,
+	hubClusterInformer clusterv1informers.ManagedClusterInformer,
 	managementLeaseClient coordv1client.CoordinationV1Interface,
 	spokeLeaseClient coordv1client.CoordinationV1Interface,
 	resyncInterval time.Duration) factory.Controller {
@@ -54,6 +59,7 @@ func NewManagedClusterAddOnLeaseController(clusterName string,
 			*addonv1beta1.ManagedClusterAddOn, addonv1beta1.ManagedClusterAddOnSpec, addonv1beta1.ManagedClusterAddOnStatus](
 			addOnClient.AddonV1beta1().ManagedClusterAddOns(clusterName)),
 		addOnLister:           addOnInformer.Lister(),
+		hubClusterLister:      hubClusterInformer.Lister(),
 		managementLeaseClient: managementLeaseClient,
 		spokeLeaseClient:      spokeLeaseClient,
 	}
@@ -109,13 +115,17 @@ func (c *managedClusterAddOnLeaseController) syncSingle(ctx context.Context,
 	syncCtx factory.SyncContext,
 	leaseNamespace string,
 	addOn *addonv1beta1.ManagedClusterAddOn) error {
+	logger := klog.FromContext(ctx).WithValues("addOnName", addOn.Name)
 	now := c.clock.Now()
 	gracePeriod := time.Duration(leaseDurationTimes*AddOnLeaseControllerLeaseDurationSeconds) * time.Second
+
+	managedCluster := getManagedClusterFromLister(c.hubClusterLister, c.clusterName)
+	outsideManagedCluster := isAddonRunningOutsideManagedCluster(addOn, managedCluster, logger)
 
 	// if the add-on agent is running on the managed cluster, try to fetch the add-on lease on the managed cluster,
 	// otherwise (running outside of the managed cluster), fetch the add-on lease on the management cluster instead.
 	leaseClient := c.spokeLeaseClient
-	if isAddonRunningOutsideManagedCluster(addOn) {
+	if outsideManagedCluster {
 		leaseClient = c.managementLeaseClient
 	}
 
@@ -126,9 +136,9 @@ func (c *managedClusterAddOnLeaseController) syncSingle(ctx context.Context,
 	switch {
 	case errors.IsNotFound(err):
 		message := fmt.Sprintf("The status of %s add-on is unknown.", addOn.Name)
-		if isAddonRunningOutsideManagedCluster(addOn) {
+		if outsideManagedCluster {
 			// No lease on the declared hosting cluster usually means it doesn't match the klusterlet's actual hosting cluster.
-			hostingCluster := addOn.Annotations[addonv1beta1.HostingClusterNameAnnotationKey]
+			hostingCluster := hostingClusterNameForAddon(addOn, managedCluster, logger)
 			message = fmt.Sprintf("%s No lease found on hosting cluster %q; verify it matches the cluster "+
 				"where this managed cluster's klusterlet actually runs.", message, hostingCluster)
 		}

--- a/pkg/registration/spoke/addon/lease_controller_test.go
+++ b/pkg/registration/spoke/addon/lease_controller_test.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,9 @@ import (
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	addonfake "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
+	clusterfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
+	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
 	"open-cluster-management.io/sdk-go/pkg/patcher"
 
@@ -107,6 +111,7 @@ func TestSync(t *testing.T) {
 		name             string
 		queueKey         string
 		addOns           []runtime.Object
+		clusters         []runtime.Object
 		hubLeases        []runtime.Object
 		managementLeases []runtime.Object
 		spokeLeases      []runtime.Object
@@ -392,6 +397,56 @@ func TestSync(t *testing.T) {
 				testingcommon.AssertNoActions(t, actions)
 			},
 		},
+		{
+			name:     "hosted mode from klusterlet install namespace when addon annotation missing",
+			queueKey: fmt.Sprintf("klusterlet-%s/work-manager", testinghelpers.TestManagedClusterName),
+			addOns: []runtime.Object{&addonv1beta1.ManagedClusterAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testinghelpers.TestManagedClusterName,
+					Name:      "work-manager",
+				},
+				Spec: addonv1beta1.ManagedClusterAddOnSpec{},
+				Status: addonv1beta1.ManagedClusterAddOnStatus{
+					Namespace: fmt.Sprintf("klusterlet-%s", testinghelpers.TestManagedClusterName),
+				},
+			}},
+			clusters: []runtime.Object{&clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testinghelpers.TestManagedClusterName,
+					Annotations: map[string]string{
+						annotationEnableHostedModeAddons:       "true",
+						annotationKlusterletDeployMode:         klusterletDeployModeHosted,
+						annotationKlusterletHostingClusterName: "local-cluster",
+					},
+				},
+			}},
+			hubLeases: []runtime.Object{},
+			managementLeases: []runtime.Object{
+				testinghelpers.NewAddOnLease(
+					fmt.Sprintf("klusterlet-%s", testinghelpers.TestManagedClusterName),
+					"work-manager",
+					now,
+				),
+			},
+			spokeLeases: []runtime.Object{},
+			validateActions: func(t *testing.T, ctx *testingcommon.FakeSyncContext, actions []clienttesting.Action) {
+				testingcommon.AssertActions(t, actions, "patch")
+				patch := actions[0].(clienttesting.PatchAction).GetPatch()
+				addOn := &addonv1beta1.ManagedClusterAddOn{}
+				err := json.Unmarshal(patch, addOn)
+				if err != nil {
+					t.Fatal(err)
+				}
+				addOnCond := meta.FindStatusCondition(addOn.Status.Conditions, "Available")
+				if addOnCond == nil {
+					t.Errorf("expected addon available condition, but failed")
+					return
+				}
+				if addOnCond.Status != metav1.ConditionTrue {
+					t.Errorf("expected addon available condition is true, got %s", addOnCond.Status)
+				}
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -408,6 +463,15 @@ func TestSync(t *testing.T) {
 			managementLeaseClient := kubefake.NewClientset(c.managementLeases...)
 			spokeLeaseClient := kubefake.NewClientset(c.spokeLeases...)
 
+			clusterClient := clusterfake.NewSimpleClientset(c.clusters...)
+			clusterInformerFactory := clusterinformers.NewSharedInformerFactory(clusterClient, time.Minute*10)
+			clusterStore := clusterInformerFactory.Cluster().V1().ManagedClusters().Informer().GetStore()
+			for _, cluster := range c.clusters {
+				if err := clusterStore.Add(cluster); err != nil {
+					t.Fatal(err)
+				}
+			}
+
 			ctrl := &managedClusterAddOnLeaseController{
 				clusterName: testinghelpers.TestManagedClusterName,
 				clock:       clocktesting.NewFakeClock(time.Now()),
@@ -415,6 +479,7 @@ func TestSync(t *testing.T) {
 					*addonv1beta1.ManagedClusterAddOn, addonv1beta1.ManagedClusterAddOnSpec, addonv1beta1.ManagedClusterAddOnStatus](
 					addOnClient.AddonV1beta1().ManagedClusterAddOns(testinghelpers.TestManagedClusterName)),
 				addOnLister:           addOnInformerFactory.Addon().V1beta1().ManagedClusterAddOns().Lister(),
+				hubClusterLister:      clusterInformerFactory.Cluster().V1().ManagedClusters().Lister(),
 				managementLeaseClient: managementLeaseClient.CoordinationV1(),
 				spokeLeaseClient:      spokeLeaseClient.CoordinationV1(),
 			}

--- a/pkg/registration/spoke/addon/registration_controller.go
+++ b/pkg/registration/spoke/addon/registration_controller.go
@@ -17,6 +17,8 @@ import (
 	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
 	addoninformerv1beta1 "open-cluster-management.io/api/client/addon/informers/externalversions/addon/v1beta1"
 	addonlisterv1beta1 "open-cluster-management.io/api/client/addon/listers/addon/v1beta1"
+	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions/cluster/v1"
+	clusterv1listers "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
 	"open-cluster-management.io/sdk-go/pkg/basecontroller/factory"
 	"open-cluster-management.io/sdk-go/pkg/patcher"
 
@@ -35,6 +37,7 @@ type addOnRegistrationController struct {
 	managementKubeClient kubernetes.Interface // in-cluster local management kubeClient
 	spokeKubeClient      kubernetes.Interface
 	hubAddOnLister       addonlisterv1beta1.ManagedClusterAddOnLister
+	hubClusterLister     clusterv1listers.ManagedClusterLister
 	patcher              patcher.Patcher[
 		*addonv1beta1.ManagedClusterAddOn, addonv1beta1.ManagedClusterAddOnSpec, addonv1beta1.ManagedClusterAddOnStatus]
 	addonDriverFactory register.AddonDriverFactory
@@ -60,6 +63,7 @@ func NewAddOnRegistrationController(
 	addonDriverFactory register.AddonDriverFactory,
 	addonAuthConfig register.AddonAuthConfig,
 	hubAddOnInformers addoninformerv1beta1.ManagedClusterAddOnInformer,
+	hubClusterInformer clusterv1informers.ManagedClusterInformer,
 ) factory.Controller {
 	c := &addOnRegistrationController{
 		clusterName:          clusterName,
@@ -68,6 +72,7 @@ func NewAddOnRegistrationController(
 		managementKubeClient: managementKubeClient,
 		spokeKubeClient:      managedKubeClient,
 		hubAddOnLister:       hubAddOnInformers.Lister(),
+		hubClusterLister:     hubClusterInformer.Lister(),
 		addonDriverFactory:   addonDriverFactory,
 		addonAuthConfig:      addonAuthConfig,
 		patcher: patcher.NewPatcher[
@@ -138,8 +143,9 @@ func (c *addOnRegistrationController) syncAddOn(ctx context.Context, syncCtx fac
 	}
 
 	installOption := addonInstallOption{
-		AgentRunningOutsideManagedCluster: isAddonRunningOutsideManagedCluster(addOn),
-		InstallationNamespace:             getAddOnInstallationNamespace(addOn),
+		AgentRunningOutsideManagedCluster: isAddonRunningOutsideManagedCluster(
+			addOn, getManagedClusterFromLister(c.hubClusterLister, c.clusterName), logger),
+		InstallationNamespace: getAddOnInstallationNamespace(addOn),
 	}
 	configs, err := getRegistrationConfigs(addOnName, c.clusterName, installOption, addOn.Status.Registrations, logger)
 	if err != nil {

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -409,6 +409,7 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 			o.agentOptions.SpokeClusterName,
 			hubClient.AddonClient,
 			hubClient.AddonInformer,
+			hubClient.ClusterInformer,
 			managementKubeClient.CoordinationV1(),
 			spokeKubeClient.CoordinationV1(),
 			AddOnLeaseControllerSyncInterval, //TODO: this interval time should be allowed to change from outside
@@ -426,6 +427,7 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 				addonDriverFactory,
 				o.registrationOption.RegisterDriverOption,
 				hubClient.AddonInformer,
+				hubClient.ClusterInformer,
 			)
 		}
 	}


### PR DESCRIPTION
## Summary

Registration-agent decides whether a ManagedClusterAddOn runs outside the managed cluster (hosted mode) primarily from the `addon.open-cluster-management.io/hosting-cluster-name` annotation on the MCA resource. When that annotation is temporarily absent—such as during concurrent updates while many clusters are being imported—the agent treats the addon as running on the spoke. It then uses the spoke API client to create hub-kubeconfig secrets and manage leases on the wrong cluster, which breaks addons that are actually deployed in the hosting cluster's `klusterlet-{cluster}` namespace.

This change adds a per-addon fallback: if the MCA reports an install namespace of `klusterlet-{managedClusterName}`, treat the addon as hosted even when the hosting-cluster-name annotation is missing. ManagedCluster-level annotations alone are not used as a gate, because some addons on a hosted cluster still run on the spoke (for example, addons installed in `open-cluster-management-agent-addon`).

Also wires the ManagedCluster lister into the addon lease controller so both the registration and lease controllers evaluate hosted mode consistently, and adds structured logging when fallback logic is used.

## Test plan

- [x] Unit tests in `pkg/registration/spoke/addon/` pass
- [x] Verify hosted addon registration and lease renewal when MCA `hosting-cluster-name` is absent but install namespace is `klusterlet-{cluster}`
- [x] Verify spoke-deployed addons on hosted clusters are still classified correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added hosted-mode add-on detection based on installation location and managed-cluster configuration.
  - Add-ons can resolve their hosting cluster from managed-cluster settings.
  - Lease and registration handling now supports hosted add-ons across the appropriate cluster context.

- **Bug Fixes**
  - Improved hosted add-on availability and lease handling when hosting annotations are absent but hosted-mode configuration is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->