### PR TITLE
:sparkles: feat(registration): support clusterLabels for klusterlet

### DIFF
--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -103,6 +103,9 @@ spec:
           {{if .ClusterAnnotationsString}}
           - "--cluster-annotations={{ .ClusterAnnotationsString }}"
           {{end}}
+          {{if .ClusterLabelsString}}
+          - "--cluster-labels={{ .ClusterLabelsString }}"
+          {{end}}
           {{if eq .InstallMode "SingletonHosted"}}
           - "--spoke-kubeconfig=/spoke/config/kubeconfig"
           - "--terminate-on-files=/spoke/config/kubeconfig"

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -88,6 +88,9 @@ spec:
           {{if .ClusterAnnotationsString}}
           - "--cluster-annotations={{ .ClusterAnnotationsString }}"
           {{end}}
+          {{if .ClusterLabelsString}}
+          - "--cluster-labels={{ .ClusterLabelsString }}"
+          {{end}}
           {{if gt .RegistrationKubeAPIQPS 0.0}}
           - "--kube-api-qps={{ .RegistrationKubeAPIQPS }}"
           {{end}}

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -60,6 +60,7 @@ func buildClusterAnnotationsString(annotations map[string]string) string {
 	return strings.Join(arr, ",")
 }
 
+// buildClusterLabelsString serializes labels into a deterministically sorted comma-separated key=value string.
 func buildClusterLabelsString(labels map[string]string) string {
 	if len(labels) == 0 {
 		return ""

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -60,6 +60,18 @@ func buildClusterAnnotationsString(annotations map[string]string) string {
 	return strings.Join(arr, ",")
 }
 
+func buildClusterLabelsString(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	arr := make([]string, 0, len(labels))
+	for k, v := range labels {
+		arr = append(arr, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(arr)
+	return strings.Join(arr, ",")
+}
+
 type klusterletController struct {
 	patcher                       patcher.Patcher[*operatorapiv1.Klusterlet, operatorapiv1.KlusterletSpec, operatorapiv1.KlusterletStatus]
 	klusterletLister              operatorlister.KlusterletLister
@@ -182,6 +194,7 @@ type klusterletConfig struct {
 	Replica                                     int32
 	ClientCertExpirationSeconds                 int32
 	ClusterAnnotationsString                    string
+	ClusterLabelsString                         string
 	RegistrationKubeAPIQPS                      float32
 	RegistrationKubeAPIBurst                    int32
 	WorkKubeAPIQPS                              float32
@@ -430,6 +443,7 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 		}
 
 		config.ClusterAnnotationsString = buildClusterAnnotationsString(klusterlet.Spec.RegistrationConfiguration.ClusterAnnotations)
+		config.ClusterLabelsString = buildClusterLabelsString(klusterlet.Spec.RegistrationConfiguration.ClusterLabels)
 
 		// Set AddOnKubeClientRegistrationAuth from the Klusterlet spec
 		if klusterlet.Spec.RegistrationConfiguration.AddOnKubeClientRegistrationDriver != nil &&

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller_test.go
@@ -1985,6 +1985,51 @@ func TestBuildClusterAnnotationsString(t *testing.T) {
 	}
 }
 
+func TestBuildClusterLabelsString(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name:   "nil map",
+			labels: nil,
+			want:   "",
+		},
+		{
+			name:   "empty map",
+			labels: map[string]string{},
+			want:   "",
+		},
+		{
+			name:   "single key",
+			labels: map[string]string{"env": "prod"},
+			want:   "env=prod",
+		},
+		{
+			name: "keys sorted lexicographically",
+			labels: map[string]string{
+				"region": "us-west-2",
+				"env":    "prod",
+				"tier":   "frontend",
+			},
+			want: "env=prod,region=us-west-2,tier=frontend",
+		},
+	}
+
+	const iterations = 1000
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := range iterations {
+				got := buildClusterLabelsString(tt.labels)
+				if got != tt.want {
+					t.Fatalf("iteration %d: got %q, want %q (non-deterministic output regresses cluster-labels flag)", i, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
 // TestReportHostingClusterDisabledByDefault: opt-in unset, no self-report args rendered.
 func TestReportHostingClusterDisabledByDefault(t *testing.T) {
 	klusterlet := newKlusterlet("klusterlet", "testns", "cluster1")

--- a/pkg/registration/spoke/options.go
+++ b/pkg/registration/spoke/options.go
@@ -36,6 +36,7 @@ type SpokeAgentOptions struct {
 	MaxCustomClusterClaims       int
 	ReservedClusterClaimSuffixes []string
 	ClusterAnnotations           map[string]string
+	ClusterLabels                map[string]string
 
 	// Self-report opt-in (KEP-188), set by the klusterlet-operator.
 	ReportHostingCluster bool
@@ -80,6 +81,8 @@ func (o *SpokeAgentOptions) AddFlags(fs *pflag.FlagSet) {
 		"A list of suffixes for reserved cluster claims.")
 	fs.StringToStringVar(&o.ClusterAnnotations, "cluster-annotations", o.ClusterAnnotations, `the annotations with the reserve
 	 prefix "agent.open-cluster-management.io" set on ManagedCluster when creating only, other actors can update it afterwards.`)
+	fs.StringToStringVar(&o.ClusterLabels, "cluster-labels", o.ClusterLabels,
+		"the labels set on ManagedCluster when creating only, other actors can update it afterwards.")
 	fs.BoolVar(&o.ReportHostingCluster, "report-hosting-cluster", o.ReportHostingCluster,
 		"Self-report the cluster this agent's own controllers actually run on via the reserved "+
 			"hosting-cluster.open-cluster-management.io ClusterClaim (KEP-188).")

--- a/pkg/registration/spoke/options.go
+++ b/pkg/registration/spoke/options.go
@@ -45,6 +45,7 @@ type SpokeAgentOptions struct {
 	RegisterDriverOption *registerfactory.Options
 }
 
+// NewSpokeAgentOptions returns a SpokeAgentOptions with default values.
 func NewSpokeAgentOptions() *SpokeAgentOptions {
 	options := &SpokeAgentOptions{
 		BootstrapKubeconfigSecret:   "bootstrap-hub-kubeconfig",

--- a/pkg/registration/spoke/registration/creating_controller.go
+++ b/pkg/registration/spoke/registration/creating_controller.go
@@ -119,6 +119,7 @@ func skipUnauthorizedError(err error) error {
 	return err
 }
 
+// AnnotationDecorator returns a ManagedClusterDecorator that applies the given annotations to a ManagedCluster.
 func AnnotationDecorator(annotations map[string]string) ManagedClusterDecorator {
 	return func(cluster *clusterv1.ManagedCluster) *clusterv1.ManagedCluster {
 		filteredAnnotations := commonhelpers.FilterClusterAnnotations(annotations)
@@ -132,6 +133,7 @@ func AnnotationDecorator(annotations map[string]string) ManagedClusterDecorator 
 	}
 }
 
+// LabelDecorator returns a ManagedClusterDecorator that applies the given labels to a ManagedCluster.
 func LabelDecorator(labels map[string]string) ManagedClusterDecorator {
 	return func(cluster *clusterv1.ManagedCluster) *clusterv1.ManagedCluster {
 		if len(labels) == 0 {

--- a/pkg/registration/spoke/registration/creating_controller.go
+++ b/pkg/registration/spoke/registration/creating_controller.go
@@ -132,6 +132,21 @@ func AnnotationDecorator(annotations map[string]string) ManagedClusterDecorator 
 	}
 }
 
+func LabelDecorator(labels map[string]string) ManagedClusterDecorator {
+	return func(cluster *clusterv1.ManagedCluster) *clusterv1.ManagedCluster {
+		if len(labels) == 0 {
+			return cluster
+		}
+		if cluster.Labels == nil {
+			cluster.Labels = make(map[string]string)
+		}
+		for key, value := range labels {
+			cluster.Labels[key] = value
+		}
+		return cluster
+	}
+}
+
 // ClientConfigDecorator merge ClientConfig
 func ClientConfigDecorator(externalServerURLs []string, caBundle []byte) ManagedClusterDecorator {
 	return func(cluster *clusterv1.ManagedCluster) *clusterv1.ManagedCluster {

--- a/pkg/registration/spoke/registration/creating_controller_test.go
+++ b/pkg/registration/spoke/registration/creating_controller_test.go
@@ -44,6 +44,10 @@ func TestCreateSpokeCluster(t *testing.T) {
 					t.Errorf("expected cluster annotations %#v but got: %#v", "agent.open-cluster-management.io/test",
 						clusterannotations["agent.open-cluster-management.io/test"])
 				}
+				clusterlabels := actual.(*clusterv1.ManagedCluster).Labels
+				if value, ok := clusterlabels["env"]; !ok || value != "production" {
+					t.Errorf("expected cluster label env=production but got: %#v", clusterlabels)
+				}
 			},
 		},
 		{
@@ -63,6 +67,9 @@ func TestCreateSpokeCluster(t *testing.T) {
 				clusterDecorators: []ManagedClusterDecorator{
 					AnnotationDecorator(map[string]string{
 						"agent.open-cluster-management.io/test": "true",
+					}),
+					LabelDecorator(map[string]string{
+						"env": "production",
 					}),
 					ClientConfigDecorator([]string{testSpokeExternalServerUrl}, []byte("testcabundle")),
 				},

--- a/pkg/registration/spoke/spokeagent.go
+++ b/pkg/registration/spoke/spokeagent.go
@@ -293,6 +293,7 @@ func (o *SpokeAgentConfig) RunSpokeAgentWithSpokeInformers(ctx context.Context,
 			o.agentOptions.SpokeClusterName,
 			[]registration.ManagedClusterDecorator{
 				registration.AnnotationDecorator(o.registrationOption.ClusterAnnotations),
+				registration.LabelDecorator(o.registrationOption.ClusterLabels),
 				registration.ClientConfigDecorator(o.registrationOption.SpokeExternalServerURLs, spokeClusterCABundle),
 				o.driver.ManagedClusterDecorator,
 			},

--- a/test/integration/registration/clusterlabels_test.go
+++ b/test/integration/registration/clusterlabels_test.go
@@ -1,0 +1,59 @@
+package registration_test
+
+import (
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	commonoptions "open-cluster-management.io/ocm/pkg/common/options"
+	registerfactory "open-cluster-management.io/ocm/pkg/registration/register/factory"
+	"open-cluster-management.io/ocm/pkg/registration/spoke"
+	"open-cluster-management.io/ocm/test/integration/util"
+)
+
+var _ = ginkgo.Describe("Cluster Labels", func() {
+	ginkgo.It("Cluster Labels should be created on the managed cluster", func() {
+		managedClusterName := "clusterlabels-spokecluster"
+		//#nosec G101
+		hubKubeconfigSecret := "clusterlabels-hub-kubeconfig-secret"
+		hubKubeconfigDir := path.Join(util.TestDir, "clusterlabels", "hub-kubeconfig")
+
+		agentOptions := &spoke.SpokeAgentOptions{
+			BootstrapKubeconfig:      bootstrapKubeConfigFile,
+			HubKubeconfigSecret:      hubKubeconfigSecret,
+			ClusterHealthCheckPeriod: 1 * time.Minute,
+			ClusterLabels: map[string]string{
+				"env":    "production",
+				"region": "us-west-2",
+			},
+			RegisterDriverOption: registerfactory.NewOptions(),
+		}
+
+		commOptions := commonoptions.NewAgentOptions()
+		commOptions.HubKubeconfigDir = hubKubeconfigDir
+		commOptions.SpokeClusterName = managedClusterName
+
+		// run registration agent
+		cancel := runAgent("clusterlabelstest", agentOptions, commOptions, spokeCfg)
+		defer cancel()
+
+		// after bootstrap the spokecluster and csr should be created
+		gomega.Eventually(func() error {
+			mc, err := util.GetManagedCluster(clusterClient, managedClusterName)
+			if err != nil {
+				return err
+			}
+
+			if mc.Labels["env"] != "production" {
+				return fmt.Errorf("expected label env=production, got %s", mc.Labels["env"])
+			}
+			if mc.Labels["region"] != "us-west-2" {
+				return fmt.Errorf("expected label region=us-west-2, got %s", mc.Labels["region"])
+			}
+			return nil
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.Succeed())
+	})
+})


### PR DESCRIPTION
## Summary

- Wires the existing `ClusterLabels` field from the Klusterlet `RegistrationConfiguration` spec through the operator and registration agent so that labels are applied to the `ManagedCluster` at creation time
- Follows the same pattern as the existing `ClusterAnnotations` support: operator builds a `--cluster-labels` flag string → deployment manifest passes it to the registration agent → `LabelDecorator` sets labels on the `ManagedCluster` during bootstrap
- Unlike annotations, labels are not prefix-filtered (matching the API spec which has no prefix restriction for `ClusterLabels`)

Fixes https://github.com/open-cluster-management-io/ocm/issues/1541

## Changes

| File | Change |
|------|--------|
| `pkg/registration/spoke/options.go` | Add `ClusterLabels` field + `--cluster-labels` flag |
| `pkg/registration/spoke/registration/creating_controller.go` | Add `LabelDecorator` |
| `pkg/registration/spoke/spokeagent.go` | Wire `LabelDecorator` into the decorator chain |
| `pkg/operator/.../klusterlet_controller.go` | Add `buildClusterLabelsString` + `ClusterLabelsString` config |
| `manifests/.../klusterlet-registration-deployment.yaml` | Pass `--cluster-labels` flag |
| `manifests/.../klusterlet-agent-deployment.yaml` | Pass `--cluster-labels` flag |

## Test plan

- [x] Unit test: `TestCreateSpokeCluster` extended to verify labels on created ManagedCluster
- [x] Unit test: `TestBuildClusterLabelsString` verifies deterministic flag string output
- [x] Integration test: `clusterlabels_test.go` verifies labels appear on ManagedCluster after agent bootstrap
- [x] Existing `TestBuildClusterAnnotationsString` and `TestCreateSpokeCluster` still pass (no regression)
- [ ] Manual: deploy klusterlet with `clusterLabels` set and verify labels on ManagedCluster on hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring labels on managed clusters during spoke-agent registration.
  * Added a `--cluster-labels` option for specifying labels as key-value pairs.
  * Configured labels are applied to the created managed cluster with consistent ordering.

* **Tests**
  * Added coverage validating label application and deterministic label handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->