### PR TITLE
:bug: fix(klusterlet): make health check port configurable for hostNetwork

### DIFF
--- a/deploy/klusterlet/chart/klusterlet/crds/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/deploy/klusterlet/chart/klusterlet/crds/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -111,6 +111,13 @@ spec:
                   - url
                   type: object
                 type: array
+              healthCheckPort:
+                description: |-
+                  healthCheckPort is the port on which the agent health check endpoint is served.
+                  When using hostNetwork, this port must be unique on the node. If not set or 0,
+                  the default port 8443 is used.
+                format: int32
+                type: integer
               hubApiServerHostAlias:
                 description: |-
                   HubApiServerHostAlias contains the host alias for hub api server.

--- a/deploy/klusterlet/config/crds/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/deploy/klusterlet/config/crds/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -111,6 +111,13 @@ spec:
                   - url
                   type: object
                 type: array
+              healthCheckPort:
+                description: |-
+                  healthCheckPort is the port on which the agent health check endpoint is served.
+                  When using hostNetwork, this port must be unique on the node. If not set or 0,
+                  the default port 8443 is used.
+                format: int32
+                type: integer
               hubApiServerHostAlias:
                 description: |-
                   HubApiServerHostAlias contains the host alias for hub api server.

--- a/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-agent-deployment.yaml
@@ -157,6 +157,9 @@ spec:
           {{if .TLSCipherSuites}}
           - "--tls-cipher-suites={{ .TLSCipherSuites }}"
           {{end}}
+          {{if ne .HealthCheckPort 8443}}
+          - "--health-port={{ .HealthCheckPort }}"
+          {{end}}
         env:
           - name: POD_NAME
             valueFrom:
@@ -201,14 +204,14 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 8443
+            port: {{ .HealthCheckPort }}
           initialDelaySeconds: 2
           periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 8443
+            port: {{ .HealthCheckPort }}
           initialDelaySeconds: 2
         {{- if or (eq .ResourceRequirementResourceType "Default") (eq .ResourceRequirementResourceType "") }}
         resources:

--- a/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-registration-deployment.yaml
@@ -129,6 +129,9 @@ spec:
           {{if .TLSCipherSuites}}
           - "--tls-cipher-suites={{ .TLSCipherSuites }}"
           {{end}}
+          {{if ne .HealthCheckPort 8443}}
+          - "--health-port={{ .HealthCheckPort }}"
+          {{end}}
         env:
           - name: POD_NAME
             valueFrom:
@@ -173,14 +176,14 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 8443
+            port: {{ .HealthCheckPort }}
           initialDelaySeconds: 2
           periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 8443
+            port: {{ .HealthCheckPort }}
           initialDelaySeconds: 2
         {{- if or (eq .ResourceRequirementResourceType "Default") (eq .ResourceRequirementResourceType "") }}
         resources:

--- a/manifests/klusterlet/management/klusterlet-work-deployment.yaml
+++ b/manifests/klusterlet/management/klusterlet-work-deployment.yaml
@@ -106,7 +106,10 @@ spec:
           {{end}}
           {{if .TLSCipherSuites}}
           - "--tls-cipher-suites={{ .TLSCipherSuites }}"
-          {{end}}  
+          {{end}}
+          {{if ne .HealthCheckPort 8443}}
+          - "--health-port={{ .HealthCheckPort }}"
+          {{end}}
         env:
           - name: POD_NAME
             valueFrom:
@@ -141,14 +144,14 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 8443
+            port: {{ .HealthCheckPort }}
           initialDelaySeconds: 2
           periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: 8443
+            port: {{ .HealthCheckPort }}
           initialDelaySeconds: 2
         {{- if or (eq .ResourceRequirementResourceType "Default") (eq .ResourceRequirementResourceType "") }}
         resources:

--- a/pkg/common/options/options.go
+++ b/pkg/common/options/options.go
@@ -24,6 +24,7 @@ type Options struct {
 	QPS             float32
 	TLSMinVersion   string
 	TLSCipherSuites string
+	HealthCheckPort int32
 }
 
 // NewOptions returns the flags with default value set
@@ -57,6 +58,8 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.TLSCipherSuites, "tls-cipher-suites", "",
 		"Comma-separated list of TLS cipher suites for the serving endpoint. "+
 			"If omitted, the default Go cipher suites are used.")
+	flags.Int32Var(&o.HealthCheckPort, "health-port", 0,
+		"Port for the health check endpoint. If not set or 0, the default port 8443 is used.")
 	if o.CmdConfig != nil {
 		flags.BoolVar(&o.CmdConfig.DisableLeaderElection, "disable-leader-election", false, "Disable leader election.")
 		flags.DurationVar(&o.CmdConfig.LeaseDuration.Duration, "leader-election-lease-duration", 137*time.Second, ""+
@@ -82,8 +85,11 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 // Inside cmd.Run, StartController calls Config() which reads the file; the TLS
 // values survive SetRecommendedHTTPServingInfoDefaults because DefaultString
 // only sets fields that are empty.
-func writeTLSServingConfig(cmd *cobra.Command, minVersion, cipherSuites string) error {
+func writeTLSServingConfig(cmd *cobra.Command, minVersion, cipherSuites string, healthPort int32) error {
 	content := "apiVersion: operator.openshift.io/v1alpha1\nkind: GenericOperatorConfig\nservingInfo:\n"
+	if healthPort > 0 {
+		content += fmt.Sprintf("  bindAddress: \"0.0.0.0:%d\"\n", healthPort)
+	}
 	if minVersion != "" {
 		content += "  minTLSVersion: " + minVersion + "\n"
 	}
@@ -119,16 +125,18 @@ func (o *Options) ApplyTLSToCommand(cmd *cobra.Command) {
 				return err
 			}
 		}
-		// Only inject when at least one TLS flag is set and --config not already provided.
-		if (o.TLSMinVersion == "" && o.TLSCipherSuites == "") || cmd.Flags().Changed("config") {
+		// Only inject when at least one TLS or health-port flag is set and --config not already provided.
+		if (o.TLSMinVersion == "" && o.TLSCipherSuites == "" && o.HealthCheckPort == 0) || cmd.Flags().Changed("config") {
 			return nil
 		}
 		// Validate TLS flags up-front so invalid values are caught early with a
 		// clear error rather than being deferred to library-go's YAML parsing.
-		if _, err := tlslib.ConfigFromFlags(o.TLSMinVersion, o.TLSCipherSuites); err != nil {
-			return fmt.Errorf("invalid TLS flags: %w", err)
+		if o.TLSMinVersion != "" || o.TLSCipherSuites != "" {
+			if _, err := tlslib.ConfigFromFlags(o.TLSMinVersion, o.TLSCipherSuites); err != nil {
+				return fmt.Errorf("invalid TLS flags: %w", err)
+			}
 		}
-		return writeTLSServingConfig(cmd, o.TLSMinVersion, o.TLSCipherSuites)
+		return writeTLSServingConfig(cmd, o.TLSMinVersion, o.TLSCipherSuites, o.HealthCheckPort)
 	}
 }
 
@@ -164,7 +172,7 @@ func applyTLSFromConfigMap(ctx context.Context, kubeClient kubernetes.Interface,
 	if len(tlsCfg.CipherSuites) > 0 {
 		cipherSuites = tlslib.CipherSuitesToString(tlsCfg.CipherSuites)
 	}
-	return writeTLSServingConfig(cmd, minVersion, cipherSuites)
+	return writeTLSServingConfig(cmd, minVersion, cipherSuites, 0)
 }
 
 // ApplyTLSFromConfigMapToCommand installs a PersistentPreRunE hook that reads

--- a/pkg/common/options/options.go
+++ b/pkg/common/options/options.go
@@ -129,6 +129,9 @@ func (o *Options) ApplyTLSToCommand(cmd *cobra.Command) {
 		if (o.TLSMinVersion == "" && o.TLSCipherSuites == "" && o.HealthCheckPort == 0) || cmd.Flags().Changed("config") {
 			return nil
 		}
+		if o.HealthCheckPort != 0 && (o.HealthCheckPort < 1 || o.HealthCheckPort > 65535) {
+			return fmt.Errorf("invalid --health-port value %d: must be 0 or between 1 and 65535", o.HealthCheckPort)
+		}
 		// Validate TLS flags up-front so invalid values are caught early with a
 		// clear error rather than being deferred to library-go's YAML parsing.
 		if o.TLSMinVersion != "" || o.TLSCipherSuites != "" {
@@ -158,7 +161,7 @@ func operatorNamespace(cmd *cobra.Command) string {
 // kube client and namespace, and if found, writes the TLS serving config file.
 // Returns nil if the ConfigMap is not found (graceful no-op).
 // Extracted for testability.
-func applyTLSFromConfigMap(ctx context.Context, kubeClient kubernetes.Interface, namespace string, cmd *cobra.Command) error {
+func applyTLSFromConfigMap(ctx context.Context, kubeClient kubernetes.Interface, namespace string, cmd *cobra.Command, healthPort int32) error {
 	tlsCfg, err := tlslib.LoadTLSConfigFromConfigMap(ctx, kubeClient, namespace)
 	if err != nil {
 		return fmt.Errorf("failed to load TLS config from ConfigMap: %w", err)
@@ -172,7 +175,7 @@ func applyTLSFromConfigMap(ctx context.Context, kubeClient kubernetes.Interface,
 	if len(tlsCfg.CipherSuites) > 0 {
 		cipherSuites = tlslib.CipherSuitesToString(tlsCfg.CipherSuites)
 	}
-	return writeTLSServingConfig(cmd, minVersion, cipherSuites, 0)
+	return writeTLSServingConfig(cmd, minVersion, cipherSuites, healthPort)
 }
 
 // ApplyTLSFromConfigMapToCommand installs a PersistentPreRunE hook that reads
@@ -215,6 +218,6 @@ func (o *Options) ApplyTLSFromConfigMapToCommand(cmd *cobra.Command) {
 		if err != nil {
 			return fmt.Errorf("failed to create kube client for TLS ConfigMap: %w", err)
 		}
-		return applyTLSFromConfigMap(context.Background(), kubeClient, namespace, cmd)
+		return applyTLSFromConfigMap(context.Background(), kubeClient, namespace, cmd, o.HealthCheckPort)
 	}
 }

--- a/pkg/common/options/options_test.go
+++ b/pkg/common/options/options_test.go
@@ -430,7 +430,7 @@ func TestApplyTLSFromConfigMap(t *testing.T) {
 			var configFile string
 			cmd.Flags().StringVar(&configFile, "config", "", "")
 
-			err := applyTLSFromConfigMap(context.Background(), kubeClient, "test-ns", cmd)
+			err := applyTLSFromConfigMap(context.Background(), kubeClient, "test-ns", cmd, 0)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -506,5 +506,79 @@ func TestApplyTLSFromConfigMapSkipsWhenConfigAlreadySet(t *testing.T) {
 	// --config must remain unchanged.
 	if configFile != "/existing/config.yaml" {
 		t.Errorf("expected --config to remain %q, got %q", "/existing/config.yaml", configFile)
+	}
+}
+
+func TestApplyTLSToCommandHealthPortValidation(t *testing.T) {
+	cases := []struct {
+		name      string
+		port      int32
+		wantError bool
+	}{
+		{name: "valid port 9443", port: 9443},
+		{name: "valid port 1", port: 1},
+		{name: "valid port 65535", port: 65535},
+		{name: "negative port", port: -1, wantError: true},
+		{name: "port exceeds 65535", port: 70000, wantError: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			opts := NewOptions()
+			opts.HealthCheckPort = c.port
+
+			cmd := &cobra.Command{Use: "test"}
+			var configFile string
+			cmd.Flags().StringVar(&configFile, "config", "", "")
+
+			opts.ApplyTLSToCommand(cmd)
+			err := cmd.PersistentPreRunE(cmd, nil)
+			if c.wantError {
+				if err == nil {
+					t.Fatal("expected an error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if configFile != "" {
+				defer os.Remove(configFile)
+			}
+		})
+	}
+}
+
+func TestApplyTLSFromConfigMapWithHealthPort(t *testing.T) {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tlslib.ConfigMapName,
+			Namespace: "test-ns",
+		},
+		Data: map[string]string{
+			tlslib.ConfigMapKeyMinVersion: "VersionTLS13",
+		},
+	}
+	kubeClient := kubefake.NewSimpleClientset(configMap)
+
+	cmd := &cobra.Command{Use: "test"}
+	var configFile string
+	cmd.Flags().StringVar(&configFile, "config", "", "")
+
+	err := applyTLSFromConfigMap(context.Background(), kubeClient, "test-ns", cmd, 9443)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if configFile == "" {
+		t.Fatal("expected --config to be set")
+	}
+	defer os.Remove(configFile)
+
+	content, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read generated config file: %v", err)
+	}
+	s := string(content)
+	if !strings.Contains(s, "bindAddress: \"0.0.0.0:9443\"") {
+		t.Errorf("expected bindAddress with port 9443, got:\n%s", s)
 	}
 }

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -241,6 +241,7 @@ type klusterletConfig struct {
 	NetworkPoliciesEnabled bool
 	TLSMinVersion          string
 	TLSCipherSuites        string
+	HealthCheckPort        int32
 }
 
 // If multiplehubs feature gate is enabled, using the bootstrapkubeconfigs from klusterlet CR.
@@ -316,6 +317,12 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 		ResourceRequirementResourceType: helpers.ResourceType(klusterlet),
 		ResourceRequirements:            resourceRequirements,
 		DisableAddonNamespace:           n.disableAddonNamespace,
+	}
+
+	if klusterlet.Spec.HealthCheckPort > 0 {
+		config.HealthCheckPort = klusterlet.Spec.HealthCheckPort
+	} else {
+		config.HealthCheckPort = 8443
 	}
 
 	if klusterlet.Spec.DeployOption.ReportHostingCluster == operatorapiv1.ReportHostingClusterModeEnable {

--- a/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
+++ b/pkg/operator/operators/klusterlet/controllers/klusterletcontroller/klusterlet_controller.go
@@ -319,10 +319,14 @@ func (n *klusterletController) sync(ctx context.Context, controllerContext facto
 		DisableAddonNamespace:           n.disableAddonNamespace,
 	}
 
-	if klusterlet.Spec.HealthCheckPort > 0 {
-		config.HealthCheckPort = klusterlet.Spec.HealthCheckPort
-	} else {
+	switch {
+	case klusterlet.Spec.HealthCheckPort == 0:
 		config.HealthCheckPort = 8443
+	case klusterlet.Spec.HealthCheckPort >= 1024 && klusterlet.Spec.HealthCheckPort <= 65535:
+		config.HealthCheckPort = klusterlet.Spec.HealthCheckPort
+	default:
+		return fmt.Errorf("invalid healthCheckPort %d: must be 0 (default 8443) or between 1024 and 65535",
+			klusterlet.Spec.HealthCheckPort)
 	}
 
 	if klusterlet.Spec.DeployOption.ReportHostingCluster == operatorapiv1.ReportHostingClusterModeEnable {

--- a/vendor/open-cluster-management.io/api/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
+++ b/vendor/open-cluster-management.io/api/operator/v1/0000_00_operator.open-cluster-management.io_klusterlets.crd.yaml
@@ -111,6 +111,13 @@ spec:
                   - url
                   type: object
                 type: array
+              healthCheckPort:
+                description: |-
+                  healthCheckPort is the port on which the agent health check endpoint is served.
+                  When using hostNetwork, this port must be unique on the node. If not set or 0,
+                  the default port 8443 is used.
+                format: int32
+                type: integer
               hubApiServerHostAlias:
                 description: |-
                   HubApiServerHostAlias contains the host alias for hub api server.

--- a/vendor/open-cluster-management.io/api/operator/v1/types_klusterlet.go
+++ b/vendor/open-cluster-management.io/api/operator/v1/types_klusterlet.go
@@ -100,6 +100,12 @@ type KlusterletSpec struct {
 	// is not available on the managed cluster.
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// HealthCheckPort is the port on which the agent health check endpoint is served.
+	// When using hostNetwork, this port must be unique on the node. If not set or 0,
+	// the default port 8443 is used.
+	// +optional
+	HealthCheckPort int32 `json:"healthCheckPort,omitempty"`
 }
 
 // ServerURL represents the apiserver url and ca bundle that is accessible externally


### PR DESCRIPTION
## Summary

Fixes #1032

When using `hostNetwork`, the hardcoded health check port 8443 causes `CrashLoopBackOff` if another process on the node already occupies that port. This PR adds a `healthCheckPort` field to `KlusterletSpec` so operators can configure an alternative port.

- Adds `healthCheckPort` (int32, optional) to `KlusterletSpec` — defaults to 8443 when unset or 0
- Updates all 3 deployment templates (registration, work, agent) to use the configured port in liveness/readiness probes
- Adds `--health-port` CLI flag to agents, which sets `bindAddress` in the GenericOperatorConfig to override library-go's default
- The `--health-port` flag is only rendered in templates when the port differs from 8443, so all existing test assertions pass unchanged

## Changes

| File | Change |
|------|--------|
| `vendor/.../types_klusterlet.go` | Add `HealthCheckPort int32` to `KlusterletSpec` |
| 3× CRD YAML | Add `healthCheckPort` field definition |
| `klusterlet_controller.go` | Add `HealthCheckPort` to `klusterletConfig`, populate from spec with 8443 default |
| 3× deployment templates | Replace `port: 8443` with `port: {{ .HealthCheckPort }}`, conditionally add `--health-port` flag |
| `options.go` | Add `--health-port` flag, extend `writeTLSServingConfig` to set `bindAddress` |

## Validation (Kind cluster, real cluster test)

### Reproduce — port 8443 conflict with hostNetwork

1. Started a process binding port 8443 on the node
2. Klusterlet agent pods entered `CrashLoopBackOff`:
   ```
   failed to listen on 0.0.0.0:8443: bind: address already in use
   ```

### Fix — set `healthCheckPort: 9443`

1. Applied `healthCheckPort: 9443` to the Klusterlet CR
2. Verified deployment templates rendered with `port: 9443` in probes
3. Confirmed `--health-port=9443` flag passed to agent containers
4. Agent logs show: `Serving securely on [::]:9443`
5. Health endpoint returns `ok`:
   ```
   $ curl -k https://localhost:9443/healthz
   ok
   ```
6. Both ports (8443 blocker + 9443 agent) coexist on the same node without conflict

### Backward compatibility

- Klusterlet CRs without `healthCheckPort` continue using port 8443 (default)
- All existing tests pass — no regression

## Test plan

- [x] `go test ./pkg/operator/...` — passes (klusterlet controller tests)
- [x] `go test ./pkg/common/...` — passes (TLS options tests)
- [x] `make build` — compiles successfully
- [x] Kind cluster validation — reproduce and fix confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable health-check ports for Klusterlet agents.
  * Health-check endpoints default to port 8443 when no custom port is provided.
  * Liveness and readiness probes now use the configured health-check port.
  * Added support for configuring the port through deployment settings and command-line options.
  * Health-check ports are validated to ensure they use an allowed, non-privileged port range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->